### PR TITLE
Add SSR data fetching for recipe detail pages

### DIFF
--- a/src/contexts/RecipeDataContext.ts
+++ b/src/contexts/RecipeDataContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react'
+import type { Recipe } from '../types/recipe'
+
+export interface RecipeData {
+  recipe?: Recipe
+}
+
+export const RecipeDataContext = createContext<RecipeData>({})

--- a/src/entry-server.test.tsx
+++ b/src/entry-server.test.tsx
@@ -127,6 +127,60 @@ describe('entry-server render', () => {
     })
   })
 
+  describe('recipe detail page /recipes/:slug with prefetched data', () => {
+    const mockRecipe = {
+      id: 'r1',
+      title: 'Spaghetti Bolognese',
+      slug: 'spaghetti-bolognese',
+      coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+      tags: ['Italian', 'Pasta'],
+      prepTime: 15,
+      cookTime: 45,
+      servings: 4,
+      createdAt: '2026-03-01T12:00:00Z',
+      intro: 'A classic Italian pasta dish with rich meat sauce.',
+      ingredients: [
+        { item: 'spaghetti', quantity: '400', unit: 'g' },
+        { item: 'minced beef', quantity: '500', unit: 'g' },
+      ],
+      steps: [
+        { order: 1, text: 'Boil the pasta.' },
+        { order: 2, text: 'Brown the mince.' },
+      ],
+      authorId: 'a1',
+      authorName: 'Akli Aissat',
+      updatedAt: '2026-03-02T10:00:00Z',
+      status: 'published',
+    }
+
+    it('produces HTML containing the recipe title', async () => {
+      const html = await render('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(html).toContain('Spaghetti Bolognese')
+    })
+
+    it('produces HTML containing Open Graph meta tags for the recipe', async () => {
+      const html = await render('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(html).toContain('property="og:title" content="Spaghetti Bolognese')
+      expect(html).toContain('property="og:description"')
+      expect(html).toContain('property="og:image"')
+      expect(html).toContain('property="og:type" content="article"')
+    })
+
+    it('produces HTML containing Twitter card meta tags for the recipe', async () => {
+      const html = await render('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(html).toContain('name="twitter:card" content="summary_large_image"')
+      expect(html).toContain('name="twitter:title"')
+      expect(html).toContain('name="twitter:image"')
+    })
+
+    it('still renders without prefetched data (loading/fallback state)', async () => {
+      const html = await render('/recipes/spaghetti-bolognese')
+      expect(html).toBeTruthy()
+      expect(html).toContain('<div id="root">')
+      expect(html).not.toContain('<div id="root"></div>')
+    })
+  })
+
   describe('error handling', () => {
     it('rejects or signals an error when the render crashes', async () => {
       vi.resetModules()

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -5,6 +5,8 @@ import { PassThrough } from 'node:stream'
 import { renderToPipeableStream } from 'react-dom/server'
 import { StaticRouter } from 'react-router-dom'
 import App from './App'
+import { RecipeDataContext } from './contexts/RecipeDataContext'
+import type { RecipeData } from './contexts/RecipeDataContext'
 import { getMetaTags, escapeHtml } from './meta'
 
 // Read the client-built index.html (copied into dist/server/ by build:prod).
@@ -29,8 +31,8 @@ try {
 
 const [templateBeforeOutlet, templateAfterOutlet] = template.split('<!--ssr-outlet-->')
 
-const buildHeadHtml = (routePath: string): string => {
-  const meta = getMetaTags(routePath)
+const buildHeadHtml = (routePath: string, data?: RecipeData): string => {
+  const meta = getMetaTags(routePath, data)
   const lines: string[] = []
 
   lines.push(`<title>${escapeHtml(meta.title)}</title>`)
@@ -79,14 +81,16 @@ const buildHeadHtml = (routePath: string): string => {
 }
 
 
-export const render = (url: string): Promise<string> =>
+export const render = (url: string, data?: RecipeData): Promise<string> =>
   new Promise<string>((resolve, reject) => {
-    const head = buildHeadHtml(url)
+    const head = buildHeadHtml(url, data)
     const beforeHtml = templateBeforeOutlet.replace('<!--ssr-head-->', head)
 
     const { pipe } = renderToPipeableStream(
       <StaticRouter location={url}>
-        <App />
+        <RecipeDataContext.Provider value={data ?? {}}>
+          <App />
+        </RecipeDataContext.Provider>
       </StaticRouter>,
       {
         onAllReady() {

--- a/src/lambda-handler.ts
+++ b/src/lambda-handler.ts
@@ -1,4 +1,5 @@
 import type { Writable } from 'node:stream'
+import type { RecipeData } from './contexts/RecipeDataContext'
 import { render } from './entry-server'
 import { isKnownRoute, normalisePath } from './meta'
 
@@ -12,10 +13,26 @@ export const handler = awslambda.streamifyResponse(
     // CloudFront defaultRootObject rewrites / to /index.html
     if (rawPath === '/index.html') rawPath = '/'
     const path = normalisePath(rawPath)
-    const statusCode = isKnownRoute(path) ? 200 : 404
+    let statusCode = isKnownRoute(path) ? 200 : 404
+
+    const recipeMatch = path.match(/^\/recipes\/([^/]+)$/)
+    let recipeData: RecipeData | undefined
+
+    if (recipeMatch) {
+      try {
+        const response = await fetch(`https://api.akli.dev/recipes/${recipeMatch[1]}`)
+        if (response.ok) {
+          recipeData = { recipe: await response.json() }
+        } else if (response.status === 404) {
+          statusCode = 404
+        }
+      } catch {
+        // API unavailable — render loading state, client will retry
+      }
+    }
 
     try {
-      const html = await render(path)
+      const html = await render(path, recipeData)
       const httpStream = awslambda.HttpResponseStream.from(responseStream, {
         statusCode,
         headers: {

--- a/src/meta.test.ts
+++ b/src/meta.test.ts
@@ -355,6 +355,89 @@ describe('getMetaTags', () => {
       expect(meta.robots).toBe('noindex')
     })
   })
+
+  describe('recipe detail route /recipes/<slug> with recipe data', () => {
+    const mockRecipe = {
+      id: 'r1',
+      title: 'Spaghetti Bolognese',
+      slug: 'spaghetti-bolognese',
+      coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+      tags: ['Italian', 'Pasta'],
+      prepTime: 15,
+      cookTime: 45,
+      servings: 4,
+      createdAt: '2026-03-01T12:00:00Z',
+      intro: 'A classic Italian pasta dish with rich meat sauce.',
+      ingredients: [
+        { item: 'spaghetti', quantity: '400', unit: 'g' },
+        { item: 'minced beef', quantity: '500', unit: 'g' },
+      ],
+      steps: [
+        { order: 1, text: 'Boil the pasta.' },
+        { order: 2, text: 'Brown the mince.' },
+      ],
+      authorId: 'a1',
+      authorName: 'Akli Aissat',
+      updatedAt: '2026-03-02T10:00:00Z',
+      status: 'published',
+    }
+
+    const longIntroRecipe = {
+      ...mockRecipe,
+      slug: 'long-intro-recipe',
+      intro:
+        'This is a very long introduction that exceeds one hundred and sixty characters in length so we can verify that the description is properly truncated when generating Open Graph meta tags for social sharing previews on various platforms.',
+    }
+
+    it('returns og:title matching the recipe title', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.og.title).toBe('Spaghetti Bolognese | Akli Aissat')
+    })
+
+    it('returns og:description from the recipe intro', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.og.description).toBe('A classic Italian pasta dish with rich meat sauce.')
+    })
+
+    it('returns og:description truncated to 160 chars when intro is longer', () => {
+      const meta = getMetaTags('/recipes/long-intro-recipe', { recipe: longIntroRecipe })
+      expect(meta.og.description.length).toBeLessThanOrEqual(160)
+    })
+
+    it('returns og:image with cover medium URL', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.og.image).toBeDefined()
+      expect(meta.og.image).toContain('spaghetti-cover')
+      expect(meta.og.image).toContain('-medium')
+    })
+
+    it('returns og:type as article', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.og.type).toBe('article')
+    })
+
+    it('returns twitter:card as summary_large_image', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.twitter.card).toBe('summary_large_image')
+    })
+
+    it('returns twitter:title matching the recipe title', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.twitter.title).toBe('Spaghetti Bolognese | Akli Aissat')
+    })
+
+    it('returns twitter:description from the recipe intro', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.twitter.description).toBe('A classic Italian pasta dish with rich meat sauce.')
+    })
+
+    it('returns twitter:image with cover medium URL', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.twitter.image).toBeDefined()
+      expect(meta.twitter.image).toContain('spaghetti-cover')
+      expect(meta.twitter.image).toContain('-medium')
+    })
+  })
 })
 
 describe('isKnownRoute', () => {

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -18,6 +18,7 @@ export interface MetaTags {
   }
 }
 
+import type { RecipeData } from './contexts/RecipeDataContext'
 import * as postsModule from './pages/Blog/posts/index'
 
 const BASE_URL = 'https://akli.dev'
@@ -107,7 +108,7 @@ const buildMetaTags = (
   }
 }
 
