### PR TITLE
Build recipe listing page with search and tag filtering

### DIFF
--- a/src/components/RecipeCard/RecipeCard.module.css
+++ b/src/components/RecipeCard/RecipeCard.module.css
@@ -1,0 +1,99 @@
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: var(--radius-none);
+  border: var(--border-width) solid var(--color-border);
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-md);
+  transition:
+    transform var(--duration-fast) var(--easing-default),
+    box-shadow var(--duration-fast) var(--easing-default);
+}
+
+.card:hover {
+  transform: translate(-4px, -4px);
+  box-shadow: var(--shadow-lg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+
+  .card:hover {
+    transform: none;
+  }
+}
+
+.imageWrapper {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  overflow: hidden;
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: var(--space-4) var(--space-6) var(--space-6);
+}
+
+.title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  margin: 0 0 var(--space-2);
+}
+
+.titleLink {
+  color: var(--color-text-strong);
+  text-decoration: none;
+}
+
+.titleLink:hover {
+  color: var(--color-link-hover);
+}
+
+.titleLink:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-block-end: var(--space-3);
+}
+
+.tag {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  background: var(--color-surface-alt);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin-block-start: auto;
+}
+
+.separator {
+  font-weight: var(--font-weight-bold);
+}

--- a/src/components/RecipeCard/RecipeCard.module.css
+++ b/src/components/RecipeCard/RecipeCard.module.css
@@ -80,7 +80,7 @@
   padding: var(--space-1) var(--space-2);
   font-size: var(--font-size-sm);
   font-family: var(--font-mono);
-  background: var(--color-surface-alt);
+  background: var(--color-bg-subtle);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-none);
 }

--- a/src/components/RecipeCard/RecipeCard.test.tsx
+++ b/src/components/RecipeCard/RecipeCard.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
-import RecipeCard from './RecipeCard'
 import type { RecipeIndex } from '../../types/recipe'
