### PR TITLE
Verify migration: tests, linting, and visual QA

### DIFF
--- a/src/components/AppsCta/AppsCta.tsx
+++ b/src/components/AppsCta/AppsCta.tsx
@@ -15,7 +15,7 @@ const AppsCta: FC = () => {
         </Typography>
 
         <Typography variant="bodyLarge" className={styles.body}>
-          Side projects and experiments I've built to explore ideas and learn
+          Side projects and experiments I&apos;ve built to explore ideas and learn
           how things work. Take a look at{' '}
           <Link to="/apps" underline={true}>
             Apps


### PR DESCRIPTION
Closes #44

## What changed
Fixed an unescaped apostrophe in AppsCta (`I've` → `I&apos;ve`) that was flagged by ESLint's `react/no-unescaped-entities` rule.

## Verification results
- **Tests:** All 88 tests pass across 19 test files
- **Linting:** ESLint passes on all changed files in the milestone
- **Visual QA:** Pending human review — all pages (Home, Apps, 404) should look identical to before the Typography migration, in both light and dark mode

## Why
Final verification step for the Typography Component milestone. Confirms the entire migration is green.