### PR TITLE
Restyle Card and Grid components

### DIFF
--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -5,17 +5,18 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-radius: var(--radius-2xl);
-  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  border: var(--border-width) solid var(--color-border);
   background-color: var(--color-surface);
+  box-shadow: var(--shadow-md);
   transition:
-    transform var(--duration-base) var(--easing-default),
-    box-shadow var(--duration-base) var(--easing-default);
+    transform var(--duration-fast) var(--easing-default),
+    box-shadow var(--duration-fast) var(--easing-default);
 }
 
 .card:hover {
-  transform: translateY(-0.25rem);
-  box-shadow: var(--shadow-xl);
+  transform: translate(-4px, -4px);
+  box-shadow: var(--shadow-lg);
 }
 
 .imageWrapper {
@@ -25,21 +26,12 @@
   overflow: hidden;
 }
 
-/* Scale the <img> inside Image when the card is hovered */
-.card:hover .imageScaled {
-  transform: scale(1.05);
-}
-
 @media (prefers-reduced-motion: reduce) {
   .card {
     transition: none;
   }
 
   .card:hover {
-    transform: none;
-  }
-
-  .card:hover .imageScaled {
     transform: none;
   }
 }

--- a/src/components/Grid/Grid.module.css
+++ b/src/components/Grid/Grid.module.css
@@ -8,11 +8,6 @@
   margin: 0;
 }
 
-@media (min-width: 768px) {
-  .grid {
-    gap: var(--space-8);
-  }
-}
 
 .item {
   list-style: none;


### PR DESCRIPTION
Closes #23

## What changed
- **Card**: `border-radius: 2px`, `2px solid` border, hard shadow (`--shadow-md`). Hover lifts card `(-4px, -4px)` with shadow growing to `--shadow-lg`. Removed image zoom on hover.
- **Grid**: Consistent `--space-6` gap at all breakpoints (removed md override).

## Why
Content display components updated to neo-brutalist token system (PRD: `docs/prds/redesign.md`).

## How to verify
1. `pnpm test` — 61 tests pass
2. Cards have visible border and hard offset shadow
3. Cards lift up-left on hover with shadow growing
4. No image zoom effect on card hover

## Decisions made
- Removed the `.imageScaled` hover rule entirely since the PRD says "remove any image zoom/scale effects on hover"
- Grid gap unified to `--space-6` — the md breakpoint override to `--space-8` was inconsistent with the PRD spec