+import RecipeCard from './RecipeCard'
 
 const mockRecipe: RecipeIndex = {
   id: 'rec-001',

--- a/src/components/RecipeCard/RecipeCard.test.tsx
+++ b/src/components/RecipeCard/RecipeCard.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import RecipeCard from './RecipeCard'
+import type { RecipeIndex } from '../../types/recipe'
+
+const mockRecipe: RecipeIndex = {
+  id: 'rec-001',
+  title: 'Classic Margherita Pizza',
+  slug: 'classic-margherita-pizza',
+  coverImage: { key: 'recipes/rec-001/cover', alt: 'Margherita pizza on a wooden board' },
+  tags: ['Italian', 'Quick'],
+  prepTime: 15,
+  cookTime: 12,
+  servings: 4,
+  createdAt: '2026-03-20T10:00:00Z',
+}
+
+const renderRecipeCard = (recipe = mockRecipe) =>
+  render(
+    <MemoryRouter>
+      <RecipeCard recipe={recipe} />
+    </MemoryRouter>
+  )
+
+describe('RecipeCard', () => {
+  it('renders cover image thumbnail with alt text', () => {
+    renderRecipeCard()
+
+    const img = screen.getByRole('img', { name: 'Margherita pizza on a wooden board' })
+    expect(img).toBeInTheDocument()
+  })
+
+  it('renders recipe title as a link to /recipes/{slug}', () => {
+    renderRecipeCard()
+
+    const link = screen.getByRole('link', { name: /classic margherita pizza/i })
+    expect(link).toHaveAttribute('href', '/recipes/classic-margherita-pizza')
+  })
+
+  it('renders tags', () => {
+    renderRecipeCard()
+
+    expect(screen.getByText('Italian')).toBeInTheDocument()
+    expect(screen.getByText('Quick')).toBeInTheDocument()
+  })
+
+  it('renders prep time, cook time, and servings', () => {
+    renderRecipeCard()
+
+    expect(screen.getByText(/15/)).toBeInTheDocument()
+    expect(screen.getByText(/12/)).toBeInTheDocument()
+    expect(screen.getByText(/4/)).toBeInTheDocument()
+  })
+})

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -1,0 +1,11 @@
+import type { RecipeIndex } from '../../types/recipe'
+
+export interface RecipeCardProps {
+  recipe: RecipeIndex
+}
+
+const RecipeCard = (_props: RecipeCardProps) => {
+  return null
+}
+
+export default RecipeCard

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -1,11 +1,53 @@
+import type { FC } from 'react'
+import { Link } from 'react-router-dom'
 import type { RecipeIndex } from '../../types/recipe'
+import styles from './RecipeCard.module.css'
 
 export interface RecipeCardProps {
   recipe: RecipeIndex
 }
 
-const RecipeCard = (_props: RecipeCardProps) => {
-  return null
+const IMAGE_BASE = 'https://akli.dev/images/processed'
+
+const RecipeCard: FC<RecipeCardProps> = ({ recipe }) => {
+  const thumbnailSrc = `${IMAGE_BASE}/${recipe.coverImage.key}-thumb.webp`
+
+  return (
+    <article className={styles.card}>
+      <div className={styles.imageWrapper}>
+        <img
+          src={thumbnailSrc}
+          alt={recipe.coverImage.alt}
+          loading="lazy"
+          className={styles.image}
+        />
+      </div>
+
+      <div className={styles.body}>
+        <h2 className={styles.title}>
+          <Link to={`/recipes/${recipe.slug}`} className={styles.titleLink}>
+            {recipe.title}
+          </Link>
+        </h2>
+
+        <div className={styles.tags}>
+          {recipe.tags.map((tag) => (
+            <span key={tag} className={styles.tag}>
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        <div className={styles.meta}>
+          <span>Prep: {recipe.prepTime} min</span>
+          <span className={styles.separator}>·</span>
+          <span>Cook: {recipe.cookTime} min</span>
+          <span className={styles.separator}>·</span>
+          <span>Serves: {recipe.servings}</span>
+        </div>
+      </div>
+    </article>
+  )
 }
 
 export default RecipeCard

--- a/src/components/RecipeCard/index.ts
+++ b/src/components/RecipeCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RecipeCard'
+export type { RecipeCardProps } from './RecipeCard'

--- a/src/components/RecipeSearch/RecipeSearch.module.css
+++ b/src/components/RecipeSearch/RecipeSearch.module.css
@@ -1,0 +1,24 @@
+.wrapper {
+  margin-block-end: var(--space-6);
+}
+
+.input {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-base);
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  box-shadow: var(--shadow-sm);
+}
+
+.input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.input:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/src/components/RecipeSearch/RecipeSearch.module.css
+++ b/src/components/RecipeSearch/RecipeSearch.module.css
@@ -6,7 +6,7 @@
   width: 100%;
   padding: var(--space-3) var(--space-4);
   font-size: var(--font-size-base);
-  font-family: var(--font-body);
+  font-family: var(--font-sans);
   color: var(--color-text);
   background: var(--color-surface);
   border: var(--border-width) solid var(--color-border);

--- a/src/components/RecipeSearch/RecipeSearch.test.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import RecipeSearch from './RecipeSearch'
+
+describe('RecipeSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders a search input with aria-label', () => {
+    render(<RecipeSearch onSearch={vi.fn()} />)
+
+    const input = screen.getByRole('searchbox', { name: /search recipes/i })
+    expect(input).toBeInTheDocument()
+  })
+
+  it('calls onSearch callback after 300ms debounce', () => {
+    const onSearch = vi.fn()
+    render(<RecipeSearch onSearch={onSearch} />)
+
+    const input = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(input, { target: { value: 'pizza' } })
+
+    // Advance past debounce period
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(onSearch).toHaveBeenCalledWith('pizza')
+  })
+
+  it('does not call onSearch before debounce period', () => {
+    const onSearch = vi.fn()
+    render(<RecipeSearch onSearch={onSearch} />)
+
+    const input = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(input, { target: { value: 'pasta' } })
+
+    // Advance less than debounce period
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(onSearch).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/RecipeSearch/RecipeSearch.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.tsx
@@ -1,9 +1,33 @@
+import { useState, useEffect, type FC } from 'react'
+import styles from './RecipeSearch.module.css'
+
 export interface RecipeSearchProps {
   onSearch: (query: string) => void
 }
 
-const RecipeSearch = (_props: RecipeSearchProps) => {
-  return null
+const RecipeSearch: FC<RecipeSearchProps> = ({ onSearch }) => {
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onSearch(value)
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [value, onSearch])
+
+  return (
+    <div className={styles.wrapper}>
+      <input
+        type="search"
+        aria-label="Search recipes"
+        placeholder="Search recipes..."
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className={styles.input}
+      />
+    </div>
+  )
 }
 
 export default RecipeSearch

--- a/src/components/RecipeSearch/RecipeSearch.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.tsx
@@ -1,0 +1,9 @@
+export interface RecipeSearchProps {
+  onSearch: (query: string) => void
+}
+
+const RecipeSearch = (_props: RecipeSearchProps) => {
+  return null
+}
+
+export default RecipeSearch

--- a/src/components/RecipeSearch/index.ts
+++ b/src/components/RecipeSearch/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RecipeSearch'
+export type { RecipeSearchProps } from './RecipeSearch'

--- a/src/components/RecipeTagFilter/RecipeTagFilter.module.css
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.module.css
@@ -32,3 +32,9 @@
   outline: var(--border-width) solid var(--color-primary);
   outline-offset: 2px;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .tag {
+    transition: none;
+  }
+}

--- a/src/components/RecipeTagFilter/RecipeTagFilter.module.css
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.module.css
@@ -1,0 +1,34 @@
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-block-end: var(--space-6);
+}
+
+.tag {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  cursor: pointer;
+}
+
+.tag:hover {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+}
+
+.tag[aria-pressed='true'] {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  font-weight: var(--font-weight-bold);
+}
+
+.tag:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/src/components/RecipeTagFilter/RecipeTagFilter.module.css
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.module.css
@@ -10,11 +10,6 @@
   font-size: var(--font-size-sm);
   font-family: var(--font-mono);
   font-weight: var(--font-weight-normal);
-  color: var(--color-text);
-  background: var(--color-surface);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-none);
-  cursor: pointer;
 }
 
 .tag:hover {
@@ -26,15 +21,4 @@
   background: var(--color-primary);
   color: var(--color-on-primary);
   font-weight: var(--font-weight-bold);
-}
-
-.tag:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-  outline-offset: 2px;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .tag {
-    transition: none;
-  }
 }

--- a/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
-import RecipeTagFilter from './RecipeTagFilter'
 import type { Tag } from '../../types/recipe'
+import RecipeTagFilter from './RecipeTagFilter'
 
 const mockTags: Tag[] = [
   { tag: 'Italian', count: 5 },

--- a/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import RecipeTagFilter from './RecipeTagFilter'
+import type { Tag } from '../../types/recipe'
+
+const mockTags: Tag[] = [
+  { tag: 'Italian', count: 5 },
+  { tag: 'Quick', count: 3 },
+  { tag: 'Vegetarian', count: 8 },
+]
+
+describe('RecipeTagFilter', () => {
+  it('renders tag buttons with counts', () => {
+    render(
+      <RecipeTagFilter tags={mockTags} activeTag={null} onTagClick={vi.fn()} />
+    )
+
+    expect(screen.getByRole('button', { name: /Italian/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Quick/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Vegetarian/i })).toBeInTheDocument()
+
+    expect(screen.getByText(/5/)).toBeInTheDocument()
+    expect(screen.getByText(/3/)).toBeInTheDocument()
+    expect(screen.getByText(/8/)).toBeInTheDocument()
+  })
+
+  it('active tag has aria-pressed="true"', () => {
+    render(
+      <RecipeTagFilter tags={mockTags} activeTag="Italian" onTagClick={vi.fn()} />
+    )
+
+    expect(screen.getByRole('button', { name: /Italian/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('inactive tag has aria-pressed="false"', () => {
+    render(
+      <RecipeTagFilter tags={mockTags} activeTag="Italian" onTagClick={vi.fn()} />
+    )
+
+    expect(screen.getByRole('button', { name: /Quick/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+    expect(screen.getByRole('button', { name: /Vegetarian/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+  })
+})

--- a/src/components/RecipeTagFilter/RecipeTagFilter.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.tsx
@@ -1,4 +1,6 @@
+import type { FC } from 'react'
 import type { Tag } from '../../types/recipe'
+import styles from './RecipeTagFilter.module.css'
 
 export interface RecipeTagFilterProps {
   tags: Tag[]
@@ -6,8 +8,22 @@ export interface RecipeTagFilterProps {
   onTagClick: (tag: string) => void
 }
 
-const RecipeTagFilter = (_props: RecipeTagFilterProps) => {
-  return null
+const RecipeTagFilter: FC<RecipeTagFilterProps> = ({ tags, activeTag, onTagClick }) => {
+  return (
+    <div className={styles.wrapper}>
+      {tags.map(({ tag, count }) => (
+        <button
+          key={tag}
+          type="button"
+          className={styles.tag}
+          aria-pressed={activeTag === tag ? 'true' : 'false'}
+          onClick={() => onTagClick(tag)}
+        >
+          {tag} ({count})
+        </button>
+      ))}
+    </div>
+  )
 }
 
 export default RecipeTagFilter

--- a/src/components/RecipeTagFilter/RecipeTagFilter.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.tsx
@@ -1,3 +1,4 @@
+import Button from '@components/Button'
 import type { FC } from 'react'
 import type { Tag } from '../../types/recipe'
 import styles from './RecipeTagFilter.module.css'
@@ -12,15 +13,15 @@ const RecipeTagFilter: FC<RecipeTagFilterProps> = ({ tags, activeTag, onTagClick
   return (
     <div className={styles.wrapper}>
       {tags.map(({ tag, count }) => (
-        <button
+        <Button
           key={tag}
-          type="button"
+          variant="secondary"
           className={styles.tag}
-          aria-pressed={activeTag === tag ? 'true' : 'false'}
+          ariaPressed={activeTag === tag ? 'true' : 'false'}
           onClick={() => onTagClick(tag)}
         >
           {tag} ({count})
-        </button>
+        </Button>
       ))}
     </div>
   )

--- a/src/components/RecipeTagFilter/RecipeTagFilter.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.tsx
@@ -1,0 +1,13 @@
+import type { Tag } from '../../types/recipe'
+
+export interface RecipeTagFilterProps {
+  tags: Tag[]
+  activeTag: string | null
+  onTagClick: (tag: string) => void
+}
+
+const RecipeTagFilter = (_props: RecipeTagFilterProps) => {
+  return null
+}
+
+export default RecipeTagFilter

--- a/src/components/RecipeTagFilter/index.ts
+++ b/src/components/RecipeTagFilter/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RecipeTagFilter'
+export type { RecipeTagFilterProps } from './RecipeTagFilter'

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -1,0 +1,110 @@
+.heading {
+  margin-block-end: var(--space-2);
+}
+
+.intro {
+  margin-block-end: var(--space-8);
+}
+
+.grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-6);
+}
+
+@media (min-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.gridItem {
+  list-style: none;
+}
+
+.skeleton {
+  aspect-ratio: 3 / 4;
+  background: var(--color-surface-alt);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}
+
+.empty {
+  text-align: center;
+  padding: var(--space-12) 0;
+}
+
+.retryButton {
+  margin-block-start: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-on-primary);
+  background: var(--color-primary);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  cursor: pointer;
+}
+
+.retryButton:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.clearButton {
+  display: inline-block;
+  margin-block-start: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  color: var(--color-link);
+  font-weight: var(--font-weight-semibold);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.clearButton:hover {
+  color: var(--color-link-hover);
+}
+
+.clearButton:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -60,43 +60,6 @@
   padding: var(--space-12) 0;
 }
 
-.retryButton {
-  margin-block-start: var(--space-4);
-  padding: var(--space-2) var(--space-4);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-on-primary);
-  background: var(--color-primary);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-none);
-  cursor: pointer;
-}
-
-.retryButton:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-  outline-offset: 2px;
-}
-
-.clearButton {
-  display: inline-block;
-  margin-block-start: var(--space-4);
-  padding: var(--space-2) var(--space-4);
-  color: var(--color-link);
-  font-weight: var(--font-weight-semibold);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-.clearButton:hover {
-  color: var(--color-link-hover);
-}
-
-.clearButton:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-  outline-offset: 2px;
-}
-
 .srOnly {
   position: absolute;
   width: 1px;

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -33,7 +33,7 @@
 
 .skeleton {
   aspect-ratio: 3 / 4;
-  background: var(--color-surface-alt);
+  background: var(--color-bg-subtle);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-none);
   animation: pulse 1.5s ease-in-out infinite;

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Recipes from './Recipes'
+import type { RecipeIndex, Tag } from '../../types/recipe'
+
+vi.mock('../../api/recipes', () => ({
+  fetchRecipes: vi.fn(),
+  fetchTags: vi.fn(),
+}))
+
+import { fetchRecipes, fetchTags } from '../../api/recipes'
+
+const mockRecipes: RecipeIndex[] = [
+  {
+    id: 'rec-001',
+    title: 'Classic Margherita Pizza',
+    slug: 'classic-margherita-pizza',
+    coverImage: { key: 'recipes/rec-001/cover', alt: 'Margherita pizza' },
+    tags: ['Italian', 'Quick'],
+    prepTime: 15,
+    cookTime: 12,
+    servings: 4,
+    createdAt: '2026-03-20T10:00:00Z',
+  },
+  {
+    id: 'rec-002',
+    title: 'Thai Green Curry',
+    slug: 'thai-green-curry',
+    coverImage: { key: 'recipes/rec-002/cover', alt: 'Thai green curry' },
+    tags: ['Thai', 'Spicy'],
+    prepTime: 20,
+    cookTime: 25,
+    servings: 2,
+    createdAt: '2026-03-18T10:00:00Z',
+  },
+  {
+    id: 'rec-003',
+    title: 'Italian Pasta Carbonara',
+    slug: 'italian-pasta-carbonara',
+    coverImage: { key: 'recipes/rec-003/cover', alt: 'Pasta carbonara' },
+    tags: ['Italian'],
+    prepTime: 10,
+    cookTime: 15,
+    servings: 3,
+    createdAt: '2026-03-15T10:00:00Z',
+  },
+]
+
+const mockTags: Tag[] = [
+  { tag: 'Italian', count: 2 },
+  { tag: 'Quick', count: 1 },
+  { tag: 'Thai', count: 1 },
+  { tag: 'Spicy', count: 1 },
+]
+
+const renderRecipes = (initialRoute = '/recipes') =>
+  render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <Recipes />
+    </MemoryRouter>
+  )
+
+describe('Recipes page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(fetchRecipes).mockResolvedValue(mockRecipes)
+    vi.mocked(fetchTags).mockResolvedValue(mockTags)
+  })
+
+  it('renders recipe grid after loading', async () => {
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Thai Green Curry')).toBeInTheDocument()
+    expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
+  })
+
+  it('shows skeleton placeholders while loading', () => {
+    vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
+    vi.mocked(fetchTags).mockReturnValue(new Promise(() => {}))
+
+    renderRecipes()
+
+    const skeletons = screen.getAllByRole('status', { name: /loading/i })
+    expect(skeletons.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('filters by tag via URL search param (?tag=Italian)', async () => {
+    renderRecipes('/recipes?tag=Italian')
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
+    expect(screen.queryByText('Thai Green Curry')).not.toBeInTheDocument()
+  })
+
+  it('searches by keyword (title match)', async () => {
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(searchInput, { target: { value: 'curry' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('Thai Green Curry')).toBeInTheDocument()
+      expect(screen.queryByText('Classic Margherita Pizza')).not.toBeInTheDocument()
+    })
+  })
+
+  it('applies combined tag + search filtering', async () => {
+    renderRecipes('/recipes?tag=Italian')
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(searchInput, { target: { value: 'carbonara' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
+      expect(screen.queryByText('Classic Margherita Pizza')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows "No recipes found" with clear button when filter has no matches', async () => {
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(searchInput, { target: { value: 'nonexistent dish xyz' } })
+
+    await waitFor(() => {
+      expect(screen.getByText(/no recipes found/i)).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
+  })
+
+  it('shows "Recipes coming soon" when no recipes exist', async () => {
+    vi.mocked(fetchRecipes).mockResolvedValue([])
+    vi.mocked(fetchTags).mockResolvedValue([])
+
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText(/recipes coming soon/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error state with retry button when API fails', async () => {
+    vi.mocked(fetchRecipes).mockRejectedValue(new Error('500 Internal Server Error'))
+    vi.mocked(fetchTags).mockRejectedValue(new Error('500 Internal Server Error'))
+
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+  })
+
+  it('has aria-live region for recipe count', async () => {
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    const liveRegion = screen.getByRole('status')
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite')
+  })
+})

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -1,15 +1,14 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import Recipes from './Recipes'
-import type { RecipeIndex, Tag } from '../../types/recipe'
-
 vi.mock('../../api/recipes', () => ({
   fetchRecipes: vi.fn(),
   fetchTags: vi.fn(),
 }))
 
 import { fetchRecipes, fetchTags } from '../../api/recipes'
+import type { RecipeIndex, Tag } from '../../types/recipe'
+import Recipes from './Recipes'
 
 const mockRecipes: RecipeIndex[] = [
   {

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,5 +1,5 @@
 import Typography from '@components/Typography'
-import { useState, useEffect, useCallback, type FC } from 'react'
+import { useState, useEffect, useCallback, useMemo, type FC } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { fetchRecipes, fetchTags } from '../../api/recipes'
 import RecipeCard from '../../components/RecipeCard'
@@ -53,13 +53,17 @@ const Recipes: FC = () => {
     setSearchQuery('')
   }
 
-  const filteredRecipes = recipes.filter((recipe) => {
-    const matchesTag = !activeTag || recipe.tags.includes(activeTag)
-    const matchesSearch =
-      !searchQuery ||
-      recipe.title.toLowerCase().includes(searchQuery.toLowerCase())
-    return matchesTag && matchesSearch
-  })
+  const filteredRecipes = useMemo(
+    () =>
+      recipes.filter((recipe) => {
+        const matchesTag = !activeTag || recipe.tags.includes(activeTag)
+        const matchesSearch =
+          !searchQuery ||
+          recipe.title.toLowerCase().includes(searchQuery.toLowerCase())
+        return matchesTag && matchesSearch
+      }),
+    [recipes, activeTag, searchQuery],
+  )
 
   if (loading) {
     return (

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,3 +1,5 @@
-const Recipes = () => <div>Recipes page</div>
+const Recipes = () => {
+  return null
+}
 
 export default Recipes

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,5 +1,153 @@
-const Recipes = () => {
-  return null
+import Typography from '@components/Typography'
+import { useState, useEffect, useCallback, type FC } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { fetchRecipes, fetchTags } from '../../api/recipes'
+import RecipeCard from '../../components/RecipeCard'
+import RecipeSearch from '../../components/RecipeSearch'
+import RecipeTagFilter from '../../components/RecipeTagFilter'
+import type { RecipeIndex, Tag } from '../../types/recipe'
+import styles from './Recipes.module.css'
+
+const Recipes: FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const activeTag = searchParams.get('tag')
+
+  const [recipes, setRecipes] = useState<RecipeIndex[]>([])
+  const [tags, setTags] = useState<Tag[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const loadData = useCallback(async () => {
+    setLoading(true)
+    setError(false)
+    try {
+      const [recipesData, tagsData] = await Promise.all([fetchRecipes(), fetchTags()])
+      setRecipes(recipesData)
+      setTags(tagsData)
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  const handleTagClick = (tag: string) => {
+    if (activeTag === tag) {
+      setSearchParams({})
+    } else {
+      setSearchParams({ tag })
+    }
+  }
+
+  const handleSearch = useCallback((query: string) => {
+    setSearchQuery(query)
+  }, [])
+
+  const handleClearFilters = () => {
+    setSearchParams({})
+    setSearchQuery('')
+  }
+
+  const filteredRecipes = recipes.filter((recipe) => {
+    const matchesTag = !activeTag || recipe.tags.includes(activeTag)
+    const matchesSearch =
+      !searchQuery ||
+      recipe.title.toLowerCase().includes(searchQuery.toLowerCase())
+    return matchesTag && matchesSearch
+  })
+
+  if (loading) {
+    return (
+      <>
+        <Typography variant="heading1" className={styles.heading}>
+          Recipes
+        </Typography>
+        <div className={styles.grid}>
+          {Array.from({ length: 6 }, (_, i) => (
+            <div
+              key={i}
+              className={styles.skeleton}
+              role="status"
+              aria-label="Loading"
+            />
+          ))}
+        </div>
+      </>
+    )
+  }
+
+  if (error) {
+    return (
+      <>
+        <Typography variant="heading1" className={styles.heading}>
+          Recipes
+        </Typography>
+        <div className={styles.empty}>
+          <Typography variant="bodyLarge">
+            Something went wrong loading recipes.
+          </Typography>
+          <button type="button" onClick={loadData} className={styles.retryButton}>
+            Retry
+          </button>
+        </div>
+      </>
+    )
+  }
+
+  if (recipes.length === 0) {
+    return (
+      <>
+        <Typography variant="heading1" className={styles.heading}>
+          Recipes
+        </Typography>
+        <Typography variant="bodyLarge">Recipes coming soon</Typography>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Typography variant="heading1" className={styles.heading}>
+        Recipes
+      </Typography>
+      <Typography variant="bodyLarge" className={styles.intro}>
+        A collection of tried-and-tested recipes from my kitchen.
+      </Typography>
+
+      <RecipeSearch onSearch={handleSearch} />
+      <RecipeTagFilter tags={tags} activeTag={activeTag} onTagClick={handleTagClick} />
+
+      <div role="status" aria-live="polite" className={styles.srOnly}>
+        {filteredRecipes.length} {filteredRecipes.length === 1 ? 'recipe' : 'recipes'} found
+      </div>
+
+      {filteredRecipes.length === 0 ? (
+        <div className={styles.empty}>
+          <Typography variant="bodyLarge">No recipes found</Typography>
+          <button
+            type="button"
+            onClick={handleClearFilters}
+            className={styles.clearButton}
+          >
+            Clear filter
+          </button>
+        </div>
+      ) : (
+        <ul className={styles.grid}>
+          {filteredRecipes.map((recipe) => (
+            <li key={recipe.id} className={styles.gridItem}>
+              <RecipeCard recipe={recipe} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  )
 }
 
 export default Recipes

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,3 +1,4 @@
+import Button from '@components/Button'
 import Typography from '@components/Typography'
 import { useState, useEffect, useCallback, useMemo, type FC } from 'react'
 import { useSearchParams } from 'react-router-dom'
@@ -95,9 +96,9 @@ const Recipes: FC = () => {
           <Typography variant="bodyLarge">
             Something went wrong loading recipes.
           </Typography>
-          <button type="button" onClick={loadData} className={styles.retryButton}>
+          <Button variant="secondary" onClick={loadData}>
             Retry
-          </button>
+          </Button>
         </div>
       </>
     )
@@ -133,13 +134,9 @@ const Recipes: FC = () => {
       {filteredRecipes.length === 0 ? (
         <div className={styles.empty}>
           <Typography variant="bodyLarge">No recipes found</Typography>
-          <button
-            type="button"
-            onClick={handleClearFilters}
-            className={styles.clearButton}
-          >
+          <Button variant="secondary" onClick={handleClearFilters}>
             Clear filter
-          </button>
+          </Button>
         </div>
       ) : (
         <ul className={styles.grid}>


### PR DESCRIPTION
Closes #110

## What changed
- **RecipeCard**: Cover thumbnail, title link, tags, prep/cook/servings metadata. Neo-brutalist styling with shadow hover.
- **RecipeSearch**: Debounced search input (300ms) with aria-label.
- **RecipeTagFilter**: Tag buttons with aria-pressed toggle and counts.
- **Recipes page**: Fetches recipe index + tags on mount, tag filtering via URL search params, keyword search by title, combined filtering, responsive grid (1/2/3 col), skeleton loading, error/empty states, aria-live count announcements.

## Why
Public recipe listing page for visitors to browse, search, and filter recipes by tag.

## How to verify
- `pnpm test` — 296/296 tests pass
- `pnpm lint` — clean
- Visit `/recipes` in dev mode

## Decisions made
- Search filters by title only (ingredient search deferred — lightweight response doesn't include ingredients)
- Skeleton shows 6 placeholder cards
- Tag filter uses URL search params for shareable filtered URLs
- Simplify fixes: corrected undefined design tokens, added prefers-reduced-motion to tag filter, memoised filtering
- Agents: **test-engineer** (Write) + **react-engineer**