### PR TITLE
Update CI/CD to deploy server bundle to Lambda

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,14 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
 
-      - name: Deploy to S3
-        run: aws s3 sync ./dist s3://${{ secrets.S3_BUCKET_NAME }} --delete --exclude "apps/sand-box/*"
+      - name: Deploy client bundle to S3
+        run: aws s3 sync ./dist/client s3://${{ secrets.S3_BUCKET_NAME }} --delete --exclude "apps/sand-box/*"
+
+      - name: Zip server bundle
+        run: cd dist/server && zip -r ../server.zip .
+
+      - name: Deploy server bundle to Lambda
+        run: aws lambda update-function-code --function-name ${{ secrets.SSR_LAMBDA_FUNCTION_NAME }} --zip-file fileb://dist/server.zip
 
       - name: Invalidate CloudFront
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
Closes #58

## What changed
Updated `.github/workflows/deploy.yml`:
- S3 sync now deploys from `dist/client/` (client assets only)
- Added step to zip server bundle
- Added step to deploy server bundle to Lambda via `aws lambda update-function-code`
- CloudFront invalidation preserved

## Why
The build now produces two artifacts: client bundle (S3) and server bundle (Lambda). CI/CD needs to deploy both.

## How to verify
- YAML syntax is valid
- New secret `SSR_LAMBDA_FUNCTION_NAME` must be added to the repo's GitHub Actions secrets before the first deploy

## Decisions made
- Server bundle zipped inline rather than using a GitHub Action — simpler, no extra dependency.
- `--exclude "apps/sand-box/*"` preserved on S3 sync.