### PR TITLE
Wrap Lambda handler with awslambda.streamifyResponse

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,6 +73,14 @@ export default [
     },
   },
   {
+    files: ['src/lambda-handler.ts'],
+    languageOptions: {
+      globals: {
+        awslambda: 'readonly',
+      },
+    },
+  },
+  {
     files: ['**/*.test.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_|^mock' }],

--- a/src/awslambda.d.ts
+++ b/src/awslambda.d.ts
@@ -1,0 +1,27 @@
+import type { Writable } from 'node:stream'
+
+interface HttpResponseStreamMetadata {
+  statusCode: number
+  headers: Record<string, string>
+}
+
+interface HttpResponseStreamStatic {
+  from(stream: Writable, metadata: HttpResponseStreamMetadata): Writable
+}
+
+type StreamHandler = (
+  event: Record<string, unknown>,
+  responseStream: Writable,
+  context: unknown
+) => Promise<void>
+
+interface AwsLambda {
+  streamifyResponse(handler: StreamHandler): StreamHandler
+  HttpResponseStream: HttpResponseStreamStatic
+}
+
+declare global {
+  const awslambda: AwsLambda
+}
+
+export type { AwsLambda }

--- a/src/lambda-handler.test.ts
+++ b/src/lambda-handler.test.ts
@@ -1,14 +1,6 @@
 // @vitest-environment node
 import { Writable } from 'node:stream'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
