### PR TITLE
Add Pokedex card to Apps page

### DIFF
--- a/src/pages/Apps/Apps.test.tsx
+++ b/src/pages/Apps/Apps.test.tsx
@@ -48,4 +48,17 @@ describe('Apps', () => {
       screen.getByRole('link', { name: 'https://akli.dev/apps/sand-box' })
     ).toBeInTheDocument()
   })
+
+  it('renders the Pokedex card with correct title, description, and link', () => {
+    render(<Apps />)
+    expect(screen.getByText('Pokedex')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'A searchable encyclopedia of Gen 1 Pokemon, styled after the classic Game Boy Color Pokedex.'
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'https://akli.dev/apps/pokedex' })
+    ).toBeInTheDocument()
+  })
 })

--- a/src/pages/Apps/Apps.tsx
+++ b/src/pages/Apps/Apps.tsx
@@ -4,11 +4,24 @@ import Grid from '@components/Grid'
 import SocialCard from '@components/SocialCard'
 import Typography from '@components/Typography'
 import type { FC } from 'react'
+import pokedexImgSrc from '../../assets/pokedex.webp'
+import pokedexImgSrcSet from '../../assets/pokedex.webp?w=320;640;768;1024;1280;1536;1920&format=webp&as=srcset'
 import imgSrc from '../../assets/sand-box.webp'
 import imgSrcSet from '../../assets/sand-box.webp?w=320;640;768;1024;1280;1536;1920&format=webp&as=srcset'
 import styles from './Apps.module.css'
 
 const CARDS: CardProps[] = [
+  {
+    title: 'Pokedex',
+    description:
+      'A searchable encyclopedia of Gen 1 Pokemon, styled after the classic Game Boy Color Pokedex.',
+    image: {
+      src: pokedexImgSrc,
+      srcSet: pokedexImgSrcSet,
+      alt: 'A searchable encyclopedia of Gen 1 Pokemon, styled after the classic Game Boy Color Pokedex',
+    },
+    href: 'https://akli.dev/apps/pokedex',
+  },
   {
     title: 'Sand box',
     description:


### PR DESCRIPTION
Closes #69

## What changed
Added Pokedex card to the Apps page before the sand-box card (most recent first). Uses vite-imagetools for responsive srcSet, links to `https://akli.dev/apps/pokedex`.

## How to verify
- `pnpm test` — 155 tests pass
- `pnpm dev` — Apps page shows Pokedex card before sand-box