### PR TITLE
Redesign FullPageHeader hero section

### DIFF
--- a/src/components/FullPageHeader/FullPageHeader.module.css
+++ b/src/components/FullPageHeader/FullPageHeader.module.css
@@ -5,7 +5,7 @@
 .header {
   position: relative;
   z-index: 0;
-  min-block-size: 100svh; /* svh for mobile chrome bar; falls back to vh */
+  min-block-size: 100svh;
   inline-size: 100vw;
   margin-inline-start: calc(-50vw + 50%);
   margin-inline-end: calc(-50vw + 50%);
@@ -14,11 +14,7 @@
   align-items: center;
   justify-content: center;
   padding: var(--space-4);
-  background-image: linear-gradient(
-    to bottom right,
-    var(--color-grad-from-light),
-    var(--color-grad-to-light)
-  );
+  background: var(--color-bg);
 
   @media (min-width: 768px) {
     flex-direction: row;
@@ -29,8 +25,7 @@
 /* ── Inner container ──────────────────────────────────────────── */
 
 .container {
-  /* 1280px matches Tailwind's xl container; no token — literal with comment */
-  max-inline-size: 1280px;
+  max-inline-size: var(--max-w-site);
   margin-inline: auto;
   inline-size: 100%;
   display: flex;
@@ -76,96 +71,29 @@
   gap: var(--space-4);
 }
 
-/* ── Animated text elements ───────────────────────────────────── */
+/* ── Text elements ───────────────────────────────────────────── */
 
 .heading {
-  font-size: var(--font-size-4xl);
-  font-weight: var(--font-weight-bold);
+  font-size: clamp(var(--font-size-4xl), 6vw, var(--font-size-5xl));
+  font-weight: var(--font-weight-extrabold);
   color: var(--color-text-strong);
-  /* entrance animation base state */
-  opacity: 0;
-  transform: translateY(var(--space-8));
-
-  @media (min-width: 768px) {
-    font-size: var(--font-size-5xl);
-  }
-
-  @media (min-width: 1024px) {
-    font-size: var(--font-size-6xl);
-  }
 }
 
 .tagline {
   font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-normal);
   color: var(--color-text-muted);
-  opacity: 0;
-  transform: translateY(var(--space-8));
-
-  @media (min-width: 768px) {
-    font-size: var(--font-size-2xl);
-  }
 }
 
 .description {
   font-size: var(--font-size-lg);
   line-height: var(--line-height-relaxed);
-  max-inline-size: var(--max-w-lg);
-  opacity: 0;
-  transform: translateY(var(--space-8));
+  max-inline-size: 60ch;
 }
 
 .cta {
-  opacity: 0;
-  transform: translateY(var(--space-8));
-}
-
-/* Loaded state — applied when isLoaded === true */
-.loaded {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-/* Transitions — wrapped in prefers-reduced-motion */
-@media (prefers-reduced-motion: no-preference) {
-  .heading {
-    transition:
-      opacity var(--duration-slower) var(--easing-in-out),
-      transform var(--duration-slower) var(--easing-in-out);
-    transition-delay: 50ms;
-  }
-
-  .tagline {
-    transition:
-      opacity var(--duration-slower) var(--easing-in-out),
-      transform var(--duration-slower) var(--easing-in-out);
-    transition-delay: 150ms;
-  }
-
-  .description {
-    transition:
-      opacity var(--duration-slower) var(--easing-in-out),
-      transform var(--duration-slower) var(--easing-in-out);
-    transition-delay: 200ms;
-  }
-
-  .cta {
-    transition:
-      opacity var(--duration-slower) var(--easing-in-out),
-      transform var(--duration-slower) var(--easing-in-out);
-    transition-delay: 350ms;
-  }
-}
-
-/* Reduced-motion: skip the entrance animation entirely */
-@media (prefers-reduced-motion: reduce) {
-  .heading,
-  .tagline,
-  .description,
-  .cta {
-    opacity: 1;
-    transform: none;
-  }
+  display: flex;
+  gap: var(--space-4);
 }
 
 /* ── Image column ─────────────────────────────────────────────── */
@@ -185,61 +113,32 @@
 .imageWrapper {
   position: relative;
   inline-size: 100%;
-  max-inline-size: var(--max-w-xs); /* 320px — matches max-w-xs */
+  max-inline-size: var(--max-w-xs); /* 320px */
   aspect-ratio: 3 / 4;
   overflow: hidden;
-  border-radius: var(--radius-2xl);
-  opacity: 0;
-  transform: scale(0.95);
+  border-radius: var(--radius-sm);
 
   @media (min-width: 640px) {
-    max-inline-size: var(--max-w-sm); /* 384px — matches max-w-sm */
+    max-inline-size: var(--max-w-sm); /* 384px */
   }
 
   @media (min-width: 768px) {
-    max-inline-size: var(--max-w-md); /* 448px — matches max-w-md */
+    max-inline-size: var(--max-w-md); /* 448px */
   }
 
   @media (min-width: 1024px) {
-    max-inline-size: var(--max-w-lg); /* 512px — matches max-w-lg */
-  }
-}
-
-.imageWrapperLoaded {
-  opacity: 1;
-  transform: scale(1);
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .imageWrapper {
-    transition:
-      opacity var(--duration-image) var(--easing-out),
-      transform var(--duration-image) var(--easing-out);
-    transition-delay: 100ms;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .imageWrapper {
-    opacity: 1;
-    transform: none;
+    max-inline-size: var(--max-w-lg); /* 512px */
   }
 }
 
 /* ── Image component overrides ────────────────────────────────── */
 
 .imageContainer {
-  border-radius: var(--radius-2xl);
-  /* border-white — no token for pure white border; literal value */
-  border: 4px solid #ffffff;
-  box-shadow: var(--shadow-xl);
-}
-
-[data-theme="dark"] .imageContainer {
-  /* gray-700 — no token for this specific border colour in dark mode */
-  border-color: #374151;
+  border-radius: var(--radius-sm);
+  border: var(--border-width-thick) solid var(--color-border);
+  box-shadow: var(--shadow-md);
 }
 
 .imageRounded {
-  border-radius: var(--radius-2xl);
+  border-radius: var(--radius-sm);
 }

--- a/src/components/FullPageHeader/FullPageHeader.test.tsx
+++ b/src/components/FullPageHeader/FullPageHeader.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { render, screen, fireEvent, act } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
 import FullPageHeader from './FullPageHeader'
 
 describe('FullPageHeader', () => {
@@ -11,14 +11,6 @@ describe('FullPageHeader', () => {
     imageSrc: '/portrait.jpg',
   }
   const { name, tagline, description, imageSrc } = DEFAULT_PROPS
-
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
 
   it('renders name, tagline, description, image, and button', () => {
     render(<FullPageHeader {...DEFAULT_PROPS} />)
@@ -45,18 +37,6 @@ describe('FullPageHeader', () => {
 
     // @ts-ignore
     window.location = originalLocation
-  })
-
-  it('applies animation classes after timeout', () => {
-    render(<FullPageHeader {...DEFAULT_PROPS} />)
-    const heading = screen.getByText(name)
-    expect(heading.className).not.toMatch(/loaded/)
-
-    act(() => {
-      vi.runAllTimers()
-    })
-
-    expect(heading.className).toMatch(/loaded/)
   })
 
   it('image has correct alt text', () => {

--- a/src/components/FullPageHeader/FullPageHeader.tsx
+++ b/src/components/FullPageHeader/FullPageHeader.tsx
@@ -1,7 +1,7 @@
 import Button from '@components/Button'
 import Image from '@components/Image'
 import { usePreloadImage } from '@hooks/usePreloadImage'
-import { useState, useEffect, FC } from 'react'
+import { FC } from 'react'
 import styles from './FullPageHeader.module.css'
 
 export interface FullPageHeaderProps {
@@ -17,8 +17,6 @@ const FullPageHeader: FC<FullPageHeaderProps> = ({
   description,
   imageSrc,
 }) => {
-  const [isLoaded, setIsLoaded] = useState(false)
-
   const imageSizes =
     '(max-width: 640px) 320px, (max-width: 768px) 384px, (max-width: 1024px) 448px, 512px'
   const imageSrcSet = [320, 640, 768, 1024, 1280, 1536, 1920]
@@ -35,51 +33,26 @@ const FullPageHeader: FC<FullPageHeaderProps> = ({
   const handleSendEmail = () =>
     (window.location.href = 'mailto:akliaissat@outlook.com?subject=Hello')
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsLoaded(true)
-    }, 300)
-
-    return () => clearTimeout(timer)
-  }, [])
-
   return (
     <header className={styles.header}>
       <div className={styles.container}>
         {/* Text Content */}
         <div className={styles.textColumn}>
           <hgroup className={styles.hgroup}>
-            <h1
-              className={`${styles.heading}${isLoaded ? ` ${styles.loaded}` : ''}`}
-            >
-              {name}
-            </h1>
-
-            <p
-              className={`${styles.tagline}${isLoaded ? ` ${styles.loaded}` : ''}`}
-            >
-              {tagline}
-            </p>
+            <h1 className={styles.heading}>{name}</h1>
+            <p className={styles.tagline}>{tagline}</p>
           </hgroup>
 
-          <p
-            className={`${styles.description}${isLoaded ? ` ${styles.loaded}` : ''}`}
-          >
-            {description}
-          </p>
+          <p className={styles.description}>{description}</p>
 
-          <div
-            className={`${styles.cta}${isLoaded ? ` ${styles.loaded}` : ''}`}
-          >
+          <div className={styles.cta}>
             <Button onClick={handleSendEmail}>Get in touch</Button>
           </div>
         </div>
 
         {/* Image */}
         <div className={styles.imageColumn}>
-          <div
-            className={`${styles.imageWrapper}${isLoaded ? ` ${styles.imageWrapperLoaded}` : ''}`}
-          >
+          <div className={styles.imageWrapper}>
             <Image
               src={imageSrc}
               alt={`Portrait of ${name}`}


### PR DESCRIPTION
Closes #21

## What changed
- **CSS**: Removed gradient background, all entrance animations, opacity/transform base states, and reduced-motion animation blocks. Heading uses fluid `clamp()` sizing with extrabold weight. Profile image is now rectangular with thick border and hard shadow. Container constrained to `--max-w-site`.
- **TSX**: Removed `useState`/`useEffect` for `isLoaded`, all conditional class logic. Static class names throughout.
- **Tests**: Removed animation test that asserted on `.loaded` class. 61 tests pass.

## Why
The hero was the most complex animation-heavy component. Stripping it to static content with the neo-brutalist token system (PRD: `docs/prds/redesign.md`).

## How to verify
1. `pnpm test` — 61 tests pass
2. Hero section renders immediately with no entrance animation
3. Profile image is rectangular (2px radius) with 3px black border and hard shadow
4. Heading scales fluidly between 36px and 48px

## Decisions made
- Removed the dark-mode-specific image border override (`[data-theme="dark"] .imageContainer`) — the new border uses `--color-border` which auto-switches via tokens
- Animation test removed rather than updated since the feature (entrance animations) no longer exists