-/**
- * Mock for the awslambda global that the Lambda runtime provides.
- *
- * streamifyResponse: extracts the inner handler so we can invoke it directly.
- * HttpResponseStream.from: captures the metadata (statusCode, headers) and
- *   returns the writable stream so we can inspect what the handler wrote.
- */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 interface CapturedMetadata {
   statusCode?: number
@@ -33,10 +25,8 @@ let innerHandler: ((
   context: unknown
 ) => Promise<void>) | null = null
 
-beforeEach(() => {
-  capturedMetadata = {}
-  innerHandler = null
-
+// Set up the awslambda global mock once before all tests
+beforeAll(() => {
   const mockAwsLambda = {
     streamifyResponse: (
       fn: (
@@ -56,67 +46,62 @@ beforeEach(() => {
     },
   }
 
-  // Set the global so the module sees it when imported
   ;(globalThis as Record<string, unknown>).awslambda = mockAwsLambda
 })
 
-afterEach(() => {
+afterAll(() => {
   delete (globalThis as Record<string, unknown>).awslambda
-  vi.resetModules()
 })
 
-/**
- * Helper: import the handler fresh (so it picks up the global mock),
- * then invoke the inner streaming handler with a mock writable.
- *
- * Returns the captured metadata and the collected stream chunks.
- */
-const invokeHandler = async (rawPath?: string) => {
-  const mod = await import('./lambda-handler')
+beforeEach(() => {
+  capturedMetadata = {}
+})
 
-  // The handler should have been registered via streamifyResponse
+const createEvent = (rawPath?: string): Record<string, unknown> => ({
+  version: '2.0',
+  routeKey: '$default',
+  rawPath,
+  rawQueryString: '',
+  headers: { 'content-type': 'text/html' },
+  requestContext: {
+    accountId: '123456789012',
+    apiId: 'api-id',
+    domainName: 'id.execute-api.us-east-1.amazonaws.com',
+    domainPrefix: 'id',
+    http: {
+      method: 'GET',
+      path: rawPath ?? '/',
+      protocol: 'HTTP/1.1',
+      sourceIp: '127.0.0.1',
+      userAgent: 'test',
+    },
+    requestId: 'id',
+    routeKey: '$default',
+    stage: '$default',
+    time: '01/Jan/2024:00:00:00 +0000',
+    timeEpoch: 1704067200000,
+  },
+  isBase64Encoded: false,
+})
+
+const invokeHandler = async (rawPath?: string) => {
+  // Import is cached after first call — innerHandler stays set
+  await import('./lambda-handler')
   expect(innerHandler).not.toBeNull()
 
   const { writable, chunks } = createMockWritable()
 
-  const event: Record<string, unknown> = {
-    version: '2.0',
-    routeKey: '$default',
-    rawPath,
-    rawQueryString: '',
-    headers: { 'content-type': 'text/html' },
-    requestContext: {
-      accountId: '123456789012',
-      apiId: 'api-id',
-      domainName: 'id.execute-api.us-east-1.amazonaws.com',
-      domainPrefix: 'id',
-      http: {
-        method: 'GET',
-        path: rawPath ?? '/',
-        protocol: 'HTTP/1.1',
-        sourceIp: '127.0.0.1',
-        userAgent: 'test',
-      },
-      requestId: 'id',
-      routeKey: '$default',
-      stage: '$default',
-      time: '01/Jan/2024:00:00:00 +0000',
-      timeEpoch: 1704067200000,
-    },
-    isBase64Encoded: false,
-  }
-
   await new Promise<void>((resolve, reject) => {
     writable.on('finish', resolve)
     writable.on('error', reject)
-    innerHandler!(event, writable, {}).catch(reject)
+    innerHandler!(createEvent(rawPath), writable, {}).catch(reject)
   })
 
-  const body = chunks.join('')
-  return { metadata: capturedMetadata, body, handler: mod.handler }
+  return { metadata: capturedMetadata, body: chunks.join('') }
 }
 
-describe('lambda-handler (streaming)', () => {
+// eslint-disable-next-line vitest/valid-describe-callback
+describe('lambda-handler (streaming)', { timeout: 30_000 }, () => {
   describe('streamifyResponse wrapping', () => {
     it('exports a handler created via awslambda.streamifyResponse', async () => {
       await import('./lambda-handler')
@@ -124,7 +109,7 @@ describe('lambda-handler (streaming)', () => {
     })
   })
 
-  describe('200 routes — writes HTML to the stream', () => {
+  describe('200 routes', () => {
     it('sets statusCode 200 and correct headers for the home route', async () => {
       const { metadata } = await invokeHandler('/')
       expect(metadata.statusCode).toBe(200)
@@ -167,39 +152,33 @@ describe('lambda-handler (streaming)', () => {
 
   describe('error handling', () => {
     it('writes a 500 error page when render fails', async () => {
-      // Mock the render function to throw
+      vi.resetModules()
+
       vi.doMock('./entry-server', () => ({
         render: () => Promise.reject(new Error('boom')),
       }))
 
-      const mod = await import('./lambda-handler')
+      // Re-import with the mocked entry-server
+      innerHandler = null
+      await import('./lambda-handler')
       expect(innerHandler).not.toBeNull()
 
       const { writable, chunks } = createMockWritable()
-      const event: Record<string, unknown> = {
-        version: '2.0',
-        routeKey: '$default',
-        rawPath: '/',
-        rawQueryString: '',
-        headers: {},
-        requestContext: {
-          http: { method: 'GET', path: '/' },
-        },
-        isBase64Encoded: false,
-      }
 
       await new Promise<void>((resolve, reject) => {
         writable.on('finish', resolve)
         writable.on('error', reject)
-        innerHandler!(event, writable, {}).catch(reject)
+        innerHandler!(createEvent('/'), writable, {}).catch(reject)
       })
 
       expect(capturedMetadata.statusCode).toBe(500)
-      const body = chunks.join('')
-      expect(body).toContain('Internal Server Error')
+      expect(chunks.join('')).toContain('Internal Server Error')
 
-      // Ensure the handler reference is used so TS doesn't complain
-      expect(mod.handler).toBeDefined()
+      // Restore modules so subsequent tests use the real entry-server
+      vi.doUnmock('./entry-server')
+      vi.resetModules()
+      innerHandler = null
+      await import('./lambda-handler')
     })
   })
 

--- a/src/lambda-handler.ts
+++ b/src/lambda-handler.ts
@@ -1,34 +1,41 @@
+import type { Writable } from 'node:stream'
 import { render } from './entry-server'
 import { isKnownRoute, normalisePath } from './meta'
 
-export const handler = async (
-  event: Record<string, unknown>
-): Promise<Record<string, unknown>> => {
-  let rawPath = (event.rawPath as string) || '/'
-  // CloudFront defaultRootObject rewrites / to /index.html
-  if (rawPath === '/index.html') rawPath = '/'
-  const path = normalisePath(rawPath)
-
-  try {
-    const html = await render(path)
+export const handler = awslambda.streamifyResponse(
+  async (
+    event: Record<string, unknown>,
+    responseStream: Writable,
+    _context: unknown
+  ) => {
+    let rawPath = (event.rawPath as string) || '/'
+    // CloudFront defaultRootObject rewrites / to /index.html
+    if (rawPath === '/index.html') rawPath = '/'
+    const path = normalisePath(rawPath)
     const statusCode = isKnownRoute(path) ? 200 : 404
 
-    return {
-      statusCode,
-      headers: {
-        'Content-Type': 'text/html; charset=utf-8',
-        'Cache-Control': statusCode === 200 ? 'public, max-age=60' : 'no-cache',
-      },
-      body: html,
-    }
-  } catch (err) {
-    console.error('SSR render failed:', err)
-    return {
-      statusCode: 500,
-      headers: {
-        'Content-Type': 'text/html; charset=utf-8',
-      },
-      body: '<!DOCTYPE html><html><body><h1>Internal Server Error</h1></body></html>',
+    try {
+      const html = await render(path)
+      const httpStream = awslambda.HttpResponseStream.from(responseStream, {
+        statusCode,
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Cache-Control':
+            statusCode === 200 ? 'public, max-age=60' : 'no-cache',
+        },
+      })
+      httpStream.write(html)
+      httpStream.end()
+    } catch (err) {
+      console.error('SSR render failed:', err)
+      const httpStream = awslambda.HttpResponseStream.from(responseStream, {
+        statusCode: 500,
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      })
+      httpStream.write(
+        '<!DOCTYPE html><html><body><h1>Internal Server Error</h1></body></html>'
+      )
+      httpStream.end()
     }
   }
-}
+)


### PR DESCRIPTION
Closes #99

## What changed
- Rewrote `lambda-handler.ts` to use `awslambda.streamifyResponse` — handler writes HTML directly to a response stream instead of returning a JSON object
- Added `awslambda.d.ts` TypeScript declarations for the Lambda runtime global
- Added `awslambda` as a readonly global in ESLint config for the handler file
- Rewrote tests to mock the `awslambda` global and assert on stream output and HTTP metadata

## Why
Lambda Function URLs with `RESPONSE_STREAM` invoke mode require handlers wrapped with `awslambda.streamifyResponse`. This is the application-side counterpart to the infrastructure changes in akli-infrastructure (Lambda Function URL with RESPONSE_STREAM).

## How to verify
- `pnpm test` — 251 tests pass
- `pnpm build:prod` — SSR build succeeds
- Status codes verified: 200 for known routes, 404 for unknown, 500 on render failure

## Decisions made
- Used `HttpResponseStream.from` to set status code and headers before writing HTML — status must be determined before streaming starts
- Currently writes the full HTML string to the stream (from `render()`) — true progressive streaming (piping React stream directly) can be a future optimisation
- Added `awslambda` global to ESLint config rather than using `// eslint-disable` in the handler file