### PR TITLE
Restyle Layout, Header, and Navigation components

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,18 +1,14 @@
 /* Header.module.css */
 
 .header {
-  position: fixed;
+  position: sticky;
   inset-block-start: 0;
-  inset-inline-start: 0;
-  inline-size: 100%;
   z-index: var(--z-header);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: var(--color-bg-overlay);
+  background-color: var(--color-bg);
   color: var(--color-text);
-  backdrop-filter: blur(12px); /* no token for blur radius */
-  -webkit-backdrop-filter: blur(12px);
-  padding-inline: var(--space-6);
-  padding-block: var(--space-4);
+  border-block-end: var(--border-width) solid var(--color-border-subtle);
+  padding: var(--space-4) var(--space-6);
 }

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -1,14 +1,15 @@
 /* Layout.module.css */
 
 .main {
-  padding: var(--space-6);
-  padding-block-end: 0;
+  min-height: 100vh;
   background-color: var(--color-bg);
   color: var(--color-text);
 }
 
-/* Non-home pages need top padding to clear the fixed header */
+/* Non-home pages: sticky header is in flow, so no large top padding needed */
 .withHeader {
-  padding-block-start: var(--space-20);
-  padding-block-end: var(--space-6);
+  max-width: var(--max-w-site);
+  margin-inline: auto;
+  padding-inline: var(--space-6);
+  padding-block: var(--space-6);
 }

--- a/src/components/Navigation/Navigation.module.css
+++ b/src/components/Navigation/Navigation.module.css
@@ -2,5 +2,20 @@
 
 .nav {
   display: flex;
-  gap: var(--space-4);
+  gap: var(--space-6);
+}
+
+.nav a {
+  color: var(--color-text);
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--easing-default);
+}
+
+.nav a:hover {
+  color: var(--color-primary);
+}
+
+.nav a:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -3,7 +3,7 @@ import styles from './Navigation.module.css'
 
 export default function Navigation() {
   return (
-    <nav className={styles.nav}>
+    <nav className={styles.nav} aria-label="Main navigation">
       <Link to="/">Home</Link>
       <Link to="/apps">Apps</Link>
     </nav>


### PR DESCRIPTION
Closes #20

## What changed
- **Header**: `position: fixed` → `position: sticky`, removed backdrop blur and transparent bg, solid `--color-bg` background, added bottom border with `--color-border-subtle`
- **Layout**: `.main` uses `min-height: 100vh`, `.withHeader` constrains to `--max-w-site` with centered margins
- **Navigation**: gap increased to `--space-6`, nav links styled with `--color-text` default and `--color-primary` on hover, added `:focus-visible` outlines and `aria-label`

## Why
Structural components for the neo-brutalist redesign (PRD: `docs/prds/redesign.md`). Header moves from fixed+blur to sticky+solid — simpler and more honest.

## How to verify
1. `pnpm test` — all 62 tests pass
2. Header sticks on scroll with solid background and bottom border
3. Nav links show blue on hover with visible focus outlines
4. Content is constrained to 1024px max-width and centered

## Decisions made
- With sticky positioning, `.withHeader` no longer needs large padding-top to clear the header — the element stays in normal flow
- Nav link hover/focus styles added directly to Navigation.module.css since the Link component will be restyled separately in #22