-export const getMetaTags = (path: string): MetaTags => {
+export const getMetaTags = (path: string, data?: RecipeData): MetaTags => {
   const normalised = normalisePath(path)
   const route = routeMeta[normalised]
   const canonical = `${BASE_URL}${normalised}`
@@ -130,6 +131,23 @@ export const getMetaTags = (path: string): MetaTags => {
         post.image,
       )
     }
+  }
+
+  const recipeMatch = normalised.match(/^\/recipes\/(.+)$/)
+  if (recipeMatch && data?.recipe) {
+    const recipe = data.recipe
+    const description = recipe.intro.length > 160
+      ? recipe.intro.slice(0, 157) + '...'
+      : recipe.intro
+    const coverMediumPath = `/images/${recipe.coverImage.key}-medium.webp`
+    return buildMetaTags(
+      `${recipe.title} | Akli Aissat`,
+      description,
+      canonical,
+      undefined,
+      'article',
+      coverMediumPath,
+    )
   }
 
   return buildMetaTags(notFoundMeta.title, notFoundMeta.description, canonical, 'noindex')


### PR DESCRIPTION
Closes #109

## What changed
- **lambda-handler.ts**: Fetches recipe data from `api.akli.dev/recipes/{slug}` before SSR render. Returns 404 if API confirms slug doesn't exist. Falls through on API failure for client retry.
- **entry-server.tsx**: Extended `render()` to accept optional `RecipeData`. Wraps `<App />` in `RecipeDataContext.Provider` for SSR hydration. Passes data to `buildHeadHtml` for dynamic meta tags.
- **meta.ts**: Extended `getMetaTags()` to generate dynamic OG/Twitter meta tags from prefetched recipe data (title, truncated intro, cover image medium URL).
- **RecipeDataContext**: Already created as stub in test phase.

## Why
Recipe detail pages need SSR for SEO and social sharing — crawlers must see full content and Open Graph tags in the initial HTML.

## How to verify
- `pnpm test` — 277/277 tests pass
- `pnpm lint` — clean

## Decisions made
- Image URL passed as relative path to `buildMetaTags` (which prepends BASE_URL) to avoid double-prefixing
- Reuses `RecipeData` interface from context across all three files
- API failure during SSR renders loading state — client retries (no hard failure)
- Agents: **test-engineer** (Write) + **react-engineer**