### PR TITLE
Create recipe API service layer and types

### DIFF
--- a/src/api/recipes.test.ts
+++ b/src/api/recipes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchRecipes, fetchRecipe, fetchTags } from './recipes'
 import type { RecipeIndex, Recipe, Tag } from '../types/recipe'
+import { fetchRecipes, fetchRecipe, fetchTags } from './recipes'
 
 const mockRecipeIndex: RecipeIndex = {
   id: 'r1',

--- a/src/api/recipes.test.ts
+++ b/src/api/recipes.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchRecipes, fetchRecipe, fetchTags } from './recipes'
+import type { RecipeIndex, Recipe, Tag } from '../types/recipe'
+
+const mockRecipeIndex: RecipeIndex = {
+  id: 'r1',
+  title: 'Spaghetti Bolognese',
+  slug: 'spaghetti-bolognese',
+  coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+  tags: ['Italian', 'Pasta'],
+  prepTime: 15,
+  cookTime: 45,
+  servings: 4,
+  createdAt: '2026-03-01T12:00:00Z',
+}
+
+const mockRecipe: Recipe = {
+  ...mockRecipeIndex,
+  intro: 'A classic Italian pasta dish.',
+  ingredients: [
+    { item: 'spaghetti', quantity: '400', unit: 'g' },
+    { item: 'minced beef', quantity: '500', unit: 'g' },
+  ],
+  steps: [
+    { order: 1, text: 'Boil the pasta.' },
+    { order: 2, text: 'Brown the mince.', image: { key: 'step-2', alt: 'Browning mince in a pan' } },
+  ],
+  authorId: 'a1',
+  authorName: 'Akli Aissat',
+  updatedAt: '2026-03-02T10:00:00Z',
+  status: 'published',
+}
+
+const mockTags: Tag[] = [
+  { tag: 'Italian', count: 3 },
+  { tag: 'Quick', count: 5 },
+]
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('fetchRecipes', () => {
+  it('returns an array of RecipeIndex on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([mockRecipeIndex]),
+      })
+    )
+
+    const result = await fetchRecipes()
+
+    expect(result).toEqual([mockRecipeIndex])
+    expect(fetch).toHaveBeenCalledWith('https://api.akli.dev/recipes')
+  })
+
+  it('throws on HTTP 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+    )
+
+    await expect(fetchRecipes()).rejects.toThrow('404')
+  })
+
+  it('throws on HTTP 500', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      })
+    )
+
+    await expect(fetchRecipes()).rejects.toThrow('500')
+  })
+
+  it('throws on network failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    )
+
+    await expect(fetchRecipes()).rejects.toThrow('Failed to fetch')
+  })
+})
+
+describe('fetchRecipe', () => {
+  it('returns a Recipe on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockRecipe),
+      })
+    )
+
+    const result = await fetchRecipe('spaghetti-bolognese')
+
+    expect(result).toEqual(mockRecipe)
+  })
+
+  it('calls the correct URL with the slug', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockRecipe),
+      })
+    )
+
+    await fetchRecipe('spaghetti-bolognese')
+
+    expect(fetch).toHaveBeenCalledWith('https://api.akli.dev/recipes/spaghetti-bolognese')
+  })
+
+  it('throws on HTTP 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+    )
+
+    await expect(fetchRecipe('nonexistent')).rejects.toThrow('404')
+  })
+
+  it('throws on network failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    )
+
+    await expect(fetchRecipe('spaghetti-bolognese')).rejects.toThrow('Failed to fetch')
+  })
+})
+
+describe('fetchTags', () => {
+  it('returns an array of Tag on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockTags),
+      })
+    )
+
+    const result = await fetchTags()
+
+    expect(result).toEqual(mockTags)
+    expect(fetch).toHaveBeenCalledWith('https://api.akli.dev/recipes/tags')
+  })
+
+  it('throws on HTTP error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+      })
+    )
+
+    await expect(fetchTags()).rejects.toThrow('503')
+  })
+})

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -1,0 +1,15 @@
+import type { RecipeIndex, Recipe, Tag } from '../types/recipe'
+
+const API_BASE = 'https://api.akli.dev'
+
+export const fetchRecipes = async (): Promise<RecipeIndex[]> => {
+  throw new Error('Not implemented')
+}
+
+export const fetchRecipe = async (slug: string): Promise<Recipe> => {
+  throw new Error('Not implemented')
+}
+
+export const fetchTags = async (): Promise<Tag[]> => {
+  throw new Error('Not implemented')
+}

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -3,13 +3,25 @@ import type { RecipeIndex, Recipe, Tag } from '../types/recipe'
 const API_BASE = 'https://api.akli.dev'
 
 export const fetchRecipes = async (): Promise<RecipeIndex[]> => {
-  throw new Error('Not implemented')
+  const response = await fetch(`${API_BASE}/recipes`)
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+  return response.json()
 }
 
 export const fetchRecipe = async (slug: string): Promise<Recipe> => {
-  throw new Error('Not implemented')
+  const response = await fetch(`${API_BASE}/recipes/${slug}`)
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+  return response.json()
 }
 
 export const fetchTags = async (): Promise<Tag[]> => {
-  throw new Error('Not implemented')
+  const response = await fetch(`${API_BASE}/recipes/tags`)
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+  return response.json()
 }

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,0 +1,43 @@
+export interface RecipeImage {
+  key: string
+  alt: string
+}
+
+export interface Ingredient {
+  item: string
+  quantity: string
+  unit: string
+}
+
+export interface Step {
+  order: number
+  text: string
+  image?: RecipeImage
+}
+
+export interface Tag {
+  tag: string
+  count: number
+}
+
+export interface RecipeIndex {
+  id: string
+  title: string
+  slug: string
+  coverImage: RecipeImage
+  tags: string[]
+  prepTime: number
+  cookTime: number
+  servings: number
+  createdAt: string
+}
+
+export interface Recipe extends RecipeIndex {
+  intro: string
+  ingredients: Ingredient[]
+  steps: Step[]
+  authorId: string
+  authorName: string
+  updatedAt: string
+  status: string
+}


### PR DESCRIPTION
Closes #107

## What changed
- Created `src/types/recipe.ts` with TypeScript interfaces: RecipeImage, Ingredient, Step, Tag, RecipeIndex, Recipe
- Created `src/api/recipes.ts` with fetch wrappers: `fetchRecipes()`, `fetchRecipe(slug)`, `fetchTags()`
- Created `src/api/recipes.test.ts` with 10 tests covering success, HTTP errors, and network failures

## Why
Foundation for all recipe frontend components — provides typed API access to the recipe backend at api.akli.dev.

## How to verify
- `pnpm test -- src/api/recipes.test.ts` — 10/10 tests pass
- `pnpm lint` — clean (1 pre-existing warning only)

## Decisions made
- Simple fetch + throw pattern (no retry/caching — PRD says not needed at this scale)
- Types match the API response shapes from the infrastructure PRD
- Agents: **test-engineer** (Write) + **react-engineer**