### PR TITLE
Add recipe routes to App router

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,7 +7,7 @@ vi.mock('@components/Header', () => ({
 }))
 
 vi.mock('@components/Layout', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  default: ({ children }: { children: import('react').ReactNode }) => <div>{children}</div>,
 }))
 
 vi.mock('@pages/Home', () => ({

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@components/Header', () => ({
+  default: () => <div data-testid="header-mock">Header</div>,
+}))
+
+vi.mock('@components/Layout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@pages/Home', () => ({
+  default: () => <div>Home page</div>,
+}))
+
+vi.mock('@pages/Apps', () => ({
+  default: () => <div>Apps page</div>,
+}))
+
+vi.mock('@pages/Blog', () => ({
+  default: () => <div>Blog page</div>,
+}))
+
+vi.mock('@pages/Blog/BlogPost', () => ({
+  default: () => <div>Blog post page</div>,
+}))
+
+vi.mock('@pages/NotFound', () => ({
+  default: () => <div>Not found page</div>,
+}))
+
+vi.mock('@pages/Recipes', () => ({
+  default: () => <div>Recipes page</div>,
+}))
+
+vi.mock('@pages/RecipeDetail', () => ({
+  default: () => <div>Recipe detail page</div>,
+}))
+
+import App from './App'
+
+const renderApp = (route: string) =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <App />
+    </MemoryRouter>
+  )
+
+describe('App routing', () => {
+  it('renders Recipes page at /recipes', () => {
+    renderApp('/recipes')
+    expect(screen.getByText('Recipes page')).toBeInTheDocument()
+  })
+
+  it('renders RecipeDetail page at /recipes/:slug', () => {
+    renderApp('/recipes/test-slug')
+    expect(screen.getByText('Recipe detail page')).toBeInTheDocument()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import Blog from '@pages/Blog'
 import BlogPost from '@pages/Blog/BlogPost'
 import Home from '@pages/Home'
 import NotFound from '@pages/NotFound'
+import RecipeDetail from '@pages/RecipeDetail'
+import Recipes from '@pages/Recipes'
 import { Routes, Route } from 'react-router-dom'
 
 const App = () => {
@@ -17,6 +19,8 @@ const App = () => {
           <Route path="/apps" element={<Apps />} />
           <Route path="/blog" element={<Blog />} />
           <Route path="/blog/:slug" element={<BlogPost />} />
+          <Route path="/recipes" element={<Recipes />} />
+          <Route path="/recipes/:slug" element={<RecipeDetail />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Layout>

--- a/src/meta.test.ts
+++ b/src/meta.test.ts
@@ -30,7 +30,7 @@ vi.mock('./pages/Blog/posts/index', () => ({
   formatDate: (d: string) => d,
 }))
 
-import { getMetaTags, normalisePath, escapeHtml } from './meta'
+import { getMetaTags, normalisePath, escapeHtml, isKnownRoute } from './meta'
 
 describe('normalisePath', () => {
   it('strips trailing slash from /apps/', () => {
@@ -354,5 +354,11 @@ describe('getMetaTags', () => {
       const meta = getMetaTags('/blog/nonexistent-slug')
       expect(meta.robots).toBe('noindex')
     })
+  })
+})
+
+describe('isKnownRoute', () => {
+  it('recognises /recipes/:slug pattern', () => {
+    expect(isKnownRoute('/recipes/some-slug')).toBe(true)
   })
 })

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -38,6 +38,10 @@ const routeMeta: Record<string, { title: string; description: string }> = {
     description:
       'Articles on web development, engineering, and lessons learned building software.',
   },
+  '/recipes': {
+    title: 'Recipes | Akli Aissat',
+    description: 'Browse recipes for delicious home-cooked meals.',
+  },
 }
 
 const notFoundMeta = {
@@ -68,6 +72,8 @@ export const isKnownRoute = (path: string): boolean => {
     const post = postsModule.getPost(blogPostMatch[1])
     return !!post
   }
+  const recipeMatch = path.match(/^\/recipes\/(.+)$/)
+  if (recipeMatch) return true
   return false
 }
 

--- a/src/pages/RecipeDetail/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.tsx
@@ -1,0 +1,3 @@
+const RecipeDetail = () => <div>Recipe detail page</div>
+
+export default RecipeDetail

--- a/src/pages/RecipeDetail/index.ts
+++ b/src/pages/RecipeDetail/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RecipeDetail'

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,0 +1,3 @@
+const Recipes = () => <div>Recipes page</div>
+
+export default Recipes

--- a/src/pages/Recipes/index.ts
+++ b/src/pages/Recipes/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Recipes'


### PR DESCRIPTION
Closes #108

## What changed
- Added `/recipes` and `/recipes/:slug` routes to `App.tsx`
- Added `/recipes` to `routeMeta` in `meta.ts` with title and description
- Added `/recipes/:slug` pattern to `isKnownRoute()` for SSR route recognition
- Created `Recipes` and `RecipeDetail` page stubs with barrel exports

## Why
Foundation for recipe frontend — routes must exist before pages can be built.

## How to verify
- `pnpm test` — 264/264 tests pass
- `pnpm lint` — clean

## Decisions made
- `isKnownRoute` always returns `true` for recipe slugs for now — actual API validation added in the SSR issue (#109)
- Page stubs render placeholder text, replaced by real implementations in #110 and #111
- Agents: **test-engineer** (Write) + **react-engineer**