### PR TITLE
Restyle Button and Link components

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -4,26 +4,30 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding-block: var(--space-3);
-  padding-inline: var(--space-6);
+  padding: var(--space-2) var(--space-6);
   font-size: var(--font-size-base);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-semibold);
   line-height: var(--line-height-normal);
-  border: none;
-  border-radius: var(--radius-lg);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm);
   cursor: pointer;
-  transition: background-color var(--duration-fast) var(--easing-default),
-              color var(--duration-fast) var(--easing-default);
+  transition: transform var(--duration-fast) var(--easing-default),
+              box-shadow var(--duration-fast) var(--easing-default);
+}
+
+.button:hover:not(:disabled) {
+  transform: translate(2px, 2px);
+  box-shadow: 0 0 0 var(--color-border);
 }
 
 .button:focus-visible {
-  outline: none;
-  box-shadow:
-    0 0 0 2px var(--color-ring-offset),
-    0 0 0 4px var(--color-primary-ring);
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .button:disabled {
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
@@ -31,38 +35,10 @@
 
 .primary {
   background-color: var(--color-primary);
-  color: #ffffff; /* no token — always white on coloured background */
-}
-
-.primary:hover:not(:disabled) {
-  background-color: var(--color-primary-hover);
-}
-
-.primary:disabled {
-  background-color: var(--color-primary-disabled);
-}
-
-.primary:focus-visible {
-  box-shadow:
-    0 0 0 2px var(--color-ring-offset),
-    0 0 0 4px var(--color-primary-ring);
+  color: #ffffff;
 }
 
 .secondary {
-  background-color: var(--color-secondary);
-  color: #ffffff; /* no token — always white on coloured background */
-}
-
-.secondary:hover:not(:disabled) {
-  background-color: var(--color-secondary-hover);
-}
-
-.secondary:disabled {
-  background-color: var(--color-secondary-disabled);
-}
-
-.secondary:focus-visible {
-  box-shadow:
-    0 0 0 2px var(--color-ring-offset),
-    0 0 0 4px var(--color-secondary-ring);
+  background-color: transparent;
+  color: var(--color-text);
 }

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -1,18 +1,19 @@
 /* Link component styles */
 
 .link {
-  color: var(--color-link);
-  text-decoration: none;
+  color: var(--color-primary);
+  font-weight: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
   transition: color var(--duration-fast) var(--easing-default);
 }
 
 .link:hover {
-  color: var(--color-link-hover);
-  text-decoration: underline;
+  color: var(--color-primary-hover);
 }
 
 .link:focus-visible {
-  outline: 2px solid var(--color-primary-ring);
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
   border-radius: var(--radius-sm);
 }
@@ -21,9 +22,5 @@
 
 .underline {
   text-decoration: underline;
-  text-underline-offset: 4px;
-}
-
-.underline:hover {
-  text-decoration: underline;
+  text-underline-offset: 2px;
 }


### PR DESCRIPTION
Closes #22

## What changed
- **Button**: Added border, hard shadow, `border-radius: 2px`. Hover produces press-down effect (translate + shadow collapse). Focus uses outline. Disabled uses opacity. Secondary variant kept as outline style.
- **Link**: Uses `--color-primary` tokens (replaces removed `--color-link`), underline by default with 2px offset, font-weight inherits.

## Why
Interactive primitives updated to neo-brutalist token system (PRD: `docs/prds/redesign.md`).

## How to verify
1. `pnpm test` — 61 tests pass
2. Buttons have visible border and shadow, press down on hover
3. Links are blue with underline, darken on hover
4. Both have visible focus outlines on keyboard nav

## Decisions made
- Secondary variant kept (it's referenced in Button.tsx props) as transparent bg with border — same hover behavior as primary
- Removed per-variant focus/hover/disabled overrides — base `.button` class handles all variants uniformly