### PR TITLE
Manual QA and refinements

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE=

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-VITE_API_BASE=
+VITE_API_BASE=/api

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -1,6 +1,6 @@
 import type { RecipeIndex, Recipe, Tag } from '../types/recipe'
 
-const API_BASE = 'https://api.akli.dev'
+const API_BASE = import.meta.env.VITE_API_BASE ?? 'https://api.akli.dev'
 
 export const fetchRecipes = async (): Promise<RecipeIndex[]> => {
   const response = await fetch(`${API_BASE}/recipes`)

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -3,10 +3,11 @@
   width: 1.5em;
   height: 1.5em;
   vertical-align: middle;
-  border: var(--border-width-thick) solid var(--color-border);
+  border: var(--border-width-thick) solid transparent;
   border-block-start-color: var(--color-text);
+  border-inline-end-color: var(--color-text);
   border-radius: var(--radius-none);
-  animation: spin 0.8s steps(4) infinite;
+  animation: spin 0.8s linear infinite;
 }
 
 @keyframes spin {
@@ -17,16 +18,9 @@
 
 @media (prefers-reduced-motion: reduce) {
   .spinner {
-    animation: pulse 1.5s ease-in-out infinite;
-  }
-
-  @keyframes pulse {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.3;
-    }
+    animation: none;
+    border-color: var(--color-border);
+    border-block-start-color: var(--color-text);
+    border-inline-end-color: var(--color-text);
   }
 }

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -7,7 +7,7 @@
   border: var(--border-width-thick) solid var(--color-border-subtle);
   border-block-start-color: var(--color-primary);
   border-inline-end-color: var(--color-primary);
-  animation: spin 0.8s steps(8) infinite;
+  animation: spin 0.8s linear infinite;
 }
 
 @keyframes spin {

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -1,10 +1,32 @@
 .spinner {
   display: inline-block;
-  width: 1em;
-  height: 1em;
+  width: 1.5em;
+  height: 1.5em;
   vertical-align: middle;
-  animation: spin 1s linear infinite;
-  border-radius: var(--radius-full);
-  border: var(--border-width-thick) solid var(--color-border-subtle);
-  border-block-start-color: var(--color-primary);
+  border: var(--border-width-thick) solid var(--color-border);
+  border-block-start-color: var(--color-text);
+  border-radius: var(--radius-none);
+  animation: spin 0.8s steps(4) infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.3;
+    }
+  }
 }

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -1,26 +1,10 @@
 .spinner {
   display: inline-block;
-  width: 1.5em;
-  height: 1.5em;
+  width: 1em;
+  height: 1em;
   vertical-align: middle;
-  border: var(--border-width-thick) solid transparent;
-  border-block-start-color: var(--color-text);
-  border-inline-end-color: var(--color-text);
-  border-radius: var(--radius-none);
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .spinner {
-    animation: none;
-    border-color: var(--color-border);
-    border-block-start-color: var(--color-text);
-    border-inline-end-color: var(--color-text);
-  }
+  animation: spin 1s linear infinite;
+  border-radius: var(--radius-full);
+  border: var(--border-width-thick) solid var(--color-border-subtle);
+  border-block-start-color: var(--color-primary);
 }

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -3,8 +3,32 @@
   width: 1em;
   height: 1em;
   vertical-align: middle;
-  animation: spin 1s linear infinite;
-  border-radius: var(--radius-full);
+  border-radius: var(--radius-none);
   border: var(--border-width-thick) solid var(--color-border-subtle);
   border-block-start-color: var(--color-primary);
+  border-inline-end-color: var(--color-primary);
+  animation: spin 0.8s steps(8) infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+
+    50% {
+      opacity: 0.4;
+    }
+  }
 }

--- a/src/components/RecipeCard/RecipeCard.module.css
+++ b/src/components/RecipeCard/RecipeCard.module.css
@@ -34,6 +34,10 @@
   border-bottom: var(--border-width) solid var(--color-border);
 }
 
