### PR TITLE
Configure Vite SSR build and update build scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Akli Aissat</title>
-    <meta name="description" content="I'm Akli Aissat and welcome to my personal website." />
+    <!--ssr-head-->
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root"><!--ssr-outlet--></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build:prod": "cp public/robots.prod.txt public/robots.txt && vite build",
+    "build:client": "vite build --outDir dist/client",
+    "build:server": "vite build --ssr src/lambda-handler.ts --outDir dist/server",
+    "build:prod": "cp public/robots.prod.txt public/robots.txt && pnpm build:client && pnpm build:server",
     "build:dev": "cp public/robots.dev.txt public/robots.txt && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,32 +4,36 @@ import { imagetools } from 'vite-imagetools'
 import { defineConfig } from 'vitest/config'
 import { sitemapPlugin } from './sitemap-plugin'
 
-export default defineConfig({
+export default defineConfig(({ isSsrBuild }) => ({
   plugins: [
     react(),
     mdx(),
     imagetools(),
-    sitemapPlugin({
-      hostname: 'https://akli.dev',
-      pagesDir: 'src/pages',
-      include: ['**/*.tsx'],
-      exclude: ['**/*.test.*', '**/*.spec.*', '**/NotFound.*', '**/*test*'],
-      routeMapping: {
-        '/home': '/',
-      },
-      routeConfig: {
-        '/': {
-          priority: 1.0,
-          changefreq: 'monthly',
-        },
-        '/apps': {
-          priority: 0.8,
-          changefreq: 'monthly',
-        },
-      },
-      defaultPriority: 0.5,
-      defaultChangefreq: 'monthly',
-    }),
+    ...(!isSsrBuild
+      ? [
+          sitemapPlugin({
+            hostname: 'https://akli.dev',
+            pagesDir: 'src/pages',
+            include: ['**/*.tsx'],
+            exclude: ['**/*.test.*', '**/*.spec.*', '**/NotFound.*', '**/*test*'],
+            routeMapping: {
+              '/home': '/',
+            },
+            routeConfig: {
+              '/': {
+                priority: 1.0,
+                changefreq: 'monthly',
+              },
+              '/apps': {
+                priority: 0.8,
+                changefreq: 'monthly',
+              },
+            },
+            defaultPriority: 0.5,
+            defaultChangefreq: 'monthly',
+          }),
+        ]
+      : []),
   ],
   resolve: {
     alias: {
@@ -37,6 +41,9 @@ export default defineConfig({
       '@pages': '/src/pages',
       '@hooks': '/src/hooks',
     },
+  },
+  ssr: {
+    noExternal: true,
   },
   test: {
     globals: true,
@@ -47,4 +54,4 @@ export default defineConfig({
       reporter: ['text', 'json', 'html'],
     },
   },
-})
+}))


### PR DESCRIPTION
Closes #55

## What changed
- **`package.json`** — added `build:client` and `build:server` scripts, updated `build:prod` to run both sequentially
- **`vite.config.ts`** — converted to function config for conditional SSR behaviour; added `ssr.noExternal: true` for self-contained Lambda bundle; sitemap plugin excluded from SSR builds
- **`index.html`** — added `<!--ssr-outlet-->` in root div, `<!--ssr-head-->` in head, removed hardcoded generic description

## Why
Enables the Vite SSR build pipeline. Client build outputs to `dist/client/` (for S3), server build outputs to `dist/server/` (for Lambda). Both builds share path aliases, imagetools, and MDX support.

## How to verify
- `pnpm dev` still works (CSR dev server)
- `pnpm build:client` produces `dist/client/` with assets
- `pnpm build:server` produces `dist/server/lambda-handler.js`
- `pnpm test` — existing tests pass

## Decisions made
- Used Vite function config with `isSsrBuild` flag to conditionally exclude sitemap plugin from server builds.
- `ssr.noExternal: true` bundles all dependencies — Lambda needs a self-contained zip with no node_modules.
- Server build entry is `src/lambda-handler.ts` (which imports entry-server).