### PR TITLE
Migrate FullPageHeader to Typography

### DIFF
--- a/src/components/FullPageHeader/FullPageHeader.module.css
+++ b/src/components/FullPageHeader/FullPageHeader.module.css
@@ -66,7 +66,6 @@
 .heading {
   font-size: var(--font-size-5xl);
   font-weight: var(--font-weight-extrabold);
-  color: var(--color-text-strong);
 
   @media (min-width: 768px) {
     font-size: clamp(var(--font-size-5xl), 6vw, 4rem);
@@ -75,14 +74,10 @@
 
 .tagline {
   font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-normal);
-  color: var(--color-text);
   margin: 0;
 }
 
 .description {
-  font-size: var(--font-size-lg);
-  line-height: var(--line-height-relaxed);
   max-inline-size: 60ch;
 }
 

--- a/src/components/FullPageHeader/FullPageHeader.tsx
+++ b/src/components/FullPageHeader/FullPageHeader.tsx
@@ -1,5 +1,6 @@
 import Button from '@components/Button'
 import Image from '@components/Image'
+import Typography from '@components/Typography'
 import { usePreloadImage } from '@hooks/usePreloadImage'
 import { FC } from 'react'
 import styles from './FullPageHeader.module.css'
@@ -39,11 +40,11 @@ const FullPageHeader: FC<FullPageHeaderProps> = ({
         {/* Text Content */}
         <div className={styles.textColumn}>
           <hgroup className={styles.hgroup}>
-            <h1 className={styles.heading}>{name}</h1>
-            <p className={styles.tagline}>{tagline}</p>
+            <Typography variant="heading1" className={styles.heading}>{name}</Typography>
+            <Typography variant="bodyLarge" className={styles.tagline}>{tagline}</Typography>
           </hgroup>
 
-          <p className={styles.description}>{description}</p>
+          <Typography variant="bodyLarge" className={styles.description}>{description}</Typography>
 
           <div className={styles.cta}>
             <Button onClick={handleSendEmail}>Get in touch</Button>


### PR DESCRIPTION
Closes #43

## What changed
Migrated FullPageHeader's typography to the Typography component:

- `h1.heading` → `Typography variant="heading1"` with CSS overrides for responsive clamp font-size (`clamp(var(--font-size-5xl), 6vw, 4rem)`) and extrabold weight
- `p.tagline` → `Typography variant="bodyLarge"` with font-size override to 20px (bodyLarge defaults to 18px)
- `p.description` → `Typography variant="bodyLarge"` with max-inline-size layout constraint

Removed color, font-size, font-weight, and line-height from CSS where Typography handles them. Kept responsive overrides and layout CSS.

## Why
Final component migration in the Typography Component milestone. FullPageHeader was the most complex due to responsive clamp-based sizing.

## How to verify
- `pnpm test` — all 88 tests pass
- Visual QA: home page hero section should look identical before and after, including at different viewport widths

## Decisions made
- Tagline uses `bodyLarge` with a font-size override (20px vs 18px default) rather than heading3 — it's semantically body text, not a heading, and the weight (400) matches bodyLarge better than heading3 (700).
- Responsive clamp stays in FullPageHeader.module.css as specified by the PRD's non-goals section.