+.imageWrapper > figure > div {
+  border: none;
+}
+
 .image {
   width: 100%;
   height: 100%;

--- a/src/components/RecipeCard/RecipeCard.module.css
+++ b/src/components/RecipeCard/RecipeCard.module.css
@@ -92,9 +92,11 @@
 .meta {
   display: flex;
   align-items: center;
+  flex-wrap: nowrap;
   gap: var(--space-2);
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
+  white-space: nowrap;
   margin-block-start: auto;
 }
 

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -2,7 +2,7 @@ import Image from '@components/Image'
 import Typography from '@components/Typography'
 import type { FC } from 'react'
 import { Link } from 'react-router-dom'
-import type { RecipeIndex } from '../../types/recipe'
+import { RECIPE_IMAGE_BASE, type RecipeIndex } from '../../types/recipe'
 import styles from './RecipeCard.module.css'
 
 export interface RecipeCardProps {
@@ -12,10 +12,9 @@ export interface RecipeCardProps {
   hideMeta?: boolean
 }
 
-const IMAGE_BASE = 'https://akli.dev/images'
 
 const RecipeCard: FC<RecipeCardProps> = ({ recipe, eager = false, hideTags = false, hideMeta = false }) => {
-  const thumbnailSrc = `${IMAGE_BASE}/${recipe.coverImage.key}-thumb.webp`
+  const thumbnailSrc = `${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-thumb.webp`
 
   return (
     <article className={styles.card}>

--- a/src/components/RecipeSearch/RecipeSearch.test.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.test.tsx
@@ -12,7 +12,7 @@ describe('RecipeSearch', () => {
   })
 
   it('renders a search input with aria-label', () => {
-    render(<RecipeSearch onSearch={vi.fn()} />)
+    render(<RecipeSearch value="" onSearch={vi.fn()} />)
 
     const input = screen.getByRole('searchbox', { name: /search recipes/i })
     expect(input).toBeInTheDocument()
@@ -20,7 +20,7 @@ describe('RecipeSearch', () => {
 
   it('calls onSearch callback after 300ms debounce', () => {
     const onSearch = vi.fn()
-    render(<RecipeSearch onSearch={onSearch} />)
+    render(<RecipeSearch value="" onSearch={onSearch} />)
 
     const input = screen.getByRole('searchbox', { name: /search recipes/i })
     fireEvent.change(input, { target: { value: 'pizza' } })
@@ -35,7 +35,7 @@ describe('RecipeSearch', () => {
 
   it('does not call onSearch before debounce period', () => {
     const onSearch = vi.fn()
-    render(<RecipeSearch onSearch={onSearch} />)
+    render(<RecipeSearch value="" onSearch={onSearch} />)
 
     const input = screen.getByRole('searchbox', { name: /search recipes/i })
     fireEvent.change(input, { target: { value: 'pasta' } })

--- a/src/components/RecipeSearch/RecipeSearch.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.tsx
@@ -2,11 +2,16 @@ import { useState, useEffect, type FC } from 'react'
 import styles from './RecipeSearch.module.css'
 
 export interface RecipeSearchProps {
+  value: string
   onSearch: (query: string) => void
 }
 
-const RecipeSearch: FC<RecipeSearchProps> = ({ onSearch }) => {
-  const [value, setValue] = useState('')
+const RecipeSearch: FC<RecipeSearchProps> = ({ value: controlledValue, onSearch }) => {
+  const [value, setValue] = useState(controlledValue)
+
+  useEffect(() => {
+    setValue(controlledValue)
+  }, [controlledValue])
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/src/components/RecipeSteps/RecipeSteps.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.tsx
@@ -1,14 +1,13 @@
 import Image from '@components/Image'
 import Typography from '@components/Typography'
 import type { FC } from 'react'
-import type { Step } from '../../types/recipe'
+import { RECIPE_IMAGE_BASE, type Step } from '../../types/recipe'
 import styles from './RecipeSteps.module.css'
 
 export interface RecipeStepsProps {
   steps: Step[]
 }
 
-const IMAGE_BASE = 'https://akli.dev/images'
 
 const RecipeSteps: FC<RecipeStepsProps> = ({ steps }) => (
   <ol className={styles.list}>
@@ -17,7 +16,7 @@ const RecipeSteps: FC<RecipeStepsProps> = ({ steps }) => (
         <Typography variant="body" className={styles.text}>{step.text}</Typography>
         {step.image && (
           <Image
-            src={`${IMAGE_BASE}/${step.image.key}-medium.webp`}
+            src={`${RECIPE_IMAGE_BASE}/${step.image.key}-medium.webp`}
             alt={step.image.alt}
             className={styles.image}
           />

--- a/src/components/RecipesCta/RecipesCta.module.css
+++ b/src/components/RecipesCta/RecipesCta.module.css
@@ -36,6 +36,6 @@
   }
 }
 
-.link {
-  display: inline-block;
+.body {
+  margin-block-start: var(--space-8);
 }

--- a/src/components/RecipesCta/RecipesCta.module.css
+++ b/src/components/RecipesCta/RecipesCta.module.css
@@ -60,21 +60,6 @@
   }
 }
 
-.tags {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: var(--space-2);
-  margin-block-end: var(--space-6);
-}
-
-.tag {
-  padding: var(--space-1) var(--space-3);
-  border: var(--border-width) solid var(--color-border-subtle);
-  border-radius: var(--radius-none);
-  font-size: var(--text-sm);
-}
-
 .link {
   display: inline-block;
 }

--- a/src/components/RecipesCta/RecipesCta.module.css
+++ b/src/components/RecipesCta/RecipesCta.module.css
@@ -36,30 +36,6 @@
   }
 }
 
-.skeleton {
-  block-size: 16rem;
-  background: var(--color-bg-subtle);
-  border: var(--border-width) solid var(--color-border-subtle);
-  border-radius: var(--radius-none);
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .skeleton {
-    animation: none;
-  }
-}
-
 .link {
   display: inline-block;
 }

--- a/src/components/RecipesCta/RecipesCta.test.tsx
+++ b/src/components/RecipesCta/RecipesCta.test.tsx
@@ -127,6 +127,6 @@ describe('RecipesCta', () => {
     })
 
     expect(screen.getByRole('heading', { name: /from the kitchen/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /recipes/i })).toHaveAttribute('href', '/recipes')
+    expect(screen.getByRole('link', { name: /kitchen/i })).toHaveAttribute('href', '/recipes')
   })
 })

--- a/src/components/RecipesCta/RecipesCta.test.tsx
+++ b/src/components/RecipesCta/RecipesCta.test.tsx
@@ -111,13 +111,12 @@ describe('RecipesCta', () => {
     expect(screen.queryByText(/from the kitchen/i)).not.toBeInTheDocument()
   })
 
-  it('shows skeleton placeholders while loading', () => {
+  it('renders nothing while loading', () => {
     vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
 
     renderRecipesCta()
 
-    const skeletons = screen.getAllByRole('status', { name: /loading/i })
-    expect(skeletons.length).toBeGreaterThanOrEqual(1)
+    expect(screen.queryByRole('heading', { name: /from the kitchen/i })).not.toBeInTheDocument()
   })
 
   it('includes a heading and link to /recipes', async () => {

--- a/src/components/RecipesCta/RecipesCta.test.tsx
+++ b/src/components/RecipesCta/RecipesCta.test.tsx
@@ -95,7 +95,7 @@ describe('RecipesCta', () => {
     })
 
     expect(container.querySelector('section')).not.toBeInTheDocument()
-    expect(screen.queryByText(/from the kitchen/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/favourite recipes/i)).not.toBeInTheDocument()
   })
 
   it('does not render the section when the API fails', async () => {
@@ -108,7 +108,7 @@ describe('RecipesCta', () => {
     })
 
     expect(container.querySelector('section')).not.toBeInTheDocument()
-    expect(screen.queryByText(/from the kitchen/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/favourite recipes/i)).not.toBeInTheDocument()
   })
 
   it('renders nothing while loading', () => {
@@ -116,7 +116,7 @@ describe('RecipesCta', () => {
 
     renderRecipesCta()
 
-    expect(screen.queryByRole('heading', { name: /from the kitchen/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /favourite recipes/i })).not.toBeInTheDocument()
   })
 
   it('includes a heading and link to /recipes', async () => {
@@ -126,7 +126,7 @@ describe('RecipesCta', () => {
       expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('heading', { name: /from the kitchen/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /kitchen/i })).toHaveAttribute('href', '/recipes')
+    expect(screen.getByRole('heading', { name: /favourite recipes/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /recipes/i })).toHaveAttribute('href', '/recipes')
   })
 })

--- a/src/components/RecipesCta/RecipesCta.test.tsx
+++ b/src/components/RecipesCta/RecipesCta.test.tsx
@@ -59,7 +59,7 @@ describe('RecipesCta', () => {
     vi.mocked(fetchRecipes).mockResolvedValue(mockRecipes)
   })
 
-  it('renders up to 3 latest recipe cards with cover image, title, and tags', async () => {
+  it('renders up to 3 latest recipe cards with cover image and title', async () => {
     renderRecipesCta()
 
     await waitFor(() => {
@@ -71,11 +71,6 @@ describe('RecipesCta', () => {
     expect(screen.getByRole('img', { name: 'Margherita pizza' })).toBeInTheDocument()
     expect(screen.getByRole('img', { name: 'Thai green curry' })).toBeInTheDocument()
     expect(screen.getByRole('img', { name: 'Pasta carbonara' })).toBeInTheDocument()
-
-    expect(screen.getByText('Italian')).toBeInTheDocument()
-    expect(screen.getByText('Quick')).toBeInTheDocument()
-    expect(screen.getByText('Thai')).toBeInTheDocument()
-    expect(screen.getByText('Spicy')).toBeInTheDocument()
   })
 
   it('shows available cards when fewer than 3 recipes exist', async () => {

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -46,9 +46,13 @@ const RecipesCta: FC = () => {
             <RecipeCard key={recipe.id} recipe={recipe} eager hideTags hideMeta />
           ))}
         </Grid>
-        <Link to="/recipes" className={styles.link}>
-          View all recipes
-        </Link>
+        <Typography variant="bodyLarge" className={styles.body}>
+          Browse all recipes in the{' '}
+          <Link to="/recipes" underline={true}>
+            kitchen
+          </Link>
+          .
+        </Typography>
       </div>
     </section>
   )

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -39,7 +39,7 @@ const RecipesCta: FC = () => {
     <section className={styles.section} aria-labelledby="recipes-section-title">
       <div className={styles.inner}>
         <Typography variant="heading2" id="recipes-section-title" className={styles.heading}>
-          From the Kitchen
+          Favourite Recipes
         </Typography>
         <Grid columns={3}>
           {recipes.map((recipe) => (
@@ -47,9 +47,9 @@ const RecipesCta: FC = () => {
           ))}
         </Grid>
         <Typography variant="bodyLarge" className={styles.body}>
-          Browse all recipes in the{' '}
+          A collection of my favourite recipes. Browse all{' '}
           <Link to="/recipes" underline={true}>
-            kitchen
+            recipes
           </Link>
           .
         </Typography>

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -2,7 +2,7 @@ import Grid from '@components/Grid'
 import Link from '@components/Link'
 import RecipeCard from '@components/RecipeCard'
 import Typography from '@components/Typography'
-import { FC, useEffect, useMemo, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { fetchRecipes } from '../../api/recipes'
 import type { RecipeIndex } from '../../types/recipe'
 import styles from './RecipesCta.module.css'
@@ -30,11 +30,6 @@ const RecipesCta: FC = () => {
         setStatus('error')
       })
   }, [])
-
-  const uniqueTags = useMemo(
-    () => [...new Set(recipes.flatMap((r) => r.tags))],
-    [recipes]
-  )
 
   if (status === 'empty' || status === 'error') {
     return null
@@ -73,13 +68,6 @@ const RecipesCta: FC = () => {
             <RecipeCard key={recipe.id} recipe={recipe} eager hideTags hideMeta />
           ))}
         </Grid>
-        <div className={styles.tags}>
-          {uniqueTags.map((tag) => (
-            <span key={tag} className={styles.tag}>
-              {tag}
-            </span>
-          ))}
-        </div>
         <Link to="/recipes" className={styles.link}>
           View all recipes
         </Link>

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -31,30 +31,8 @@ const RecipesCta: FC = () => {
       })
   }, [])
 
-  if (status === 'empty' || status === 'error') {
+  if (status !== 'loaded') {
     return null
-  }
-
-  if (status === 'loading') {
-    return (
-      <section className={styles.section} aria-labelledby="recipes-section-title">
-        <div className={styles.inner}>
-          <Typography variant="heading2" id="recipes-section-title" className={styles.heading}>
-            From the Kitchen
-          </Typography>
-          <div className={styles.grid}>
-            {Array.from({ length: MAX_RECIPES }, (_, i) => (
-              <div
-                key={i}
-                role="status"
-                aria-label="Loading recipe"
-                className={styles.skeleton}
-              />
-            ))}
-          </div>
-        </div>
-      </section>
-    )
   }
 
   return (

--- a/src/pages/RecipeDetail/RecipeDetail.module.css
+++ b/src/pages/RecipeDetail/RecipeDetail.module.css
@@ -4,6 +4,10 @@
   padding: var(--space-6) var(--space-4);
 }
 
+.coverImageWrapper {
+  margin-block-end: var(--space-10);
+}
+
 .coverImage {
   display: block;
   width: 100%;
@@ -12,7 +16,7 @@
   object-fit: cover;
   border-radius: var(--radius-none);
   border: var(--border-width) solid var(--color-border);
-  margin-block-end: var(--space-6);
+  margin-block-end: var(--space-10);
 }
 
 .title {
@@ -76,6 +80,10 @@
   font-size: var(--font-size-lg);
   line-height: var(--line-height-relaxed);
   margin-block-end: var(--space-8);
+}
+
+.section {
+  margin-block-end: var(--space-10);
 }
 
 .sectionHeading {

--- a/src/pages/RecipeDetail/RecipeDetail.module.css
+++ b/src/pages/RecipeDetail/RecipeDetail.module.css
@@ -26,27 +26,6 @@
   margin: 0 0 var(--space-3);
 }
 
-.meta {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-  margin-block-end: var(--space-3);
-}
-
-.metaBar {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-  margin-block-end: var(--space-4);
-}
-
-.separator {
-  font-weight: var(--font-weight-bold);
-}
 
 .tags {
   display: flex;

--- a/src/pages/RecipeDetail/RecipeDetail.test.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.test.tsx
@@ -67,8 +67,7 @@ describe('RecipeDetail page', () => {
       screen.getByRole('heading', { level: 1, name: 'Test Recipe' })
     ).toBeInTheDocument()
 
-    // Author and date
-    expect(screen.getByText(/Akli/)).toBeInTheDocument()
+    // Date and metadata
     expect(screen.getByText(/10 April 2026/i)).toBeInTheDocument()
 
     // Ingredients

--- a/src/pages/RecipeDetail/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.tsx
@@ -121,23 +121,14 @@ const RecipeDetail: FC = () => {
         priority
         maxWidth="var(--max-w-site)"
         className={styles.coverImage}
+        containerClassName={styles.coverImageWrapper}
       />
 
       <Typography variant="heading1" className={styles.title}>{recipe.title}</Typography>
 
-      <div className={styles.meta}>
-        <span>{recipe.authorName}</span>
-        <span className={styles.separator}>·</span>
-        <time dateTime={recipe.createdAt}>{formatDate(recipe.createdAt)}</time>
-      </div>
-
-      <div className={styles.metaBar}>
-        <span>Prep: {recipe.prepTime} min</span>
-        <span className={styles.separator}>·</span>
-        <span>Cook: {recipe.cookTime} min</span>
-        <span className={styles.separator}>·</span>
-        <span>Serves: {recipe.servings}</span>
-      </div>
+      <Typography variant="body">
+        <time dateTime={recipe.createdAt}>{formatDate(recipe.createdAt)}</time> · {recipe.prepTime} min prep · {recipe.cookTime} min cook · Serves {recipe.servings}
+      </Typography>
 
       <div className={styles.tags}>
         {recipe.tags.map((tag) => (
@@ -149,12 +140,12 @@ const RecipeDetail: FC = () => {
 
       <Typography variant="bodyLarge" className={styles.intro}>{recipe.intro}</Typography>
 
-      <section>
+      <section className={styles.section}>
         <Typography variant="heading2" className={styles.sectionHeading}>Ingredients</Typography>
         <RecipeIngredients ingredients={recipe.ingredients} />
       </section>
 
-      <section>
+      <section className={styles.section}>
         <Typography variant="heading2" className={styles.sectionHeading}>Method</Typography>
         <RecipeSteps steps={recipe.steps} />
       </section>

--- a/src/pages/RecipeDetail/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.tsx
@@ -1,5 +1,6 @@
 import Button from '@components/Button'
 import Image from '@components/Image'
+import Loading from '@components/Loading'
 import Typography from '@components/Typography'
 import NotFound from '@pages/NotFound'
 import { useContext, useEffect, useState, type FC } from 'react'
@@ -8,10 +9,9 @@ import { fetchRecipe } from '../../api/recipes'
 import RecipeIngredients from '../../components/RecipeIngredients'
 import RecipeSteps from '../../components/RecipeSteps'
 import { RecipeDataContext } from '../../contexts/RecipeDataContext'
-import type { Recipe } from '../../types/recipe'
+import { RECIPE_IMAGE_BASE, type Recipe } from '../../types/recipe'
 import styles from './RecipeDetail.module.css'
 
-const IMAGE_BASE = 'https://akli.dev/images'
 
 const formatDate = (dateString: string): string => {
   const date = new Date(dateString)
@@ -72,8 +72,8 @@ const RecipeDetail: FC = () => {
 
   if (loading) {
     return (
-      <div className={styles.loading} role="status" aria-label="Loading">
-        Loading...
+      <div className={styles.loading}>
+        <Loading />
       </div>
     )
   }
@@ -115,8 +115,8 @@ const RecipeDetail: FC = () => {
   return (
     <article className={styles.page}>
       <Image
-        src={`${IMAGE_BASE}/${recipe.coverImage.key}-medium.webp`}
-        srcSet={`${IMAGE_BASE}/${recipe.coverImage.key}-medium.webp 800w, ${IMAGE_BASE}/${recipe.coverImage.key}-full.webp 1200w`}
+        src={`${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-medium.webp`}
+        srcSet={`${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-medium.webp 800w, ${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-full.webp 1200w`}
         alt={recipe.coverImage.alt}
         priority
         maxWidth="var(--max-w-site)"

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -1,3 +1,7 @@
+.page {
+  padding-block-end: var(--space-12);
+}
+
 .heading {
   margin-block-end: var(--space-2);
 }

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -6,6 +6,12 @@
   margin-block-end: var(--space-8);
 }
 
+.loadingWrapper {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-12) 0;
+}
+
 .empty {
   text-align: center;
   padding: var(--space-12) 0;

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -6,51 +6,6 @@
   margin-block-end: var(--space-8);
 }
 
-.grid {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-6);
-}
-
-@media (min-width: 640px) {
-  .grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (min-width: 1024px) {
-  .grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-.skeleton {
-  aspect-ratio: 3 / 4;
-  background: var(--color-bg-subtle);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-none);
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .skeleton {
-    animation: none;
-  }
-}
-
 .empty {
   text-align: center;
   padding: var(--space-12) 0;

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -77,16 +77,14 @@ describe('Recipes page', () => {
     expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
   })
 
-  it('shows skeleton placeholders while loading', async () => {
+  it('shows skeleton placeholders while loading', () => {
     vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
     vi.mocked(fetchTags).mockReturnValue(new Promise(() => {}))
 
     renderRecipes()
 
-    await waitFor(() => {
-      const skeletons = screen.getAllByRole('status', { name: /loading/i })
-      expect(skeletons.length).toBeGreaterThanOrEqual(1)
-    })
+    const skeletons = screen.getAllByRole('status', { name: /loading/i })
+    expect(skeletons.length).toBeGreaterThanOrEqual(1)
   })
 
   it('filters by tag via URL search param (?tag=Italian)', async () => {

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -77,14 +77,16 @@ describe('Recipes page', () => {
     expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
   })
 
-  it('shows skeleton placeholders while loading', () => {
+  it('shows skeleton placeholders while loading', async () => {
     vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
     vi.mocked(fetchTags).mockReturnValue(new Promise(() => {}))
 
     renderRecipes()
 
-    const skeletons = screen.getAllByRole('status', { name: /loading/i })
-    expect(skeletons.length).toBeGreaterThanOrEqual(1)
+    await waitFor(() => {
+      const skeletons = screen.getAllByRole('status', { name: /loading/i })
+      expect(skeletons.length).toBeGreaterThanOrEqual(1)
+    })
   })
 
   it('filters by tag via URL search param (?tag=Italian)', async () => {

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -77,14 +77,13 @@ describe('Recipes page', () => {
     expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
   })
 
-  it('shows skeleton placeholders while loading', () => {
+  it('shows loading indicator while fetching', () => {
     vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
     vi.mocked(fetchTags).mockReturnValue(new Promise(() => {}))
 
     renderRecipes()
 
-    const skeletons = screen.getAllByRole('status', { name: /loading/i })
-    expect(skeletons.length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
   })
 
   it('filters by tag via URL search param (?tag=Italian)', async () => {

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,5 +1,6 @@
 import Button from '@components/Button'
 import Grid from '@components/Grid'
+import Loading from '@components/Loading'
 import Typography from '@components/Typography'
 import { useState, useEffect, useCallback, useMemo, type FC } from 'react'
 import { useSearchParams } from 'react-router-dom'
@@ -69,16 +70,7 @@ const Recipes: FC = () => {
         <Typography variant="heading1" className={styles.heading}>
           Recipes
         </Typography>
-        <div className={styles.grid}>
-          {Array.from({ length: 6 }, (_, i) => (
-            <div
-              key={i}
-              className={styles.skeleton}
-              role="status"
-              aria-label="Loading"
-            />
-          ))}
-        </div>
+        <Loading />
       </>
     )
   }

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -23,7 +23,10 @@ const Recipes: FC = () => {
   const loadData = useCallback(async () => {
     setError(false)
     try {
-      const [recipesData, tagsData] = await Promise.all([fetchRecipes(), fetchTags()])
+      const [recipesData, tagsData] = await Promise.all([
+        fetchRecipes(),
+        fetchTags(),
+      ])
       setRecipes(recipesData)
       setTags(tagsData)
     } catch {
@@ -61,7 +64,7 @@ const Recipes: FC = () => {
           recipe.title.toLowerCase().includes(searchQuery.toLowerCase())
         return matchesTag && matchesSearch
       }),
-    [recipes, activeTag, searchQuery],
+    [recipes, activeTag, searchQuery]
   )
 
   if (recipes === null && !error) {
@@ -115,11 +118,16 @@ const Recipes: FC = () => {
         A collection of tried-and-tested recipes from my kitchen.
       </Typography>
 
-      <RecipeSearch onSearch={handleSearch} />
-      <RecipeTagFilter tags={tags} activeTag={activeTag} onTagClick={handleTagClick} />
+      <RecipeSearch value={searchQuery} onSearch={handleSearch} />
+      <RecipeTagFilter
+        tags={tags}
+        activeTag={activeTag}
+        onTagClick={handleTagClick}
+      />
 
       <div role="status" aria-live="polite" className={styles.srOnly}>
-        {filteredRecipes.length} {filteredRecipes.length === 1 ? 'recipe' : 'recipes'} found
+        {filteredRecipes.length}{' '}
+        {filteredRecipes.length === 1 ? 'recipe' : 'recipes'} found
       </div>
 
       {filteredRecipes.length === 0 ? (

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -14,16 +14,12 @@ const Recipes: FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTag = searchParams.get('tag')
 
-  const [recipes, setRecipes] = useState<RecipeIndex[]>([])
+  const [recipes, setRecipes] = useState<RecipeIndex[] | null>(null)
   const [tags, setTags] = useState<Tag[]>([])
-  const [loading, setLoading] = useState(true)
-  const [showSkeleton, setShowSkeleton] = useState(false)
   const [error, setError] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
 
   const loadData = useCallback(async () => {
-    setLoading(true)
-    setShowSkeleton(false)
     setError(false)
     try {
       const [recipesData, tagsData] = await Promise.all([fetchRecipes(), fetchTags()])
@@ -31,20 +27,12 @@ const Recipes: FC = () => {
       setTags(tagsData)
     } catch {
       setError(true)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
   useEffect(() => {
     loadData()
   }, [loadData])
-
-  useEffect(() => {
-    if (!loading) return
-    const timer = setTimeout(() => setShowSkeleton(true), 200)
-    return () => clearTimeout(timer)
-  }, [loading])
 
   const handleTagClick = (tag: string) => {
     if (activeTag === tag) {
@@ -65,7 +53,7 @@ const Recipes: FC = () => {
 
   const filteredRecipes = useMemo(
     () =>
-      recipes.filter((recipe) => {
+      (recipes ?? []).filter((recipe) => {
         const matchesTag = !activeTag || recipe.tags.includes(activeTag)
         const matchesSearch =
           !searchQuery ||
@@ -75,8 +63,7 @@ const Recipes: FC = () => {
     [recipes, activeTag, searchQuery],
   )
 
-  if (loading) {
-    if (!showSkeleton) return null
+  if (recipes === null && !error) {
     return (
       <>
         <Typography variant="heading1" className={styles.heading}>
@@ -114,7 +101,7 @@ const Recipes: FC = () => {
     )
   }
 
-  if (recipes.length === 0) {
+  if (recipes !== null && recipes.length === 0) {
     return (
       <>
         <Typography variant="heading1" className={styles.heading}>

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -70,7 +70,9 @@ const Recipes: FC = () => {
         <Typography variant="heading1" className={styles.heading}>
           Recipes
         </Typography>
-        <Loading />
+        <div className={styles.loadingWrapper}>
+          <Loading />
+        </div>
       </>
     )
   }

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -110,7 +110,7 @@ const Recipes: FC = () => {
   }
 
   return (
-    <>
+    <div className={styles.page}>
       <Typography variant="heading1" className={styles.heading}>
         Recipes
       </Typography>
@@ -144,7 +144,7 @@ const Recipes: FC = () => {
           ))}
         </Grid>
       )}
-    </>
+    </div>
   )
 }
 

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -17,11 +17,13 @@ const Recipes: FC = () => {
   const [recipes, setRecipes] = useState<RecipeIndex[]>([])
   const [tags, setTags] = useState<Tag[]>([])
   const [loading, setLoading] = useState(true)
+  const [showSkeleton, setShowSkeleton] = useState(false)
   const [error, setError] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
 
   const loadData = useCallback(async () => {
     setLoading(true)
+    setShowSkeleton(false)
     setError(false)
     try {
       const [recipesData, tagsData] = await Promise.all([fetchRecipes(), fetchTags()])
@@ -37,6 +39,12 @@ const Recipes: FC = () => {
   useEffect(() => {
     loadData()
   }, [loadData])
+
+  useEffect(() => {
+    if (!loading) return
+    const timer = setTimeout(() => setShowSkeleton(true), 200)
+    return () => clearTimeout(timer)
+  }, [loading])
 
   const handleTagClick = (tag: string) => {
     if (activeTag === tag) {
@@ -68,6 +76,7 @@ const Recipes: FC = () => {
   )
 
   if (loading) {
+    if (!showSkeleton) return null
     return (
       <>
         <Typography variant="heading1" className={styles.heading}>

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,3 +1,5 @@
+export const RECIPE_IMAGE_BASE = 'https://akli.dev/images'
+
 export interface RecipeImage {
   key: string
   alt: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -98,6 +98,14 @@ export default defineConfig(({ isSsrBuild }) => ({
       '@hooks': '/src/hooks',
     },
   },
+  server: {
+    proxy: {
+      '/recipes': {
+        target: 'https://api.akli.dev',
+        changeOrigin: true,
+      },
+    },
+  },
   ssr: {
     noExternal: true,
     external: ['node:fs', 'node:path'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -100,9 +100,10 @@ export default defineConfig(({ isSsrBuild }) => ({
   },
   server: {
     proxy: {
-      '/recipes': {
+      '/api': {
         target: 'https://api.akli.dev',
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
Closes #114

## What changed
QA refinements from manual testing:
- **Dev proxy**: Added Vite proxy for `/api` prefix to bypass CORS in local dev
- **Loading**: Replaced skeleton cards with Loading spinner on Recipes page (prevents flash), redesigned spinner for neo-brutalist design
- **RecipesCta**: Removed skeletons (renders nothing until loaded), removed non-interactive tags, updated copy ("Favourite Recipes"), matched link style with AppsCta
- **RecipeCard**: Fixed double border on images, prevented metadata text wrapping
- **RecipeSearch**: Added controlled value prop so clear filters resets input text
- **RecipeDetail**: Simplified meta line to match Blog post style, added section spacing, added cover image spacing via containerClassName
- **Recipes page**: Added bottom padding, used null initial state to prevent skeleton flash
- **Shared**: Extracted RECIPE_IMAGE_BASE constant, used Loading component in RecipeDetail

## How to verify
- `pnpm test` — 315/315 tests pass
- `pnpm lint` — clean
- `pnpm dev` then visit `/recipes`, homepage CTA, and recipe detail pages