### PR TITLE
Restyle Image and Loading components

### DIFF
--- a/src/components/Image/Image.module.css
+++ b/src/components/Image/Image.module.css
@@ -1,7 +1,9 @@
 .container {
   position: relative;
   overflow: hidden;
-  background-color: var(--color-surface-raised); /* gray-100 / gray-700 via token */
+  background-color: var(--color-bg-subtle);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-sm);
 }
 
 /* ── Placeholder overlay ─────────────────────────────────── */
@@ -11,7 +13,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: opacity var(--duration-slow) var(--easing-out);
+  transition: opacity var(--duration-base) var(--easing-default);
   opacity: 1;
 }
 
@@ -32,26 +34,24 @@
 .pulsePlaceholder {
   width: 100%;
   height: 100%;
-  background: linear-gradient(to bottom right, var(--color-placeholder-from), var(--color-placeholder-to));
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  background: var(--color-bg-subtle);
 }
 
-/* ── Empty placeholder (circle with icon) ────────────────── */
+/* ── Empty placeholder (icon centered) ───────────────────── */
 .emptyPlaceholder {
-  width: var(--size-12);
-  height: var(--size-12);
-  border-radius: var(--radius-full);
-  background-color: var(--color-bg-muted); /* gray-200 / gray-600 via token */
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  width: 3rem;
+  height: 3rem;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg-subtle);
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .emptyPlaceholder svg {
-  width: var(--size-6);
-  height: var(--size-6);
-  color: var(--color-icon-muted);
+  width: 1.5rem;
+  height: 1.5rem;
+  color: var(--color-text-muted);
 }
 
 /* ── Error overlay ───────────────────────────────────────── */
@@ -61,13 +61,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--color-surface-raised); /* gray-100 / gray-700 via token */
+  background-color: var(--color-bg-subtle);
 }
 
 .errorIcon {
-  width: var(--size-12);
-  height: var(--size-12);
-  color: var(--color-icon-muted);
+  width: 3rem;
+  height: 3rem;
+  color: var(--color-text-muted);
   margin-inline: auto;
   margin-block-end: var(--space-2);
 }
@@ -85,14 +85,11 @@
 .image {
   width: 100%;
   height: 100%;
-  transition: all var(--duration-slow) var(--easing-out);
   opacity: 0;
-  transform: scale(1.05);
 }
 
 .loaded {
   opacity: 1;
-  transform: scale(1);
 }
 
 /* ── Loading overlay ─────────────────────────────────────── */

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -5,7 +5,6 @@
   vertical-align: middle;
   animation: spin 1s linear infinite;
   border-radius: var(--radius-full);
-  /* 0.15em border that scales with font size */
-  border: 0.15em solid var(--color-text-subtle); /* gray-400 / gray-500 via token */
-  border-block-start-color: transparent;
+  border: var(--border-width-thick) solid var(--color-border-subtle);
+  border-block-start-color: var(--color-primary);
 }


### PR DESCRIPTION
Closes #25

## What changed
- **Image**: Removed scale-in animation and pulse placeholder. Flat `--color-bg-subtle` placeholder. Added border and `border-radius: 2px`. Replaced all removed tokens.
- **Loading**: Spinner uses `--border-width-thick`, `--color-border-subtle` border, `--color-primary` top segment.

## Why
Media components updated to neo-brutalist tokens — no decorative animations (PRD: `docs/prds/redesign.md`).

## How to verify
1. `pnpm test` — 61 tests pass
2. Images appear instantly without scale-in effect
3. Placeholder is flat gray, no pulse animation
4. Loading spinner spins with blue top segment

## Decisions made
- Kept `opacity: 0` → `opacity: 1` on image load (functional — prevents flash of broken image) but removed the transition so it's instant
- Spinner border uses `--border-width-thick` (3px) instead of relative `0.15em` for consistency with design system