### PR TITLE
Manual QA and refinements

### DIFF
--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -27,6 +27,8 @@ try {
 </html>`
 }
 
+const [templateBeforeOutlet, templateAfterOutlet] = template.split('<!--ssr-outlet-->')
+
 const buildHeadHtml = (routePath: string): string => {
   const meta = getMetaTags(routePath)
   const lines: string[] = []
@@ -149,8 +151,7 @@ const resolveSuspenseBoundaries = (html: string): string => {
 export const render = (url: string): Promise<string> =>
   new Promise<string>((resolve, reject) => {
     const head = buildHeadHtml(url)
-    const [beforeOutlet, afterOutlet] = template.split('<!--ssr-outlet-->')
-    const beforeHtml = beforeOutlet.replace('<!--ssr-head-->', head)
+    const beforeHtml = templateBeforeOutlet.replace('<!--ssr-head-->', head)
 
     const { pipe } = renderToPipeableStream(
       <StaticRouter location={url}>
@@ -166,7 +167,7 @@ export const render = (url: string): Promise<string> =>
           })
 
           reactStream.on('end', () => {
-            const fullHtml = beforeHtml + reactHtml + afterOutlet
+            const fullHtml = beforeHtml + reactHtml + templateAfterOutlet
             resolve(resolveSuspenseBoundaries(fullHtml))
           })
 


### PR DESCRIPTION
Closes #100

## What changed
- Cached template split at module load instead of per-request (from /simplify review)
- Verified SSR output for all routes via production build

## QA results
| Route | Status | Title | Notes |
|---|---|---|---|
| `/` | 200 | Akli Aissat — Full-Stack Engineer | OK |
| `/apps` | 200 | Apps & Experiments | OK |
| `/blog` | 200 | Blog | OK |
| `/blog/building-a-pokedex` | 200 | Building a Pokedex... | Full content, no "Loading...", OG image, article type |
| `/nonexistent` | 404 | Page Not Found | noindex meta tag |

- No `<!--ssr-outlet-->` or `<!--ssr-head-->` markers in output
- All meta tags present (title, description, OG, Twitter, canonical)
- Blog post content fully server-rendered (65KB HTML)

## How to verify
- `pnpm test` — 251 tests pass
- `pnpm build:prod` — SSR build succeeds