### PR TITLE
Verify SSR: tests, build, linting, and simplify review

### DIFF
--- a/src/lambda-handler.ts
+++ b/src/lambda-handler.ts
@@ -1,7 +1,5 @@
 import { render } from './entry-server'
-import { normalisePath } from './meta'
-
-const KNOWN_ROUTES = new Set(['/', '/apps'])
+import { KNOWN_ROUTES, normalisePath } from './meta'
 
 export async function handler(
   event: Record<string, unknown>
@@ -9,14 +7,25 @@ export async function handler(
   const rawPath = (event.rawPath as string) || '/'
   const path = normalisePath(rawPath)
 
-  const html = render(path)
-  const statusCode = KNOWN_ROUTES.has(path) ? 200 : 404
+  try {
+    const html = render(path)
+    const statusCode = KNOWN_ROUTES.has(path) ? 200 : 404
 
-  return {
-    statusCode,
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-    },
-    body: html,
+    return {
+      statusCode,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'public, max-age=60',
+      },
+      body: html,
+    }
+  } catch {
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+      },
+      body: '<!DOCTYPE html><html><body><h1>Internal Server Error</h1></body></html>',
+    }
   }
 }

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -47,38 +47,22 @@ export function escapeHtml(str: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
 }
 
-export function getMetaTags(path: string): MetaTags {
-  const normalised = normalisePath(path)
-  const route = routeMeta[normalised]
-  const canonical = `${BASE_URL}${normalised}`
+export const KNOWN_ROUTES = new Set(Object.keys(routeMeta))
 
-  if (route) {
-    return {
-      title: route.title,
-      description: route.description,
-      canonical,
-      og: {
-        type: 'website',
-        url: canonical,
-        title: route.title,
-        description: route.description,
-      },
-      twitter: {
-        card: 'summary',
-        title: route.title,
-        description: route.description,
-      },
-    }
-  }
-
-  const { title, description } = notFoundMeta
+function buildMetaTags(
+  title: string,
+  description: string,
+  canonical: string,
+  robots?: string,
+): MetaTags {
   return {
     title,
     description,
     canonical,
-    robots: 'noindex',
+    ...(robots && { robots }),
     og: {
       type: 'website',
       url: canonical,
@@ -91,4 +75,16 @@ export function getMetaTags(path: string): MetaTags {
       description,
     },
   }
+}
+
+export function getMetaTags(path: string): MetaTags {
+  const normalised = normalisePath(path)
+  const route = routeMeta[normalised]
+  const canonical = `${BASE_URL}${normalised}`
+
+  if (route) {
+    return buildMetaTags(route.title, route.description, canonical)
+  }
+
+  return buildMetaTags(notFoundMeta.title, notFoundMeta.description, canonical, 'noindex')
 }


### PR DESCRIPTION
Closes #59

## What changed
Ran /simplify on the full SSR epic and fixed the findings:

- **DRY meta.ts** — extracted `buildMetaTags` helper, removing ~20 lines of duplication
- **Single route registry** — `KNOWN_ROUTES` now derived from `routeMeta` keys (was duplicated in lambda-handler.ts)
- **Error handling** — Lambda handler now catches render failures and returns a 500 HTML response instead of a raw 502
- **Cache-Control** — added `public, max-age=60` header to align with CloudFront SSR cache policy
- **escapeHtml** — added single-quote escaping for completeness

## Verification results
- All 147 tests pass
- ESLint clean on all changed files
- `pnpm build:prod` succeeds (client + server bundles)
- `pnpm dev` works (CSR unchanged)

## Manual verification still needed
- Hydration mismatch check in browser console (post-deploy)
- CSS Module class name matching (post-deploy)
- Server bundle runs on Node.js 20 (post-deploy)