### PR TITLE
Create meta tag mapping module

### DIFF
--- a/src/meta.ts
+++ b/src/meta.ts
@@ -16,29 +16,79 @@ export interface MetaTags {
   }
 }
 
-export function getMetaTags(_path: string): MetaTags {
+const BASE_URL = 'https://akli.dev'
+
+const routeMeta: Record<string, { title: string; description: string }> = {
+  '/': {
+    title: 'Akli Aissat — Full-Stack Engineer',
+    description:
+      'Full-stack engineer building responsive web applications with React, TypeScript, and modern web technologies. Explore my projects and experiments.',
+  },
+  '/apps': {
+    title: 'Apps & Experiments | Akli Aissat',
+    description:
+      'Interactive side projects and experiments built to explore ideas and learn how things work.',
+  },
+}
+
+const notFoundMeta = {
+  title: 'Page Not Found | Akli Aissat',
+  description: 'The page you are looking for does not exist.',
+}
+
+export function normalisePath(path: string): string {
+  if (path === '/') return '/'
+  return path.endsWith('/') ? path.slice(0, -1) : path
+}
+
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export function getMetaTags(path: string): MetaTags {
+  const normalised = normalisePath(path)
+  const route = routeMeta[normalised]
+  const canonical = `${BASE_URL}${normalised}`
+
+  if (route) {
+    return {
+      title: route.title,
+      description: route.description,
+      canonical,
+      og: {
+        type: 'website',
+        url: canonical,
+        title: route.title,
+        description: route.description,
+      },
+      twitter: {
+        card: 'summary',
+        title: route.title,
+        description: route.description,
+      },
+    }
+  }
+
+  const { title, description } = notFoundMeta
   return {
-    title: '',
-    description: '',
-    canonical: '',
+    title,
+    description,
+    canonical,
+    robots: 'noindex',
     og: {
-      type: '',
-      url: '',
-      title: '',
-      description: '',
+      type: 'website',
+      url: canonical,
+      title,
+      description,
     },
     twitter: {
-      card: '',
-      title: '',
-      description: '',
+      card: 'summary',
+      title,
+      description,
     },
   }
-}
-
-export function normalisePath(_path: string): string {
-  return _path
-}
-
-export function escapeHtml(_str: string): string {
-  return _str
 }


### PR DESCRIPTION
Closes #54

## What changed
Replaced the `src/meta.ts` stub with a full implementation. Exports `getMetaTags(path)`, `normalisePath(path)`, `escapeHtml(str)`, and the `MetaTags` interface. Maps `/` and `/apps` to their specific meta content, unknown routes to 404 meta with noindex. All values include OG, Twitter Card, and canonical URL tags. HTML-escaped.

## Why
Single source of truth for per-page meta tags, consumed by the server entry point to inject correct SEO tags into the HTML response.

## How to verify
- `pnpm test src/meta.test.ts` — all 34 meta tests pass

## Decisions made
- Route lookup uses exact match after normalisation — no fuzzy matching or regex.
- `escapeHtml` covers `&`, `<`, `>`, `"` — sufficient for meta tag attribute values.