### PR TITLE
Recipe Frontend

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE=

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-VITE_API_BASE=
+VITE_API_BASE=/api

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ To write a new PRD, copy `docs/prds/template.md` and fill it in.
 - Neo-brutalist design: use `var(--radius-none)` for border-radius — no rounded corners on any component
 - Use const arrow functions, not function declarations — enforced by ESLint (`func-style: expression`)
 - After modifying TSX files, run `pnpm exec eslint --fix` on changed files to auto-fix import order
+- Before creating new UI elements, check `src/components/` for existing reusable components (Image, Typography, Button, Card, Link, Loading, etc.). Always prefer existing components over raw HTML tags.
 - Site images (cards, hero) live in `src/assets/` — imported via Vite, get hashed filenames and responsive srcSet
 - Blog post images live in `public/images/blog/` — referenced by URL string in MDX, served as-is, no Vite processing. Optimise manually before adding.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ pnpm dev
 ```
 src/
   components/    # Reusable components (<Name>/<Name>.tsx + index.ts)
-  pages/         # Route pages (Home, Apps, Blog, NotFound)
+  pages/         # Route pages (Home, Apps, Blog, Recipes, RecipeDetail, NotFound)
+  api/           # API service layers (recipes)
+  types/         # Shared TypeScript interfaces
+  contexts/      # React contexts (RecipeDataContext for SSR)
   hooks/         # Custom hooks
   styles/        # Design tokens and animations
   assets/        # Images and static files
@@ -55,6 +58,8 @@ tests/
 - `/apps/pokedex` — Searchable Gen 1 Pokemon encyclopedia (deployed separately)
 - `/blog` — Technical blog with tag filtering
 - `/blog/:slug` — Individual blog posts (MDX with code blocks, callouts, file trees)
+- `/recipes` — Recipe listing with search and tag filtering
+- `/recipes/:slug` — Recipe detail with SSR for SEO and Open Graph
 
 ## Design
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "personal-website",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,7 +7,7 @@ vi.mock('@components/Header', () => ({
 }))
 
 vi.mock('@components/Layout', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  default: ({ children }: { children: import('react').ReactNode }) => <div>{children}</div>,
 }))
 
 vi.mock('@pages/Home', () => ({

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@components/Header', () => ({
+  default: () => <div data-testid="header-mock">Header</div>,
+}))
+
+vi.mock('@components/Layout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@pages/Home', () => ({
+  default: () => <div>Home page</div>,
+}))
+
+vi.mock('@pages/Apps', () => ({
+  default: () => <div>Apps page</div>,
+}))
+
+vi.mock('@pages/Blog', () => ({
+  default: () => <div>Blog page</div>,
+}))
+
+vi.mock('@pages/Blog/BlogPost', () => ({
+  default: () => <div>Blog post page</div>,
+}))
+
+vi.mock('@pages/NotFound', () => ({
+  default: () => <div>Not found page</div>,
+}))
+
+vi.mock('@pages/Recipes', () => ({
+  default: () => <div>Recipes page</div>,
+}))
+
+vi.mock('@pages/RecipeDetail', () => ({
+  default: () => <div>Recipe detail page</div>,
+}))
+
+import App from './App'
+
+const renderApp = (route: string) =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <App />
+    </MemoryRouter>
+  )
+
+describe('App routing', () => {
+  it('renders Recipes page at /recipes', () => {
+    renderApp('/recipes')
+    expect(screen.getByText('Recipes page')).toBeInTheDocument()
+  })
+
+  it('renders RecipeDetail page at /recipes/:slug', () => {
+    renderApp('/recipes/test-slug')
+    expect(screen.getByText('Recipe detail page')).toBeInTheDocument()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import Blog from '@pages/Blog'
 import BlogPost from '@pages/Blog/BlogPost'
 import Home from '@pages/Home'
 import NotFound from '@pages/NotFound'
+import RecipeDetail from '@pages/RecipeDetail'
+import Recipes from '@pages/Recipes'
 import { Routes, Route } from 'react-router-dom'
 
 const App = () => {
@@ -17,6 +19,8 @@ const App = () => {
           <Route path="/apps" element={<Apps />} />
           <Route path="/blog" element={<Blog />} />
           <Route path="/blog/:slug" element={<BlogPost />} />
+          <Route path="/recipes" element={<Recipes />} />
+          <Route path="/recipes/:slug" element={<RecipeDetail />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Layout>

--- a/src/api/recipes.test.ts
+++ b/src/api/recipes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchRecipes, fetchRecipe, fetchTags } from './recipes'
 import type { RecipeIndex, Recipe, Tag } from '../types/recipe'
+import { fetchRecipes, fetchRecipe, fetchTags } from './recipes'
 
 const mockRecipeIndex: RecipeIndex = {
   id: 'r1',

--- a/src/api/recipes.test.ts
+++ b/src/api/recipes.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchRecipes, fetchRecipe, fetchTags } from './recipes'
+import type { RecipeIndex, Recipe, Tag } from '../types/recipe'
+
+const mockRecipeIndex: RecipeIndex = {
+  id: 'r1',
+  title: 'Spaghetti Bolognese',
+  slug: 'spaghetti-bolognese',
+  coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+  tags: ['Italian', 'Pasta'],
+  prepTime: 15,
+  cookTime: 45,
+  servings: 4,
+  createdAt: '2026-03-01T12:00:00Z',
+}
+
+const mockRecipe: Recipe = {
+  ...mockRecipeIndex,
+  intro: 'A classic Italian pasta dish.',
+  ingredients: [
+    { item: 'spaghetti', quantity: '400', unit: 'g' },
+    { item: 'minced beef', quantity: '500', unit: 'g' },
+  ],
+  steps: [
+    { order: 1, text: 'Boil the pasta.' },
+    { order: 2, text: 'Brown the mince.', image: { key: 'step-2', alt: 'Browning mince in a pan' } },
+  ],
+  authorId: 'a1',
+  authorName: 'Akli Aissat',
+  updatedAt: '2026-03-02T10:00:00Z',
+  status: 'published',
+}
+
+const mockTags: Tag[] = [
+  { tag: 'Italian', count: 3 },
+  { tag: 'Quick', count: 5 },
+]
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('fetchRecipes', () => {
+  it('returns an array of RecipeIndex on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([mockRecipeIndex]),
+      })
+    )
+
+    const result = await fetchRecipes()
+
+    expect(result).toEqual([mockRecipeIndex])
+    expect(fetch).toHaveBeenCalledWith('https://api.akli.dev/recipes')
+  })
+
+  it('throws on HTTP 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+    )
+
+    await expect(fetchRecipes()).rejects.toThrow('404')
+  })
+
+  it('throws on HTTP 500', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      })
+    )
+
+    await expect(fetchRecipes()).rejects.toThrow('500')
+  })
+
+  it('throws on network failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    )
+
+    await expect(fetchRecipes()).rejects.toThrow('Failed to fetch')
+  })
+})
+
+describe('fetchRecipe', () => {
+  it('returns a Recipe on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockRecipe),
+      })
+    )
+
+    const result = await fetchRecipe('spaghetti-bolognese')
+
+    expect(result).toEqual(mockRecipe)
+  })
+
+  it('calls the correct URL with the slug', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockRecipe),
+      })
+    )
+
+    await fetchRecipe('spaghetti-bolognese')
+
+    expect(fetch).toHaveBeenCalledWith('https://api.akli.dev/recipes/spaghetti-bolognese')
+  })
+
+  it('throws on HTTP 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+    )
+
+    await expect(fetchRecipe('nonexistent')).rejects.toThrow('404')
+  })
+
+  it('throws on network failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    )
+
+    await expect(fetchRecipe('spaghetti-bolognese')).rejects.toThrow('Failed to fetch')
+  })
+})
+
+describe('fetchTags', () => {
+  it('returns an array of Tag on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockTags),
+      })
+    )
+
+    const result = await fetchTags()
+
+    expect(result).toEqual(mockTags)
+    expect(fetch).toHaveBeenCalledWith('https://api.akli.dev/recipes/tags')
+  })
+
+  it('throws on HTTP error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+      })
+    )
+
+    await expect(fetchTags()).rejects.toThrow('503')
+  })
+})

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -1,6 +1,6 @@
 import type { RecipeIndex, Recipe, Tag } from '../types/recipe'
 
-const API_BASE = 'https://api.akli.dev'
+const API_BASE = import.meta.env.VITE_API_BASE ?? 'https://api.akli.dev'
 
 export const fetchRecipes = async (): Promise<RecipeIndex[]> => {
   const response = await fetch(`${API_BASE}/recipes`)

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -1,0 +1,15 @@
+import type { RecipeIndex, Recipe, Tag } from '../types/recipe'
+
+const API_BASE = 'https://api.akli.dev'
+
+export const fetchRecipes = async (): Promise<RecipeIndex[]> => {
+  throw new Error('Not implemented')
+}
+
+export const fetchRecipe = async (slug: string): Promise<Recipe> => {
+  throw new Error('Not implemented')
+}
+
+export const fetchTags = async (): Promise<Tag[]> => {
+  throw new Error('Not implemented')
+}

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -3,13 +3,25 @@ import type { RecipeIndex, Recipe, Tag } from '../types/recipe'
 const API_BASE = 'https://api.akli.dev'
 
 export const fetchRecipes = async (): Promise<RecipeIndex[]> => {
-  throw new Error('Not implemented')
+  const response = await fetch(`${API_BASE}/recipes`)
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+  return response.json()
 }
 
 export const fetchRecipe = async (slug: string): Promise<Recipe> => {
-  throw new Error('Not implemented')
+  const response = await fetch(`${API_BASE}/recipes/${slug}`)
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+  return response.json()
 }
 
 export const fetchTags = async (): Promise<Tag[]> => {
-  throw new Error('Not implemented')
+  const response = await fetch(`${API_BASE}/recipes/tags`)
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+  return response.json()
 }

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -3,10 +3,11 @@
   width: 1.5em;
   height: 1.5em;
   vertical-align: middle;
-  border: var(--border-width-thick) solid var(--color-border);
+  border: var(--border-width-thick) solid transparent;
   border-block-start-color: var(--color-text);
+  border-inline-end-color: var(--color-text);
   border-radius: var(--radius-none);
-  animation: spin 0.8s steps(4) infinite;
+  animation: spin 0.8s linear infinite;
 }
 
 @keyframes spin {
@@ -17,16 +18,9 @@
 
 @media (prefers-reduced-motion: reduce) {
   .spinner {
-    animation: pulse 1.5s ease-in-out infinite;
-  }
-
-  @keyframes pulse {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.3;
-    }
+    animation: none;
+    border-color: var(--color-border);
+    border-block-start-color: var(--color-text);
+    border-inline-end-color: var(--color-text);
   }
 }

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -7,7 +7,7 @@
   border: var(--border-width-thick) solid var(--color-border-subtle);
   border-block-start-color: var(--color-primary);
   border-inline-end-color: var(--color-primary);
-  animation: spin 0.8s steps(8) infinite;
+  animation: spin 0.8s linear infinite;
 }
 
 @keyframes spin {

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -1,10 +1,32 @@
 .spinner {
   display: inline-block;
-  width: 1em;
-  height: 1em;
+  width: 1.5em;
+  height: 1.5em;
   vertical-align: middle;
-  animation: spin 1s linear infinite;
-  border-radius: var(--radius-full);
-  border: var(--border-width-thick) solid var(--color-border-subtle);
-  border-block-start-color: var(--color-primary);
+  border: var(--border-width-thick) solid var(--color-border);
+  border-block-start-color: var(--color-text);
+  border-radius: var(--radius-none);
+  animation: spin 0.8s steps(4) infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.3;
+    }
+  }
 }

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -1,26 +1,10 @@
 .spinner {
   display: inline-block;
-  width: 1.5em;
-  height: 1.5em;
+  width: 1em;
+  height: 1em;
   vertical-align: middle;
-  border: var(--border-width-thick) solid transparent;
-  border-block-start-color: var(--color-text);
-  border-inline-end-color: var(--color-text);
-  border-radius: var(--radius-none);
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .spinner {
-    animation: none;
-    border-color: var(--color-border);
-    border-block-start-color: var(--color-text);
-    border-inline-end-color: var(--color-text);
-  }
+  animation: spin 1s linear infinite;
+  border-radius: var(--radius-full);
+  border: var(--border-width-thick) solid var(--color-border-subtle);
+  border-block-start-color: var(--color-primary);
 }

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -3,8 +3,32 @@
   width: 1em;
   height: 1em;
   vertical-align: middle;
-  animation: spin 1s linear infinite;
-  border-radius: var(--radius-full);
+  border-radius: var(--radius-none);
   border: var(--border-width-thick) solid var(--color-border-subtle);
   border-block-start-color: var(--color-primary);
+  border-inline-end-color: var(--color-primary);
+  animation: spin 0.8s steps(8) infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+
+    50% {
+      opacity: 0.4;
+    }
+  }
 }

--- a/src/components/RecipeCard/RecipeCard.module.css
+++ b/src/components/RecipeCard/RecipeCard.module.css
@@ -34,6 +34,10 @@
   border-bottom: var(--border-width) solid var(--color-border);
 }
 
+.imageWrapper > figure > div {
+  border: none;
+}
+
 .image {
   width: 100%;
   height: 100%;

--- a/src/components/RecipeCard/RecipeCard.module.css
+++ b/src/components/RecipeCard/RecipeCard.module.css
@@ -1,0 +1,99 @@
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: var(--radius-none);
+  border: var(--border-width) solid var(--color-border);
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-md);
+  transition:
+    transform var(--duration-fast) var(--easing-default),
+    box-shadow var(--duration-fast) var(--easing-default);
+}
+
+.card:hover {
+  transform: translate(-4px, -4px);
+  box-shadow: var(--shadow-lg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+
+  .card:hover {
+    transform: none;
+  }
+}
+
+.imageWrapper {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  overflow: hidden;
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: var(--space-4) var(--space-6) var(--space-6);
+}
+
+.title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  margin: 0 0 var(--space-2);
+}
+
+.titleLink {
+  color: var(--color-text-strong);
+  text-decoration: none;
+}
+
+.titleLink:hover {
+  color: var(--color-link-hover);
+}
+
+.titleLink:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-block-end: var(--space-3);
+}
+
+.tag {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  background: var(--color-surface-alt);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin-block-start: auto;
+}
+
+.separator {
+  font-weight: var(--font-weight-bold);
+}

--- a/src/components/RecipeCard/RecipeCard.module.css
+++ b/src/components/RecipeCard/RecipeCard.module.css
@@ -92,9 +92,11 @@
 .meta {
   display: flex;
   align-items: center;
+  flex-wrap: nowrap;
   gap: var(--space-2);
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
+  white-space: nowrap;
   margin-block-start: auto;
 }
 

--- a/src/components/RecipeCard/RecipeCard.module.css
+++ b/src/components/RecipeCard/RecipeCard.module.css
@@ -80,7 +80,7 @@
   padding: var(--space-1) var(--space-2);
   font-size: var(--font-size-sm);
   font-family: var(--font-mono);
-  background: var(--color-surface-alt);
+  background: var(--color-bg-subtle);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-none);
 }

--- a/src/components/RecipeCard/RecipeCard.test.tsx
+++ b/src/components/RecipeCard/RecipeCard.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
-import RecipeCard from './RecipeCard'
 import type { RecipeIndex } from '../../types/recipe'
+import RecipeCard from './RecipeCard'
 
 const mockRecipe: RecipeIndex = {
   id: 'rec-001',

--- a/src/components/RecipeCard/RecipeCard.test.tsx
+++ b/src/components/RecipeCard/RecipeCard.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import RecipeCard from './RecipeCard'
+import type { RecipeIndex } from '../../types/recipe'
+
+const mockRecipe: RecipeIndex = {
+  id: 'rec-001',
+  title: 'Classic Margherita Pizza',
+  slug: 'classic-margherita-pizza',
+  coverImage: { key: 'recipes/rec-001/cover', alt: 'Margherita pizza on a wooden board' },
+  tags: ['Italian', 'Quick'],
+  prepTime: 15,
+  cookTime: 12,
+  servings: 4,
+  createdAt: '2026-03-20T10:00:00Z',
+}
+
+const renderRecipeCard = (recipe = mockRecipe) =>
+  render(
+    <MemoryRouter>
+      <RecipeCard recipe={recipe} />
+    </MemoryRouter>
+  )
+
+describe('RecipeCard', () => {
+  it('renders cover image thumbnail with alt text', () => {
+    renderRecipeCard()
+
+    const img = screen.getByRole('img', { name: 'Margherita pizza on a wooden board' })
+    expect(img).toBeInTheDocument()
+  })
+
+  it('renders recipe title as a link to /recipes/{slug}', () => {
+    renderRecipeCard()
+
+    const link = screen.getByRole('link', { name: /classic margherita pizza/i })
+    expect(link).toHaveAttribute('href', '/recipes/classic-margherita-pizza')
+  })
+
+  it('renders tags', () => {
+    renderRecipeCard()
+
+    expect(screen.getByText('Italian')).toBeInTheDocument()
+    expect(screen.getByText('Quick')).toBeInTheDocument()
+  })
+
+  it('renders prep time, cook time, and servings', () => {
+    renderRecipeCard()
+
+    expect(screen.getByText(/15/)).toBeInTheDocument()
+    expect(screen.getByText(/12/)).toBeInTheDocument()
+    expect(screen.getByText(/4/)).toBeInTheDocument()
+  })
+})

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -7,11 +7,14 @@ import styles from './RecipeCard.module.css'
 
 export interface RecipeCardProps {
   recipe: RecipeIndex
+  eager?: boolean
+  hideTags?: boolean
+  hideMeta?: boolean
 }
 
 const IMAGE_BASE = 'https://akli.dev/images'
 
-const RecipeCard: FC<RecipeCardProps> = ({ recipe }) => {
+const RecipeCard: FC<RecipeCardProps> = ({ recipe, eager = false, hideTags = false, hideMeta = false }) => {
   const thumbnailSrc = `${IMAGE_BASE}/${recipe.coverImage.key}-thumb.webp`
 
   return (
@@ -22,6 +25,7 @@ const RecipeCard: FC<RecipeCardProps> = ({ recipe }) => {
           alt={recipe.coverImage.alt}
           aspectRatio="16/9"
           className={styles.image}
+          lazy={!eager}
         />
       </div>
 
@@ -32,21 +36,25 @@ const RecipeCard: FC<RecipeCardProps> = ({ recipe }) => {
           </Link>
         </Typography>
 
-        <div className={styles.tags}>
-          {recipe.tags.map((tag) => (
-            <span key={tag} className={styles.tag}>
-              {tag}
-            </span>
-          ))}
-        </div>
+        {!hideTags && (
+          <div className={styles.tags}>
+            {recipe.tags.map((tag) => (
+              <span key={tag} className={styles.tag}>
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
 
-        <div className={styles.meta}>
-          <span>Prep: {recipe.prepTime} min</span>
-          <span className={styles.separator}>·</span>
-          <span>Cook: {recipe.cookTime} min</span>
-          <span className={styles.separator}>·</span>
-          <span>Serves: {recipe.servings}</span>
-        </div>
+        {!hideMeta && (
+          <div className={styles.meta}>
+            <span>Prep: {recipe.prepTime} min</span>
+            <span className={styles.separator}>·</span>
+            <span>Cook: {recipe.cookTime} min</span>
+            <span className={styles.separator}>·</span>
+            <span>Serves: {recipe.servings}</span>
+          </div>
+        )}
       </div>
     </article>
   )

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -2,7 +2,7 @@ import Image from '@components/Image'
 import Typography from '@components/Typography'
 import type { FC } from 'react'
 import { Link } from 'react-router-dom'
-import type { RecipeIndex } from '../../types/recipe'
+import { RECIPE_IMAGE_BASE, type RecipeIndex } from '../../types/recipe'
 import styles from './RecipeCard.module.css'
 
 export interface RecipeCardProps {
@@ -12,10 +12,9 @@ export interface RecipeCardProps {
   hideMeta?: boolean
 }
 
-const IMAGE_BASE = 'https://akli.dev/images'
 
 const RecipeCard: FC<RecipeCardProps> = ({ recipe, eager = false, hideTags = false, hideMeta = false }) => {
-  const thumbnailSrc = `${IMAGE_BASE}/${recipe.coverImage.key}-thumb.webp`
+  const thumbnailSrc = `${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-thumb.webp`
 
   return (
     <article className={styles.card}>

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -7,7 +7,7 @@ export interface RecipeCardProps {
   recipe: RecipeIndex
 }
 
-const IMAGE_BASE = 'https://akli.dev/images/processed'
+const IMAGE_BASE = 'https://akli.dev/images'
 
 const RecipeCard: FC<RecipeCardProps> = ({ recipe }) => {
   const thumbnailSrc = `${IMAGE_BASE}/${recipe.coverImage.key}-thumb.webp`

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -1,0 +1,11 @@
+import type { RecipeIndex } from '../../types/recipe'
+
+export interface RecipeCardProps {
+  recipe: RecipeIndex
+}
+
+const RecipeCard = (_props: RecipeCardProps) => {
+  return null
+}
+
+export default RecipeCard

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -1,11 +1,53 @@
+import type { FC } from 'react'
+import { Link } from 'react-router-dom'
 import type { RecipeIndex } from '../../types/recipe'
+import styles from './RecipeCard.module.css'
 
 export interface RecipeCardProps {
   recipe: RecipeIndex
 }
 
-const RecipeCard = (_props: RecipeCardProps) => {
-  return null
+const IMAGE_BASE = 'https://akli.dev/images/processed'
+
+const RecipeCard: FC<RecipeCardProps> = ({ recipe }) => {
+  const thumbnailSrc = `${IMAGE_BASE}/${recipe.coverImage.key}-thumb.webp`
+
+  return (
+    <article className={styles.card}>
+      <div className={styles.imageWrapper}>
+        <img
+          src={thumbnailSrc}
+          alt={recipe.coverImage.alt}
+          loading="lazy"
+          className={styles.image}
+        />
+      </div>
+
+      <div className={styles.body}>
+        <h2 className={styles.title}>
+          <Link to={`/recipes/${recipe.slug}`} className={styles.titleLink}>
+            {recipe.title}
+          </Link>
+        </h2>
+
+        <div className={styles.tags}>
+          {recipe.tags.map((tag) => (
+            <span key={tag} className={styles.tag}>
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        <div className={styles.meta}>
+          <span>Prep: {recipe.prepTime} min</span>
+          <span className={styles.separator}>·</span>
+          <span>Cook: {recipe.cookTime} min</span>
+          <span className={styles.separator}>·</span>
+          <span>Serves: {recipe.servings}</span>
+        </div>
+      </div>
+    </article>
+  )
 }
 
 export default RecipeCard

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -1,3 +1,4 @@
+import Image from '@components/Image'
 import type { FC } from 'react'
 import { Link } from 'react-router-dom'
 import type { RecipeIndex } from '../../types/recipe'
@@ -15,10 +16,10 @@ const RecipeCard: FC<RecipeCardProps> = ({ recipe }) => {
   return (
     <article className={styles.card}>
       <div className={styles.imageWrapper}>
-        <img
+        <Image
           src={thumbnailSrc}
           alt={recipe.coverImage.alt}
-          loading="lazy"
+          aspectRatio="16/9"
           className={styles.image}
         />
       </div>

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -1,4 +1,5 @@
 import Image from '@components/Image'
+import Typography from '@components/Typography'
 import type { FC } from 'react'
 import { Link } from 'react-router-dom'
 import type { RecipeIndex } from '../../types/recipe'
@@ -25,11 +26,11 @@ const RecipeCard: FC<RecipeCardProps> = ({ recipe }) => {
       </div>
 
       <div className={styles.body}>
-        <h2 className={styles.title}>
+        <Typography variant="heading3" as="h2" className={styles.title}>
           <Link to={`/recipes/${recipe.slug}`} className={styles.titleLink}>
             {recipe.title}
           </Link>
-        </h2>
+        </Typography>
 
         <div className={styles.tags}>
           {recipe.tags.map((tag) => (

--- a/src/components/RecipeCard/index.ts
+++ b/src/components/RecipeCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RecipeCard'
+export type { RecipeCardProps } from './RecipeCard'

--- a/src/components/RecipeIngredients/RecipeIngredients.module.css
+++ b/src/components/RecipeIngredients/RecipeIngredients.module.css
@@ -1,0 +1,21 @@
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.item {
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.quantity {
+  font-weight: var(--font-weight-bold);
+}
+
+.unit {
+  color: var(--color-text-muted);
+}

--- a/src/components/RecipeIngredients/RecipeIngredients.test.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import type { Ingredient } from '../../types/recipe'
+import RecipeIngredients from './RecipeIngredients'
+
+const mockIngredients: Ingredient[] = [
+  { item: 'flour', quantity: '200', unit: 'g' },
+  { item: 'sugar', quantity: '100', unit: 'g' },
+  { item: 'butter', quantity: '50', unit: 'g' },
+]
+
+describe('RecipeIngredients', () => {
+  it('renders a list with ingredient items', () => {
+    render(<RecipeIngredients ingredients={mockIngredients} />)
+
+    const list = screen.getByRole('list')
+    expect(list).toBeInTheDocument()
+
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(3)
+  })
+
+  it('shows quantity, unit, and item name for each ingredient', () => {
+    render(<RecipeIngredients ingredients={mockIngredients} />)
+
+    expect(screen.getByText(/200/)).toBeInTheDocument()
+    expect(screen.getByText(/g/)).toBeInTheDocument()
+    expect(screen.getByText(/flour/)).toBeInTheDocument()
+
+    expect(screen.getByText(/100/)).toBeInTheDocument()
+    expect(screen.getByText(/sugar/)).toBeInTheDocument()
+
+    expect(screen.getByText(/50/)).toBeInTheDocument()
+    expect(screen.getByText(/butter/)).toBeInTheDocument()
+  })
+})

--- a/src/components/RecipeIngredients/RecipeIngredients.test.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.test.tsx
@@ -23,14 +23,8 @@ describe('RecipeIngredients', () => {
   it('shows quantity, unit, and item name for each ingredient', () => {
     render(<RecipeIngredients ingredients={mockIngredients} />)
 
-    expect(screen.getByText(/200/)).toBeInTheDocument()
-    expect(screen.getByText(/g/)).toBeInTheDocument()
-    expect(screen.getByText(/flour/)).toBeInTheDocument()
-
-    expect(screen.getByText(/100/)).toBeInTheDocument()
-    expect(screen.getByText(/sugar/)).toBeInTheDocument()
-
-    expect(screen.getByText(/50/)).toBeInTheDocument()
-    expect(screen.getByText(/butter/)).toBeInTheDocument()
+    expect(screen.getByText('200 g flour')).toBeInTheDocument()
+    expect(screen.getByText('100 g sugar')).toBeInTheDocument()
+    expect(screen.getByText('50 g butter')).toBeInTheDocument()
   })
 })

--- a/src/components/RecipeIngredients/RecipeIngredients.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.tsx
@@ -1,10 +1,19 @@
 import type { FC } from 'react'
 import type { Ingredient } from '../../types/recipe'
+import styles from './RecipeIngredients.module.css'
 
 export interface RecipeIngredientsProps {
   ingredients: Ingredient[]
 }
 
-const RecipeIngredients: FC<RecipeIngredientsProps> = () => null
+const RecipeIngredients: FC<RecipeIngredientsProps> = ({ ingredients }) => (
+  <ul className={styles.list}>
+    {ingredients.map((ingredient) => (
+      <li key={ingredient.item} className={styles.item}>
+        {ingredient.quantity} {ingredient.item}
+      </li>
+    ))}
+  </ul>
+)
 
 export default RecipeIngredients

--- a/src/components/RecipeIngredients/RecipeIngredients.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.tsx
@@ -8,9 +8,9 @@ export interface RecipeIngredientsProps {
 
 const RecipeIngredients: FC<RecipeIngredientsProps> = ({ ingredients }) => (
   <ul className={styles.list}>
-    {ingredients.map((ingredient) => (
-      <li key={ingredient.item} className={styles.item}>
-        {ingredient.quantity} {ingredient.item}
+    {ingredients.map((ingredient, idx) => (
+      <li key={`${ingredient.item}-${idx}`} className={styles.item}>
+        {ingredient.quantity} {ingredient.unit} {ingredient.item}
       </li>
     ))}
   </ul>

--- a/src/components/RecipeIngredients/RecipeIngredients.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.tsx
@@ -1,0 +1,10 @@
+import type { FC } from 'react'
+import type { Ingredient } from '../../types/recipe'
+
+export interface RecipeIngredientsProps {
+  ingredients: Ingredient[]
+}
+
+const RecipeIngredients: FC<RecipeIngredientsProps> = () => null
+
+export default RecipeIngredients

--- a/src/components/RecipeIngredients/index.ts
+++ b/src/components/RecipeIngredients/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RecipeIngredients'
+export type { RecipeIngredientsProps } from './RecipeIngredients'

--- a/src/components/RecipeSearch/RecipeSearch.module.css
+++ b/src/components/RecipeSearch/RecipeSearch.module.css
@@ -1,0 +1,24 @@
+.wrapper {
+  margin-block-end: var(--space-6);
+}
+
+.input {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-base);
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  box-shadow: var(--shadow-sm);
+}
+
+.input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.input:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/src/components/RecipeSearch/RecipeSearch.module.css
+++ b/src/components/RecipeSearch/RecipeSearch.module.css
@@ -6,7 +6,7 @@
   width: 100%;
   padding: var(--space-3) var(--space-4);
   font-size: var(--font-size-base);
-  font-family: var(--font-body);
+  font-family: var(--font-sans);
   color: var(--color-text);
   background: var(--color-surface);
   border: var(--border-width) solid var(--color-border);

--- a/src/components/RecipeSearch/RecipeSearch.test.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.test.tsx
@@ -12,7 +12,7 @@ describe('RecipeSearch', () => {
   })
 
   it('renders a search input with aria-label', () => {
-    render(<RecipeSearch onSearch={vi.fn()} />)
+    render(<RecipeSearch value="" onSearch={vi.fn()} />)
 
     const input = screen.getByRole('searchbox', { name: /search recipes/i })
     expect(input).toBeInTheDocument()
@@ -20,7 +20,7 @@ describe('RecipeSearch', () => {
 
   it('calls onSearch callback after 300ms debounce', () => {
     const onSearch = vi.fn()
-    render(<RecipeSearch onSearch={onSearch} />)
+    render(<RecipeSearch value="" onSearch={onSearch} />)
 
     const input = screen.getByRole('searchbox', { name: /search recipes/i })
     fireEvent.change(input, { target: { value: 'pizza' } })
@@ -35,7 +35,7 @@ describe('RecipeSearch', () => {
 
   it('does not call onSearch before debounce period', () => {
     const onSearch = vi.fn()
-    render(<RecipeSearch onSearch={onSearch} />)
+    render(<RecipeSearch value="" onSearch={onSearch} />)
 
     const input = screen.getByRole('searchbox', { name: /search recipes/i })
     fireEvent.change(input, { target: { value: 'pasta' } })

--- a/src/components/RecipeSearch/RecipeSearch.test.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import RecipeSearch from './RecipeSearch'
+
+describe('RecipeSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders a search input with aria-label', () => {
+    render(<RecipeSearch onSearch={vi.fn()} />)
+
+    const input = screen.getByRole('searchbox', { name: /search recipes/i })
+    expect(input).toBeInTheDocument()
+  })
+
+  it('calls onSearch callback after 300ms debounce', () => {
+    const onSearch = vi.fn()
+    render(<RecipeSearch onSearch={onSearch} />)
+
+    const input = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(input, { target: { value: 'pizza' } })
+
+    // Advance past debounce period
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(onSearch).toHaveBeenCalledWith('pizza')
+  })
+
+  it('does not call onSearch before debounce period', () => {
+    const onSearch = vi.fn()
+    render(<RecipeSearch onSearch={onSearch} />)
+
+    const input = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(input, { target: { value: 'pasta' } })
+
+    // Advance less than debounce period
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(onSearch).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/RecipeSearch/RecipeSearch.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.tsx
@@ -1,9 +1,33 @@
+import { useState, useEffect, type FC } from 'react'
+import styles from './RecipeSearch.module.css'
+
 export interface RecipeSearchProps {
   onSearch: (query: string) => void
 }
 
-const RecipeSearch = (_props: RecipeSearchProps) => {
-  return null
+const RecipeSearch: FC<RecipeSearchProps> = ({ onSearch }) => {
+  const [value, setValue] = useState('')
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onSearch(value)
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [value, onSearch])
+
+  return (
+    <div className={styles.wrapper}>
+      <input
+        type="search"
+        aria-label="Search recipes"
+        placeholder="Search recipes..."
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className={styles.input}
+      />
+    </div>
+  )
 }
 
 export default RecipeSearch

--- a/src/components/RecipeSearch/RecipeSearch.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.tsx
@@ -2,11 +2,16 @@ import { useState, useEffect, type FC } from 'react'
 import styles from './RecipeSearch.module.css'
 
 export interface RecipeSearchProps {
+  value: string
   onSearch: (query: string) => void
 }
 
-const RecipeSearch: FC<RecipeSearchProps> = ({ onSearch }) => {
-  const [value, setValue] = useState('')
+const RecipeSearch: FC<RecipeSearchProps> = ({ value: controlledValue, onSearch }) => {
+  const [value, setValue] = useState(controlledValue)
+
+  useEffect(() => {
+    setValue(controlledValue)
+  }, [controlledValue])
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/src/components/RecipeSearch/RecipeSearch.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.tsx
@@ -1,0 +1,9 @@
+export interface RecipeSearchProps {
+  onSearch: (query: string) => void
+}
+
+const RecipeSearch = (_props: RecipeSearchProps) => {
+  return null
+}
+
+export default RecipeSearch

--- a/src/components/RecipeSearch/index.ts
+++ b/src/components/RecipeSearch/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RecipeSearch'
+export type { RecipeSearchProps } from './RecipeSearch'

--- a/src/components/RecipeSteps/RecipeSteps.module.css
+++ b/src/components/RecipeSteps/RecipeSteps.module.css
@@ -1,0 +1,22 @@
+.list {
+  padding-inline-start: var(--space-6);
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.item {
+  padding-inline-start: var(--space-2);
+}
+
+.text {
+  margin: 0 0 var(--space-3);
+}
+
+.image {
+  display: block;
+  max-width: 100%;
+  border-radius: var(--radius-none);
+  border: var(--border-width) solid var(--color-border);
+}

--- a/src/components/RecipeSteps/RecipeSteps.test.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import type { Step } from '../../types/recipe'
+import RecipeSteps from './RecipeSteps'
+
+const mockSteps: Step[] = [
+  {
+    order: 1,
+    text: 'Mix ingredients together',
+    image: { key: 'processed/recipes/recipe-1/step-1', alt: 'Mixing bowl' },
+  },
+  { order: 2, text: 'Bake for 30 minutes' },
+  {
+    order: 3,
+    text: 'Let it cool',
+    image: { key: 'processed/recipes/recipe-1/step-3', alt: 'Cooling rack' },
+  },
+]
+
+describe('RecipeSteps', () => {
+  it('renders an ordered list with step items', () => {
+    render(<RecipeSteps steps={mockSteps} />)
+
+    const list = screen.getByRole('list')
+    expect(list.tagName).toBe('OL')
+
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(3)
+  })
+
+  it('shows step text', () => {
+    render(<RecipeSteps steps={mockSteps} />)
+
+    expect(screen.getByText('Mix ingredients together')).toBeInTheDocument()
+    expect(screen.getByText('Bake for 30 minutes')).toBeInTheDocument()
+    expect(screen.getByText('Let it cool')).toBeInTheDocument()
+  })
+
+  it('shows step image with alt text when image is present', () => {
+    render(<RecipeSteps steps={mockSteps} />)
+
+    const mixingImg = screen.getByRole('img', { name: 'Mixing bowl' })
+    expect(mixingImg).toBeInTheDocument()
+    expect(mixingImg).toHaveAttribute('loading', 'lazy')
+    expect(mixingImg).toHaveAttribute(
+      'src',
+      expect.stringContaining('processed/recipes/recipe-1/step-1-medium')
+    )
+
+    const coolingImg = screen.getByRole('img', { name: 'Cooling rack' })
+    expect(coolingImg).toBeInTheDocument()
+  })
+
+  it('does not show image when step has no image', () => {
+    render(<RecipeSteps steps={[{ order: 1, text: 'Bake for 30 minutes' }]} />)
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/RecipeSteps/RecipeSteps.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.tsx
@@ -1,10 +1,29 @@
 import type { FC } from 'react'
 import type { Step } from '../../types/recipe'
+import styles from './RecipeSteps.module.css'
 
 export interface RecipeStepsProps {
   steps: Step[]
 }
 
-const RecipeSteps: FC<RecipeStepsProps> = () => null
+const IMAGE_BASE = 'https://akli.dev/images'
+
+const RecipeSteps: FC<RecipeStepsProps> = ({ steps }) => (
+  <ol className={styles.list}>
+    {steps.map((step) => (
+      <li key={step.order} className={styles.item}>
+        <p className={styles.text}>{step.text}</p>
+        {step.image && (
+          <img
+            src={`${IMAGE_BASE}/${step.image.key}-medium.webp`}
+            alt={step.image.alt}
+            loading="lazy"
+            className={styles.image}
+          />
+        )}
+      </li>
+    ))}
+  </ol>
+)
 
 export default RecipeSteps

--- a/src/components/RecipeSteps/RecipeSteps.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.tsx
@@ -1,4 +1,5 @@
 import Image from '@components/Image'
+import Typography from '@components/Typography'
 import type { FC } from 'react'
 import type { Step } from '../../types/recipe'
 import styles from './RecipeSteps.module.css'
@@ -13,7 +14,7 @@ const RecipeSteps: FC<RecipeStepsProps> = ({ steps }) => (
   <ol className={styles.list}>
     {steps.map((step) => (
       <li key={step.order} className={styles.item}>
-        <p className={styles.text}>{step.text}</p>
+        <Typography variant="body" className={styles.text}>{step.text}</Typography>
         {step.image && (
           <Image
             src={`${IMAGE_BASE}/${step.image.key}-medium.webp`}

--- a/src/components/RecipeSteps/RecipeSteps.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.tsx
@@ -1,3 +1,4 @@
+import Image from '@components/Image'
 import type { FC } from 'react'
 import type { Step } from '../../types/recipe'
 import styles from './RecipeSteps.module.css'
@@ -14,10 +15,9 @@ const RecipeSteps: FC<RecipeStepsProps> = ({ steps }) => (
       <li key={step.order} className={styles.item}>
         <p className={styles.text}>{step.text}</p>
         {step.image && (
-          <img
+          <Image
             src={`${IMAGE_BASE}/${step.image.key}-medium.webp`}
             alt={step.image.alt}
-            loading="lazy"
             className={styles.image}
           />
         )}

--- a/src/components/RecipeSteps/RecipeSteps.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.tsx
@@ -1,0 +1,10 @@
+import type { FC } from 'react'
+import type { Step } from '../../types/recipe'
+
+export interface RecipeStepsProps {
+  steps: Step[]
+}
+
+const RecipeSteps: FC<RecipeStepsProps> = () => null
+
+export default RecipeSteps

--- a/src/components/RecipeSteps/RecipeSteps.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.tsx
@@ -1,14 +1,13 @@
 import Image from '@components/Image'
 import Typography from '@components/Typography'
 import type { FC } from 'react'
-import type { Step } from '../../types/recipe'
+import { RECIPE_IMAGE_BASE, type Step } from '../../types/recipe'
 import styles from './RecipeSteps.module.css'
 
 export interface RecipeStepsProps {
   steps: Step[]
 }
 
-const IMAGE_BASE = 'https://akli.dev/images'
 
 const RecipeSteps: FC<RecipeStepsProps> = ({ steps }) => (
   <ol className={styles.list}>
@@ -17,7 +16,7 @@ const RecipeSteps: FC<RecipeStepsProps> = ({ steps }) => (
         <Typography variant="body" className={styles.text}>{step.text}</Typography>
         {step.image && (
           <Image
-            src={`${IMAGE_BASE}/${step.image.key}-medium.webp`}
+            src={`${RECIPE_IMAGE_BASE}/${step.image.key}-medium.webp`}
             alt={step.image.alt}
             className={styles.image}
           />

--- a/src/components/RecipeSteps/index.ts
+++ b/src/components/RecipeSteps/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RecipeSteps'
+export type { RecipeStepsProps } from './RecipeSteps'

--- a/src/components/RecipeTagFilter/RecipeTagFilter.module.css
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.module.css
@@ -32,3 +32,9 @@
   outline: var(--border-width) solid var(--color-primary);
   outline-offset: 2px;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .tag {
+    transition: none;
+  }
+}

--- a/src/components/RecipeTagFilter/RecipeTagFilter.module.css
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.module.css
@@ -1,0 +1,34 @@
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-block-end: var(--space-6);
+}
+
+.tag {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  cursor: pointer;
+}
+
+.tag:hover {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+}
+
+.tag[aria-pressed='true'] {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  font-weight: var(--font-weight-bold);
+}
+
+.tag:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/src/components/RecipeTagFilter/RecipeTagFilter.module.css
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.module.css
@@ -10,11 +10,6 @@
   font-size: var(--font-size-sm);
   font-family: var(--font-mono);
   font-weight: var(--font-weight-normal);
-  color: var(--color-text);
-  background: var(--color-surface);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-none);
-  cursor: pointer;
 }
 
 .tag:hover {
@@ -26,15 +21,4 @@
   background: var(--color-primary);
   color: var(--color-on-primary);
   font-weight: var(--font-weight-bold);
-}
-
-.tag:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-  outline-offset: 2px;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .tag {
-    transition: none;
-  }
 }

--- a/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
-import RecipeTagFilter from './RecipeTagFilter'
 import type { Tag } from '../../types/recipe'
+import RecipeTagFilter from './RecipeTagFilter'
 
 const mockTags: Tag[] = [
   { tag: 'Italian', count: 5 },

--- a/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import RecipeTagFilter from './RecipeTagFilter'
+import type { Tag } from '../../types/recipe'
+
+const mockTags: Tag[] = [
+  { tag: 'Italian', count: 5 },
+  { tag: 'Quick', count: 3 },
+  { tag: 'Vegetarian', count: 8 },
+]
+
+describe('RecipeTagFilter', () => {
+  it('renders tag buttons with counts', () => {
+    render(
+      <RecipeTagFilter tags={mockTags} activeTag={null} onTagClick={vi.fn()} />
+    )
+
+    expect(screen.getByRole('button', { name: /Italian/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Quick/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Vegetarian/i })).toBeInTheDocument()
+
+    expect(screen.getByText(/5/)).toBeInTheDocument()
+    expect(screen.getByText(/3/)).toBeInTheDocument()
+    expect(screen.getByText(/8/)).toBeInTheDocument()
+  })
+
+  it('active tag has aria-pressed="true"', () => {
+    render(
+      <RecipeTagFilter tags={mockTags} activeTag="Italian" onTagClick={vi.fn()} />
+    )
+
+    expect(screen.getByRole('button', { name: /Italian/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('inactive tag has aria-pressed="false"', () => {
+    render(
+      <RecipeTagFilter tags={mockTags} activeTag="Italian" onTagClick={vi.fn()} />
+    )
+
+    expect(screen.getByRole('button', { name: /Quick/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+    expect(screen.getByRole('button', { name: /Vegetarian/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+  })
+})

--- a/src/components/RecipeTagFilter/RecipeTagFilter.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.tsx
@@ -1,4 +1,6 @@
+import type { FC } from 'react'
 import type { Tag } from '../../types/recipe'
+import styles from './RecipeTagFilter.module.css'
 
 export interface RecipeTagFilterProps {
   tags: Tag[]
@@ -6,8 +8,22 @@ export interface RecipeTagFilterProps {
   onTagClick: (tag: string) => void
 }
 
-const RecipeTagFilter = (_props: RecipeTagFilterProps) => {
-  return null
+const RecipeTagFilter: FC<RecipeTagFilterProps> = ({ tags, activeTag, onTagClick }) => {
+  return (
+    <div className={styles.wrapper}>
+      {tags.map(({ tag, count }) => (
+        <button
+          key={tag}
+          type="button"
+          className={styles.tag}
+          aria-pressed={activeTag === tag ? 'true' : 'false'}
+          onClick={() => onTagClick(tag)}
+        >
+          {tag} ({count})
+        </button>
+      ))}
+    </div>
+  )
 }
 
 export default RecipeTagFilter

--- a/src/components/RecipeTagFilter/RecipeTagFilter.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.tsx
@@ -1,3 +1,4 @@
+import Button from '@components/Button'
 import type { FC } from 'react'
 import type { Tag } from '../../types/recipe'
 import styles from './RecipeTagFilter.module.css'
@@ -12,15 +13,15 @@ const RecipeTagFilter: FC<RecipeTagFilterProps> = ({ tags, activeTag, onTagClick
   return (
     <div className={styles.wrapper}>
       {tags.map(({ tag, count }) => (
-        <button
+        <Button
           key={tag}
-          type="button"
+          variant="secondary"
           className={styles.tag}
-          aria-pressed={activeTag === tag ? 'true' : 'false'}
+          ariaPressed={activeTag === tag ? 'true' : 'false'}
           onClick={() => onTagClick(tag)}
         >
           {tag} ({count})
-        </button>
+        </Button>
       ))}
     </div>
   )

--- a/src/components/RecipeTagFilter/RecipeTagFilter.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.tsx
@@ -1,0 +1,13 @@
+import type { Tag } from '../../types/recipe'
+
+export interface RecipeTagFilterProps {
+  tags: Tag[]
+  activeTag: string | null
+  onTagClick: (tag: string) => void
+}
+
+const RecipeTagFilter = (_props: RecipeTagFilterProps) => {
+  return null
+}
+
+export default RecipeTagFilter

--- a/src/components/RecipeTagFilter/index.ts
+++ b/src/components/RecipeTagFilter/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RecipeTagFilter'
+export type { RecipeTagFilterProps } from './RecipeTagFilter'

--- a/src/components/RecipesCta/RecipesCta.module.css
+++ b/src/components/RecipesCta/RecipesCta.module.css
@@ -1,0 +1,80 @@
+/* RecipesCta component styles */
+
+.section {
+  position: relative;
+  padding-block: var(--space-12);
+}
+
+.section::before {
+  content: '';
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: 50%;
+  inline-size: 100vw;
+  transform: translateX(-50%);
+  border-block-start: var(--border-width) solid var(--color-border-subtle);
+}
+
+.inner {
+  text-align: center;
+}
+
+.heading {
+  margin-block-end: var(--space-6);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-6);
+  margin-block-end: var(--space-8);
+}
+
+@media (min-width: 768px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.skeleton {
+  block-size: 16rem;
+  background: var(--color-surface-raised);
+  border: var(--border-width) solid var(--color-border-subtle);
+  border-radius: var(--radius-none);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
+  margin-block-end: var(--space-6);
+}
+
+.tag {
+  padding: var(--space-1) var(--space-3);
+  border: var(--border-width) solid var(--color-border-subtle);
+  border-radius: var(--radius-none);
+  font-size: var(--text-sm);
+}
+
+.link {
+  display: inline-block;
+}

--- a/src/components/RecipesCta/RecipesCta.module.css
+++ b/src/components/RecipesCta/RecipesCta.module.css
@@ -38,7 +38,7 @@
 
 .skeleton {
   block-size: 16rem;
-  background: var(--color-surface-raised);
+  background: var(--color-bg-subtle);
   border: var(--border-width) solid var(--color-border-subtle);
   border-radius: var(--radius-none);
   animation: pulse 1.5s ease-in-out infinite;

--- a/src/components/RecipesCta/RecipesCta.module.css
+++ b/src/components/RecipesCta/RecipesCta.module.css
@@ -36,6 +36,6 @@
   }
 }
 
-.link {
-  display: inline-block;
+.body {
+  margin-block-start: var(--space-8);
 }

--- a/src/components/RecipesCta/RecipesCta.module.css
+++ b/src/components/RecipesCta/RecipesCta.module.css
@@ -60,21 +60,6 @@
   }
 }
 
-.tags {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: var(--space-2);
-  margin-block-end: var(--space-6);
-}
-
-.tag {
-  padding: var(--space-1) var(--space-3);
-  border: var(--border-width) solid var(--color-border-subtle);
-  border-radius: var(--radius-none);
-  font-size: var(--text-sm);
-}
-
 .link {
   display: inline-block;
 }

--- a/src/components/RecipesCta/RecipesCta.module.css
+++ b/src/components/RecipesCta/RecipesCta.module.css
@@ -36,30 +36,6 @@
   }
 }
 
-.skeleton {
-  block-size: 16rem;
-  background: var(--color-bg-subtle);
-  border: var(--border-width) solid var(--color-border-subtle);
-  border-radius: var(--radius-none);
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .skeleton {
-    animation: none;
-  }
-}
-
 .link {
   display: inline-block;
 }

--- a/src/components/RecipesCta/RecipesCta.test.tsx
+++ b/src/components/RecipesCta/RecipesCta.test.tsx
@@ -127,6 +127,6 @@ describe('RecipesCta', () => {
     })
 
     expect(screen.getByRole('heading', { name: /from the kitchen/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /recipes/i })).toHaveAttribute('href', '/recipes')
+    expect(screen.getByRole('link', { name: /kitchen/i })).toHaveAttribute('href', '/recipes')
   })
 })

--- a/src/components/RecipesCta/RecipesCta.test.tsx
+++ b/src/components/RecipesCta/RecipesCta.test.tsx
@@ -111,13 +111,12 @@ describe('RecipesCta', () => {
     expect(screen.queryByText(/from the kitchen/i)).not.toBeInTheDocument()
   })
 
-  it('shows skeleton placeholders while loading', () => {
+  it('renders nothing while loading', () => {
     vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
 
     renderRecipesCta()
 
-    const skeletons = screen.getAllByRole('status', { name: /loading/i })
-    expect(skeletons.length).toBeGreaterThanOrEqual(1)
+    expect(screen.queryByRole('heading', { name: /from the kitchen/i })).not.toBeInTheDocument()
   })
 
   it('includes a heading and link to /recipes', async () => {

--- a/src/components/RecipesCta/RecipesCta.test.tsx
+++ b/src/components/RecipesCta/RecipesCta.test.tsx
@@ -95,7 +95,7 @@ describe('RecipesCta', () => {
     })
 
     expect(container.querySelector('section')).not.toBeInTheDocument()
-    expect(screen.queryByText(/from the kitchen/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/favourite recipes/i)).not.toBeInTheDocument()
   })
 
   it('does not render the section when the API fails', async () => {
@@ -108,7 +108,7 @@ describe('RecipesCta', () => {
     })
 
     expect(container.querySelector('section')).not.toBeInTheDocument()
-    expect(screen.queryByText(/from the kitchen/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/favourite recipes/i)).not.toBeInTheDocument()
   })
 
   it('renders nothing while loading', () => {
@@ -116,7 +116,7 @@ describe('RecipesCta', () => {
 
     renderRecipesCta()
 
-    expect(screen.queryByRole('heading', { name: /from the kitchen/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /favourite recipes/i })).not.toBeInTheDocument()
   })
 
   it('includes a heading and link to /recipes', async () => {
@@ -126,7 +126,7 @@ describe('RecipesCta', () => {
       expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('heading', { name: /from the kitchen/i })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /kitchen/i })).toHaveAttribute('href', '/recipes')
+    expect(screen.getByRole('heading', { name: /favourite recipes/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /recipes/i })).toHaveAttribute('href', '/recipes')
   })
 })

--- a/src/components/RecipesCta/RecipesCta.test.tsx
+++ b/src/components/RecipesCta/RecipesCta.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../api/recipes', () => ({
+  fetchRecipes: vi.fn(),
+}))
+
+import { fetchRecipes } from '../../api/recipes'
+import type { RecipeIndex } from '../../types/recipe'
+import RecipesCta from './RecipesCta'
+
+const mockRecipes: RecipeIndex[] = [
+  {
+    id: 'rec-001',
+    title: 'Classic Margherita Pizza',
+    slug: 'classic-margherita-pizza',
+    coverImage: { key: 'recipes/rec-001/cover', alt: 'Margherita pizza' },
+    tags: ['Italian', 'Quick'],
+    prepTime: 15,
+    cookTime: 12,
+    servings: 4,
+    createdAt: '2026-03-20T10:00:00Z',
+  },
+  {
+    id: 'rec-002',
+    title: 'Thai Green Curry',
+    slug: 'thai-green-curry',
+    coverImage: { key: 'recipes/rec-002/cover', alt: 'Thai green curry' },
+    tags: ['Thai', 'Spicy'],
+    prepTime: 20,
+    cookTime: 25,
+    servings: 2,
+    createdAt: '2026-03-18T10:00:00Z',
+  },
+  {
+    id: 'rec-003',
+    title: 'Italian Pasta Carbonara',
+    slug: 'italian-pasta-carbonara',
+    coverImage: { key: 'recipes/rec-003/cover', alt: 'Pasta carbonara' },
+    tags: ['Italian'],
+    prepTime: 10,
+    cookTime: 15,
+    servings: 3,
+    createdAt: '2026-03-15T10:00:00Z',
+  },
+]
+
+const renderRecipesCta = () =>
+  render(
+    <MemoryRouter>
+      <RecipesCta />
+    </MemoryRouter>
+  )
+
+describe('RecipesCta', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(fetchRecipes).mockResolvedValue(mockRecipes)
+  })
+
+  it('renders up to 3 latest recipe cards with cover image, title, and tags', async () => {
+    renderRecipesCta()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Thai Green Curry')).toBeInTheDocument()
+    expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
+
+    expect(screen.getByRole('img', { name: 'Margherita pizza' })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Thai green curry' })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Pasta carbonara' })).toBeInTheDocument()
+
+    expect(screen.getByText('Italian')).toBeInTheDocument()
+    expect(screen.getByText('Quick')).toBeInTheDocument()
+    expect(screen.getByText('Thai')).toBeInTheDocument()
+    expect(screen.getByText('Spicy')).toBeInTheDocument()
+  })
+
+  it('shows available cards when fewer than 3 recipes exist', async () => {
+    vi.mocked(fetchRecipes).mockResolvedValue(mockRecipes.slice(0, 2))
+
+    renderRecipesCta()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Thai Green Curry')).toBeInTheDocument()
+    expect(screen.getAllByRole('img')).toHaveLength(2)
+  })
+
+  it('does not render the section when no published recipes exist', async () => {
+    vi.mocked(fetchRecipes).mockResolvedValue([])
+
+    const { container } = renderRecipesCta()
+
+    await waitFor(() => {
+      expect(fetchRecipes).toHaveBeenCalled()
+    })
+
+    expect(container.querySelector('section')).not.toBeInTheDocument()
+    expect(screen.queryByText(/from the kitchen/i)).not.toBeInTheDocument()
+  })
+
+  it('does not render the section when the API fails', async () => {
+    vi.mocked(fetchRecipes).mockRejectedValue(new Error('500 Internal Server Error'))
+
+    const { container } = renderRecipesCta()
+
+    await waitFor(() => {
+      expect(fetchRecipes).toHaveBeenCalled()
+    })
+
+    expect(container.querySelector('section')).not.toBeInTheDocument()
+    expect(screen.queryByText(/from the kitchen/i)).not.toBeInTheDocument()
+  })
+
+  it('shows skeleton placeholders while loading', () => {
+    vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
+
+    renderRecipesCta()
+
+    const skeletons = screen.getAllByRole('status', { name: /loading/i })
+    expect(skeletons.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('includes a heading and link to /recipes', async () => {
+    renderRecipesCta()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('heading', { name: /from the kitchen/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /recipes/i })).toHaveAttribute('href', '/recipes')
+  })
+})

--- a/src/components/RecipesCta/RecipesCta.test.tsx
+++ b/src/components/RecipesCta/RecipesCta.test.tsx
@@ -59,7 +59,7 @@ describe('RecipesCta', () => {
     vi.mocked(fetchRecipes).mockResolvedValue(mockRecipes)
   })
 
-  it('renders up to 3 latest recipe cards with cover image, title, and tags', async () => {
+  it('renders up to 3 latest recipe cards with cover image and title', async () => {
     renderRecipesCta()
 
     await waitFor(() => {
@@ -71,11 +71,6 @@ describe('RecipesCta', () => {
     expect(screen.getByRole('img', { name: 'Margherita pizza' })).toBeInTheDocument()
     expect(screen.getByRole('img', { name: 'Thai green curry' })).toBeInTheDocument()
     expect(screen.getByRole('img', { name: 'Pasta carbonara' })).toBeInTheDocument()
-
-    expect(screen.getByText('Italian')).toBeInTheDocument()
-    expect(screen.getByText('Quick')).toBeInTheDocument()
-    expect(screen.getByText('Thai')).toBeInTheDocument()
-    expect(screen.getByText('Spicy')).toBeInTheDocument()
   })
 
   it('shows available cards when fewer than 3 recipes exist', async () => {

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -1,0 +1,7 @@
+import { FC } from 'react'
+
+const RecipesCta: FC = () => {
+  return null
+}
+
+export default RecipesCta

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -16,8 +16,10 @@ const RecipesCta: FC = () => {
   const [status, setStatus] = useState<Status>('loading')
 
   useEffect(() => {
+    let cancelled = false
     fetchRecipes()
       .then((data) => {
+        if (cancelled) return
         const latest = data.slice(0, MAX_RECIPES)
         if (latest.length === 0) {
           setStatus('empty')
@@ -27,8 +29,9 @@ const RecipesCta: FC = () => {
         }
       })
       .catch(() => {
-        setStatus('error')
+        if (!cancelled) setStatus('error')
       })
+    return () => { cancelled = true }
   }, [])
 
   if (status !== 'loaded') {

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -46,9 +46,13 @@ const RecipesCta: FC = () => {
             <RecipeCard key={recipe.id} recipe={recipe} eager hideTags hideMeta />
           ))}
         </Grid>
-        <Link to="/recipes" className={styles.link}>
-          View all recipes
-        </Link>
+        <Typography variant="bodyLarge" className={styles.body}>
+          Browse all recipes in the{' '}
+          <Link to="/recipes" underline={true}>
+            kitchen
+          </Link>
+          .
+        </Typography>
       </div>
     </section>
   )

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -1,3 +1,4 @@
+import Grid from '@components/Grid'
 import Link from '@components/Link'
 import RecipeCard from '@components/RecipeCard'
 import Typography from '@components/Typography'
@@ -67,11 +68,11 @@ const RecipesCta: FC = () => {
         <Typography variant="heading2" id="recipes-section-title" className={styles.heading}>
           From the Kitchen
         </Typography>
-        <div className={styles.grid}>
+        <Grid columns={3}>
           {recipes.map((recipe) => (
             <RecipeCard key={recipe.id} recipe={recipe} eager hideTags hideMeta />
           ))}
-        </div>
+        </Grid>
         <div className={styles.tags}>
           {uniqueTags.map((tag) => (
             <span key={tag} className={styles.tag}>

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -39,7 +39,7 @@ const RecipesCta: FC = () => {
     <section className={styles.section} aria-labelledby="recipes-section-title">
       <div className={styles.inner}>
         <Typography variant="heading2" id="recipes-section-title" className={styles.heading}>
-          From the Kitchen
+          Favourite Recipes
         </Typography>
         <Grid columns={3}>
           {recipes.map((recipe) => (
@@ -47,9 +47,9 @@ const RecipesCta: FC = () => {
           ))}
         </Grid>
         <Typography variant="bodyLarge" className={styles.body}>
-          Browse all recipes in the{' '}
+          A collection of my favourite recipes. Browse all{' '}
           <Link to="/recipes" underline={true}>
-            kitchen
+            recipes
           </Link>
           .
         </Typography>

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -2,7 +2,7 @@ import Grid from '@components/Grid'
 import Link from '@components/Link'
 import RecipeCard from '@components/RecipeCard'
 import Typography from '@components/Typography'
-import { FC, useEffect, useMemo, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { fetchRecipes } from '../../api/recipes'
 import type { RecipeIndex } from '../../types/recipe'
 import styles from './RecipesCta.module.css'
@@ -30,11 +30,6 @@ const RecipesCta: FC = () => {
         setStatus('error')
       })
   }, [])
-
-  const uniqueTags = useMemo(
-    () => [...new Set(recipes.flatMap((r) => r.tags))],
-    [recipes]
-  )
 
   if (status === 'empty' || status === 'error') {
     return null
@@ -73,13 +68,6 @@ const RecipesCta: FC = () => {
             <RecipeCard key={recipe.id} recipe={recipe} eager hideTags hideMeta />
           ))}
         </Grid>
-        <div className={styles.tags}>
-          {uniqueTags.map((tag) => (
-            <span key={tag} className={styles.tag}>
-              {tag}
-            </span>
-          ))}
-        </div>
         <Link to="/recipes" className={styles.link}>
           View all recipes
         </Link>

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -31,30 +31,8 @@ const RecipesCta: FC = () => {
       })
   }, [])
 
-  if (status === 'empty' || status === 'error') {
+  if (status !== 'loaded') {
     return null
-  }
-
-  if (status === 'loading') {
-    return (
-      <section className={styles.section} aria-labelledby="recipes-section-title">
-        <div className={styles.inner}>
-          <Typography variant="heading2" id="recipes-section-title" className={styles.heading}>
-            From the Kitchen
-          </Typography>
-          <div className={styles.grid}>
-            {Array.from({ length: MAX_RECIPES }, (_, i) => (
-              <div
-                key={i}
-                role="status"
-                aria-label="Loading recipe"
-                className={styles.skeleton}
-              />
-            ))}
-          </div>
-        </div>
-      </section>
-    )
   }
 
   return (

--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -1,7 +1,90 @@
-import { FC } from 'react'
+import Link from '@components/Link'
+import RecipeCard from '@components/RecipeCard'
+import Typography from '@components/Typography'
+import { FC, useEffect, useMemo, useState } from 'react'
+import { fetchRecipes } from '../../api/recipes'
+import type { RecipeIndex } from '../../types/recipe'
+import styles from './RecipesCta.module.css'
+
+type Status = 'loading' | 'loaded' | 'empty' | 'error'
+
+const MAX_RECIPES = 3
 
 const RecipesCta: FC = () => {
-  return null
+  const [recipes, setRecipes] = useState<RecipeIndex[]>([])
+  const [status, setStatus] = useState<Status>('loading')
+
+  useEffect(() => {
+    fetchRecipes()
+      .then((data) => {
+        const latest = data.slice(0, MAX_RECIPES)
+        if (latest.length === 0) {
+          setStatus('empty')
+        } else {
+          setRecipes(latest)
+          setStatus('loaded')
+        }
+      })
+      .catch(() => {
+        setStatus('error')
+      })
+  }, [])
+
+  const uniqueTags = useMemo(
+    () => [...new Set(recipes.flatMap((r) => r.tags))],
+    [recipes]
+  )
+
+  if (status === 'empty' || status === 'error') {
+    return null
+  }
+
+  if (status === 'loading') {
+    return (
+      <section className={styles.section} aria-labelledby="recipes-section-title">
+        <div className={styles.inner}>
+          <Typography variant="heading2" id="recipes-section-title" className={styles.heading}>
+            From the Kitchen
+          </Typography>
+          <div className={styles.grid}>
+            {Array.from({ length: MAX_RECIPES }, (_, i) => (
+              <div
+                key={i}
+                role="status"
+                aria-label="Loading recipe"
+                className={styles.skeleton}
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className={styles.section} aria-labelledby="recipes-section-title">
+      <div className={styles.inner}>
+        <Typography variant="heading2" id="recipes-section-title" className={styles.heading}>
+          From the Kitchen
+        </Typography>
+        <div className={styles.grid}>
+          {recipes.map((recipe) => (
+            <RecipeCard key={recipe.id} recipe={recipe} eager hideTags hideMeta />
+          ))}
+        </div>
+        <div className={styles.tags}>
+          {uniqueTags.map((tag) => (
+            <span key={tag} className={styles.tag}>
+              {tag}
+            </span>
+          ))}
+        </div>
+        <Link to="/recipes" className={styles.link}>
+          View all recipes
+        </Link>
+      </div>
+    </section>
+  )
 }
 
 export default RecipesCta

--- a/src/components/RecipesCta/index.ts
+++ b/src/components/RecipesCta/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RecipesCta'

--- a/src/contexts/RecipeDataContext.ts
+++ b/src/contexts/RecipeDataContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react'
+import type { Recipe } from '../types/recipe'
+
+export interface RecipeData {
+  recipe?: Recipe
+}
+
+export const RecipeDataContext = createContext<RecipeData>({})

--- a/src/entry-server.test.tsx
+++ b/src/entry-server.test.tsx
@@ -127,6 +127,60 @@ describe('entry-server render', () => {
     })
   })
 
+  describe('recipe detail page /recipes/:slug with prefetched data', () => {
+    const mockRecipe = {
+      id: 'r1',
+      title: 'Spaghetti Bolognese',
+      slug: 'spaghetti-bolognese',
+      coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+      tags: ['Italian', 'Pasta'],
+      prepTime: 15,
+      cookTime: 45,
+      servings: 4,
+      createdAt: '2026-03-01T12:00:00Z',
+      intro: 'A classic Italian pasta dish with rich meat sauce.',
+      ingredients: [
+        { item: 'spaghetti', quantity: '400', unit: 'g' },
+        { item: 'minced beef', quantity: '500', unit: 'g' },
+      ],
+      steps: [
+        { order: 1, text: 'Boil the pasta.' },
+        { order: 2, text: 'Brown the mince.' },
+      ],
+      authorId: 'a1',
+      authorName: 'Akli Aissat',
+      updatedAt: '2026-03-02T10:00:00Z',
+      status: 'published',
+    }
+
+    it('produces HTML containing the recipe title', async () => {
+      const html = await render('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(html).toContain('Spaghetti Bolognese')
+    })
+
+    it('produces HTML containing Open Graph meta tags for the recipe', async () => {
+      const html = await render('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(html).toContain('property="og:title" content="Spaghetti Bolognese')
+      expect(html).toContain('property="og:description"')
+      expect(html).toContain('property="og:image"')
+      expect(html).toContain('property="og:type" content="article"')
+    })
+
+    it('produces HTML containing Twitter card meta tags for the recipe', async () => {
+      const html = await render('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(html).toContain('name="twitter:card" content="summary_large_image"')
+      expect(html).toContain('name="twitter:title"')
+      expect(html).toContain('name="twitter:image"')
+    })
+
+    it('still renders without prefetched data (loading/fallback state)', async () => {
+      const html = await render('/recipes/spaghetti-bolognese')
+      expect(html).toBeTruthy()
+      expect(html).toContain('<div id="root">')
+      expect(html).not.toContain('<div id="root"></div>')
+    })
+  })
+
   describe('error handling', () => {
     it('rejects or signals an error when the render crashes', async () => {
       vi.resetModules()

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -5,6 +5,8 @@ import { PassThrough } from 'node:stream'
 import { renderToPipeableStream } from 'react-dom/server'
 import { StaticRouter } from 'react-router-dom'
 import App from './App'
+import { RecipeDataContext } from './contexts/RecipeDataContext'
+import type { RecipeData } from './contexts/RecipeDataContext'
 import { getMetaTags, escapeHtml } from './meta'
 
 // Read the client-built index.html (copied into dist/server/ by build:prod).
@@ -29,8 +31,8 @@ try {
 
 const [templateBeforeOutlet, templateAfterOutlet] = template.split('<!--ssr-outlet-->')
 
-const buildHeadHtml = (routePath: string): string => {
-  const meta = getMetaTags(routePath)
+const buildHeadHtml = (routePath: string, data?: RecipeData): string => {
+  const meta = getMetaTags(routePath, data)
   const lines: string[] = []
 
   lines.push(`<title>${escapeHtml(meta.title)}</title>`)
@@ -79,14 +81,16 @@ const buildHeadHtml = (routePath: string): string => {
 }
 
 
-export const render = (url: string): Promise<string> =>
+export const render = (url: string, data?: RecipeData): Promise<string> =>
   new Promise<string>((resolve, reject) => {
-    const head = buildHeadHtml(url)
+    const head = buildHeadHtml(url, data)
     const beforeHtml = templateBeforeOutlet.replace('<!--ssr-head-->', head)
 
     const { pipe } = renderToPipeableStream(
       <StaticRouter location={url}>
-        <App />
+        <RecipeDataContext.Provider value={data ?? {}}>
+          <App />
+        </RecipeDataContext.Provider>
       </StaticRouter>,
       {
         onAllReady() {

--- a/src/lambda-handler.ts
+++ b/src/lambda-handler.ts
@@ -1,4 +1,5 @@
 import type { Writable } from 'node:stream'
+import type { RecipeData } from './contexts/RecipeDataContext'
 import { render } from './entry-server'
 import { isKnownRoute, normalisePath } from './meta'
 
@@ -12,10 +13,26 @@ export const handler = awslambda.streamifyResponse(
     // CloudFront defaultRootObject rewrites / to /index.html
     if (rawPath === '/index.html') rawPath = '/'
     const path = normalisePath(rawPath)
-    const statusCode = isKnownRoute(path) ? 200 : 404
+    let statusCode = isKnownRoute(path) ? 200 : 404
+
+    const recipeMatch = path.match(/^\/recipes\/([^/]+)$/)
+    let recipeData: RecipeData | undefined
+
+    if (recipeMatch) {
+      try {
+        const response = await fetch(`https://api.akli.dev/recipes/${recipeMatch[1]}`)
+        if (response.ok) {
+          recipeData = { recipe: await response.json() }
+        } else if (response.status === 404) {
+          statusCode = 404
+        }
+      } catch {
+        // API unavailable — render loading state, client will retry
+      }
+    }
 
     try {
-      const html = await render(path)
+      const html = await render(path, recipeData)
       const httpStream = awslambda.HttpResponseStream.from(responseStream, {
         statusCode,
         headers: {

--- a/src/meta.test.ts
+++ b/src/meta.test.ts
@@ -30,7 +30,7 @@ vi.mock('./pages/Blog/posts/index', () => ({
   formatDate: (d: string) => d,
 }))
 
-import { getMetaTags, normalisePath, escapeHtml } from './meta'
+import { getMetaTags, normalisePath, escapeHtml, isKnownRoute } from './meta'
 
 describe('normalisePath', () => {
   it('strips trailing slash from /apps/', () => {
@@ -354,5 +354,11 @@ describe('getMetaTags', () => {
       const meta = getMetaTags('/blog/nonexistent-slug')
       expect(meta.robots).toBe('noindex')
     })
+  })
+})
+
+describe('isKnownRoute', () => {
+  it('recognises /recipes/:slug pattern', () => {
+    expect(isKnownRoute('/recipes/some-slug')).toBe(true)
   })
 })

--- a/src/meta.test.ts
+++ b/src/meta.test.ts
@@ -355,6 +355,89 @@ describe('getMetaTags', () => {
       expect(meta.robots).toBe('noindex')
     })
   })
+
+  describe('recipe detail route /recipes/<slug> with recipe data', () => {
+    const mockRecipe = {
+      id: 'r1',
+      title: 'Spaghetti Bolognese',
+      slug: 'spaghetti-bolognese',
+      coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+      tags: ['Italian', 'Pasta'],
+      prepTime: 15,
+      cookTime: 45,
+      servings: 4,
+      createdAt: '2026-03-01T12:00:00Z',
+      intro: 'A classic Italian pasta dish with rich meat sauce.',
+      ingredients: [
+        { item: 'spaghetti', quantity: '400', unit: 'g' },
+        { item: 'minced beef', quantity: '500', unit: 'g' },
+      ],
+      steps: [
+        { order: 1, text: 'Boil the pasta.' },
+        { order: 2, text: 'Brown the mince.' },
+      ],
+      authorId: 'a1',
+      authorName: 'Akli Aissat',
+      updatedAt: '2026-03-02T10:00:00Z',
+      status: 'published',
+    }
+
+    const longIntroRecipe = {
+      ...mockRecipe,
+      slug: 'long-intro-recipe',
+      intro:
+        'This is a very long introduction that exceeds one hundred and sixty characters in length so we can verify that the description is properly truncated when generating Open Graph meta tags for social sharing previews on various platforms.',
+    }
+
+    it('returns og:title matching the recipe title', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.og.title).toBe('Spaghetti Bolognese | Akli Aissat')
+    })
+
+    it('returns og:description from the recipe intro', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.og.description).toBe('A classic Italian pasta dish with rich meat sauce.')
+    })
+
+    it('returns og:description truncated to 160 chars when intro is longer', () => {
+      const meta = getMetaTags('/recipes/long-intro-recipe', { recipe: longIntroRecipe })
+      expect(meta.og.description.length).toBeLessThanOrEqual(160)
+    })
+
+    it('returns og:image with cover medium URL', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.og.image).toBeDefined()
+      expect(meta.og.image).toContain('spaghetti-cover')
+      expect(meta.og.image).toContain('-medium')
+    })
+
+    it('returns og:type as article', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.og.type).toBe('article')
+    })
+
+    it('returns twitter:card as summary_large_image', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.twitter.card).toBe('summary_large_image')
+    })
+
+    it('returns twitter:title matching the recipe title', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.twitter.title).toBe('Spaghetti Bolognese | Akli Aissat')
+    })
+
+    it('returns twitter:description from the recipe intro', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.twitter.description).toBe('A classic Italian pasta dish with rich meat sauce.')
+    })
+
+    it('returns twitter:image with cover medium URL', () => {
+      const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
+      expect(meta.twitter.image).toBeDefined()
+      expect(meta.twitter.image).toContain('spaghetti-cover')
+      expect(meta.twitter.image).toContain('-medium')
+    })
+  })
 })
 
 describe('isKnownRoute', () => {

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -38,6 +38,10 @@ const routeMeta: Record<string, { title: string; description: string }> = {
     description:
       'Articles on web development, engineering, and lessons learned building software.',
   },
+  '/recipes': {
+    title: 'Recipes | Akli Aissat',
+    description: 'Browse recipes for delicious home-cooked meals.',
+  },
 }
 
 const notFoundMeta = {
@@ -68,6 +72,8 @@ export const isKnownRoute = (path: string): boolean => {
     const post = postsModule.getPost(blogPostMatch[1])
     return !!post
   }
+  const recipeMatch = path.match(/^\/recipes\/(.+)$/)
+  if (recipeMatch) return true
   return false
 }
 

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -18,6 +18,7 @@ export interface MetaTags {
   }
 }
 
+import type { RecipeData } from './contexts/RecipeDataContext'
 import * as postsModule from './pages/Blog/posts/index'
 
 const BASE_URL = 'https://akli.dev'
@@ -107,7 +108,7 @@ const buildMetaTags = (
   }
 }
 
-export const getMetaTags = (path: string): MetaTags => {
+export const getMetaTags = (path: string, data?: RecipeData): MetaTags => {
   const normalised = normalisePath(path)
   const route = routeMeta[normalised]
   const canonical = `${BASE_URL}${normalised}`
@@ -130,6 +131,23 @@ export const getMetaTags = (path: string): MetaTags => {
         post.image,
       )
     }
+  }
+
+  const recipeMatch = normalised.match(/^\/recipes\/(.+)$/)
+  if (recipeMatch && data?.recipe) {
+    const recipe = data.recipe
+    const description = recipe.intro.length > 160
+      ? recipe.intro.slice(0, 157) + '...'
+      : recipe.intro
+    const coverMediumPath = `/images/${recipe.coverImage.key}-medium.webp`
+    return buildMetaTags(
+      `${recipe.title} | Akli Aissat`,
+      description,
+      canonical,
+      undefined,
+      'article',
+      coverMediumPath,
+    )
   }
 
   return buildMetaTags(notFoundMeta.title, notFoundMeta.description, canonical, 'noindex')

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -2,6 +2,7 @@ import AppsCta from '@components/AppsCta'
 import CVDownload from '@components/CVDownload'
 import FullPageHeader from '@components/FullPageHeader'
 import type { FullPageHeaderProps } from '@components/FullPageHeader'
+import RecipesCta from '@components/RecipesCta'
 import img from '../../assets/profile.webp'
 
 const FULL_PAGE_HEADER_PROPS: FullPageHeaderProps = {
@@ -18,6 +19,7 @@ export default function Home() {
       <FullPageHeader {...FULL_PAGE_HEADER_PROPS} />
       <CVDownload />
       <AppsCta />
+      <RecipesCta />
     </>
   )
 }

--- a/src/pages/RecipeDetail/RecipeDetail.module.css
+++ b/src/pages/RecipeDetail/RecipeDetail.module.css
@@ -64,7 +64,7 @@
 
 .tag:hover {
   background: var(--color-primary);
-  color: var(--color-text-on-primary);
+  color: var(--color-on-primary);
 }
 
 .tag:focus-visible {

--- a/src/pages/RecipeDetail/RecipeDetail.module.css
+++ b/src/pages/RecipeDetail/RecipeDetail.module.css
@@ -1,0 +1,100 @@
+.page {
+  max-width: var(--max-w-site);
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-4);
+}
+
+.coverImage {
+  display: block;
+  width: 100%;
+  max-width: var(--max-w-site);
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: var(--radius-none);
+  border: var(--border-width) solid var(--color-border);
+  margin-block-end: var(--space-6);
+}
+
+.title {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  margin: 0 0 var(--space-3);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin-block-end: var(--space-3);
+}
+
+.metaBar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin-block-end: var(--space-4);
+}
+
+.separator {
+  font-weight: var(--font-weight-bold);
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-block-end: var(--space-6);
+}
+
+.tag {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  background: var(--color-bg-subtle);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.tag:hover {
+  background: var(--color-primary);
+  color: var(--color-text-on-primary);
+}
+
+.tag:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.intro {
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-relaxed);
+  margin-block-end: var(--space-8);
+}
+
+.sectionHeading {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  margin: 0 0 var(--space-4);
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-12);
+  color: var(--color-text-muted);
+}
+
+.error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-12);
+}

--- a/src/pages/RecipeDetail/RecipeDetail.module.css
+++ b/src/pages/RecipeDetail/RecipeDetail.module.css
@@ -4,6 +4,10 @@
   padding: var(--space-6) var(--space-4);
 }
 
+.coverImageWrapper {
+  margin-block-end: var(--space-10);
+}
+
 .coverImage {
   display: block;
   width: 100%;
@@ -12,7 +16,7 @@
   object-fit: cover;
   border-radius: var(--radius-none);
   border: var(--border-width) solid var(--color-border);
-  margin-block-end: var(--space-6);
+  margin-block-end: var(--space-10);
 }
 
 .title {
@@ -76,6 +80,10 @@
   font-size: var(--font-size-lg);
   line-height: var(--line-height-relaxed);
   margin-block-end: var(--space-8);
+}
+
+.section {
+  margin-block-end: var(--space-10);
 }
 
 .sectionHeading {

--- a/src/pages/RecipeDetail/RecipeDetail.module.css
+++ b/src/pages/RecipeDetail/RecipeDetail.module.css
@@ -26,27 +26,6 @@
   margin: 0 0 var(--space-3);
 }
 
-.meta {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-  margin-block-end: var(--space-3);
-}
-
-.metaBar {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-  margin-block-end: var(--space-4);
-}
-
-.separator {
-  font-weight: var(--font-weight-bold);
-}
 
 .tags {
   display: flex;

--- a/src/pages/RecipeDetail/RecipeDetail.test.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+vi.mock('../../api/recipes', () => ({
+  fetchRecipe: vi.fn(),
+}))
+
+import { fetchRecipe } from '../../api/recipes'
+import { RecipeDataContext } from '../../contexts/RecipeDataContext'
+import type { Recipe } from '../../types/recipe'
+import RecipeDetail from './RecipeDetail'
+
+const mockRecipe: Recipe = {
+  id: 'recipe-1',
+  title: 'Test Recipe',
+  slug: 'test-recipe',
+  intro: 'A delicious test recipe',
+  coverImage: { key: 'processed/recipes/recipe-1/cover', alt: 'Test cover' },
+  ingredients: [
+    { item: 'flour', quantity: '200', unit: 'g' },
+    { item: 'sugar', quantity: '100', unit: 'g' },
+  ],
+  steps: [
+    {
+      order: 1,
+      text: 'Mix ingredients',
+      image: { key: 'processed/recipes/recipe-1/step-1', alt: 'Mixing' },
+    },
+    { order: 2, text: 'Bake for 30 minutes' },
+  ],
+  tags: ['Baking', 'Dessert'],
+  prepTime: 15,
+  cookTime: 30,
+  servings: 4,
+  authorId: 'user-1',
+  authorName: 'Akli',
+  createdAt: '2026-04-10T12:00:00Z',
+  updatedAt: '2026-04-10T12:00:00Z',
+  status: 'published',
+}
+
+const renderRecipeDetail = (recipe?: Recipe) =>
+  render(
+    <RecipeDataContext.Provider value={{ recipe }}>
+      <MemoryRouter initialEntries={['/recipes/test-recipe']}>
+        <Routes>
+          <Route path="/recipes/:slug" element={<RecipeDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </RecipeDataContext.Provider>
+  )
+
+describe('RecipeDetail page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('renders full recipe content when SSR data is in context', () => {
+    renderRecipeDetail(mockRecipe)
+
+    // Cover image
+    const coverImg = screen.getByRole('img', { name: 'Test cover' })
+    expect(coverImg).toBeInTheDocument()
+
+    // Title
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Test Recipe' })
+    ).toBeInTheDocument()
+
+    // Author and date
+    expect(screen.getByText(/Akli/)).toBeInTheDocument()
+    expect(screen.getByText(/10 April 2026/i)).toBeInTheDocument()
+
+    // Ingredients
+    expect(screen.getByText(/flour/)).toBeInTheDocument()
+    expect(screen.getByText(/sugar/)).toBeInTheDocument()
+
+    // Steps
+    expect(screen.getByText('Mix ingredients')).toBeInTheDocument()
+    expect(screen.getByText('Bake for 30 minutes')).toBeInTheDocument()
+
+    // Tags
+    expect(screen.getByText('Baking')).toBeInTheDocument()
+    expect(screen.getByText('Dessert')).toBeInTheDocument()
+  })
+
+  it('renders cover image with srcSet containing medium and full variants', () => {
+    renderRecipeDetail(mockRecipe)
+
+    const coverImg = screen.getByRole('img', { name: 'Test cover' })
+    const srcSet = coverImg.getAttribute('srcSet') ?? coverImg.getAttribute('srcset')
+    expect(srcSet).toContain('medium')
+    expect(srcSet).toContain('full')
+    expect(coverImg).toHaveAttribute('loading', 'eager')
+  })
+
+  it('renders tags as links to /recipes?tag=X', () => {
+    renderRecipeDetail(mockRecipe)
+
+    const bakingLink = screen.getByRole('link', { name: 'Baking' })
+    expect(bakingLink).toHaveAttribute('href', '/recipes?tag=Baking')
+
+    const dessertLink = screen.getByRole('link', { name: 'Dessert' })
+    expect(dessertLink).toHaveAttribute('href', '/recipes?tag=Dessert')
+  })
+
+  it('fetches from API on client-side navigation when context is empty', async () => {
+    vi.mocked(fetchRecipe).mockResolvedValue(mockRecipe)
+
+    renderRecipeDetail(undefined)
+
+    await waitFor(() => {
+      expect(fetchRecipe).toHaveBeenCalledWith('test-recipe')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Recipe')).toBeInTheDocument()
+    })
+  })
+
+  it('shows 404 for non-existent slug', async () => {
+    vi.mocked(fetchRecipe).mockRejectedValue(new Error('404 Not Found'))
+
+    renderRecipeDetail(undefined)
+
+    await waitFor(() => {
+      expect(screen.getByText(/not found/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error state with retry button on API failure', async () => {
+    vi.mocked(fetchRecipe).mockRejectedValue(
+      new Error('500 Internal Server Error')
+    )
+
+    renderRecipeDetail(undefined)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+  })
+
+  it('uses SSR data from context without calling fetchRecipe', () => {
+    renderRecipeDetail(mockRecipe)
+
+    expect(screen.getByText('Test Recipe')).toBeInTheDocument()
+    expect(fetchRecipe).not.toHaveBeenCalled()
+  })
+})

--- a/src/pages/RecipeDetail/RecipeDetail.test.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 vi.mock('../../api/recipes', () => ({

--- a/src/pages/RecipeDetail/RecipeDetail.test.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.test.tsx
@@ -67,8 +67,7 @@ describe('RecipeDetail page', () => {
       screen.getByRole('heading', { level: 1, name: 'Test Recipe' })
     ).toBeInTheDocument()
 
-    // Author and date
-    expect(screen.getByText(/Akli/)).toBeInTheDocument()
+    // Date and metadata
     expect(screen.getByText(/10 April 2026/i)).toBeInTheDocument()
 
     // Ingredients

--- a/src/pages/RecipeDetail/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.tsx
@@ -1,5 +1,6 @@
 import Button from '@components/Button'
 import Image from '@components/Image'
+import Typography from '@components/Typography'
 import NotFound from '@pages/NotFound'
 import { useContext, useEffect, useState, type FC } from 'react'
 import { Link, useParams } from 'react-router-dom'
@@ -122,7 +123,7 @@ const RecipeDetail: FC = () => {
         className={styles.coverImage}
       />
 
-      <h1 className={styles.title}>{recipe.title}</h1>
+      <Typography variant="heading1" className={styles.title}>{recipe.title}</Typography>
 
       <div className={styles.meta}>
         <span>{recipe.authorName}</span>
@@ -146,15 +147,15 @@ const RecipeDetail: FC = () => {
         ))}
       </div>
 
-      <p className={styles.intro}>{recipe.intro}</p>
+      <Typography variant="bodyLarge" className={styles.intro}>{recipe.intro}</Typography>
 
       <section>
-        <h2 className={styles.sectionHeading}>Ingredients</h2>
+        <Typography variant="heading2" className={styles.sectionHeading}>Ingredients</Typography>
         <RecipeIngredients ingredients={recipe.ingredients} />
       </section>
 
       <section>
-        <h2 className={styles.sectionHeading}>Method</h2>
+        <Typography variant="heading2" className={styles.sectionHeading}>Method</Typography>
         <RecipeSteps steps={recipe.steps} />
       </section>
     </article>

--- a/src/pages/RecipeDetail/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.tsx
@@ -1,0 +1,3 @@
+const RecipeDetail = () => <div>Recipe detail page</div>
+
+export default RecipeDetail

--- a/src/pages/RecipeDetail/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.tsx
@@ -1,3 +1,162 @@
-const RecipeDetail = () => <div>Recipe detail page</div>
+import Button from '@components/Button'
+import NotFound from '@pages/NotFound'
+import { useContext, useEffect, useState, type FC } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { fetchRecipe } from '../../api/recipes'
+import RecipeIngredients from '../../components/RecipeIngredients'
+import RecipeSteps from '../../components/RecipeSteps'
+import { RecipeDataContext } from '../../contexts/RecipeDataContext'
+import type { Recipe } from '../../types/recipe'
+import styles from './RecipeDetail.module.css'
+
+const IMAGE_BASE = 'https://akli.dev/images'
+
+const formatDate = (dateString: string): string => {
+  const date = new Date(dateString)
+  return date.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+const RecipeDetail: FC = () => {
+  const { slug } = useParams<{ slug: string }>()
+  const { recipe: ssrRecipe } = useContext(RecipeDataContext)
+
+  const [recipe, setRecipe] = useState<Recipe | undefined>(ssrRecipe)
+  const [loading, setLoading] = useState(!ssrRecipe)
+  const [error, setError] = useState<string | undefined>()
+  const [notFound, setNotFound] = useState(false)
+
+  useEffect(() => {
+    if (ssrRecipe || !slug) return
+
+    let cancelled = false
+
+    const load = async () => {
+      setLoading(true)
+      setError(undefined)
+      setNotFound(false)
+      try {
+        const data = await fetchRecipe(slug)
+        if (!cancelled) {
+          setRecipe(data)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : 'Unknown error'
+          if (message.includes('404')) {
+            setNotFound(true)
+          } else {
+            setError(message)
+          }
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    load()
+
+    return () => {
+      cancelled = true
+    }
+  }, [slug, ssrRecipe])
+
+  if (notFound) return <NotFound />
+
+  if (loading) {
+    return (
+      <div className={styles.loading} role="status" aria-label="Loading">
+        Loading...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className={styles.error}>
+        <p>Something went wrong loading this recipe.</p>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            setError(undefined)
+            setLoading(true)
+            setNotFound(false)
+            if (slug) {
+              fetchRecipe(slug)
+                .then(setRecipe)
+                .catch((err) => {
+                  const message =
+                    err instanceof Error ? err.message : 'Unknown error'
+                  if (message.includes('404')) {
+                    setNotFound(true)
+                  } else {
+                    setError(message)
+                  }
+                })
+                .finally(() => setLoading(false))
+            }
+          }}
+        >
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  if (!recipe) return null
+
+  return (
+    <article className={styles.page}>
+      <img
+        srcSet={`${IMAGE_BASE}/${recipe.coverImage.key}-medium.webp 800w, ${IMAGE_BASE}/${recipe.coverImage.key}-full.webp 1200w`}
+        src={`${IMAGE_BASE}/${recipe.coverImage.key}-medium.webp`}
+        alt={recipe.coverImage.alt}
+        loading="eager"
+        className={styles.coverImage}
+      />
+
+      <h1 className={styles.title}>{recipe.title}</h1>
+
+      <div className={styles.meta}>
+        <span>{recipe.authorName}</span>
+        <span className={styles.separator}>·</span>
+        <time dateTime={recipe.createdAt}>{formatDate(recipe.createdAt)}</time>
+      </div>
+
+      <div className={styles.metaBar}>
+        <span>Prep: {recipe.prepTime} min</span>
+        <span className={styles.separator}>·</span>
+        <span>Cook: {recipe.cookTime} min</span>
+        <span className={styles.separator}>·</span>
+        <span>Serves: {recipe.servings}</span>
+      </div>
+
+      <div className={styles.tags}>
+        {recipe.tags.map((tag) => (
+          <Link key={tag} to={`/recipes?tag=${tag}`} className={styles.tag}>
+            {tag}
+          </Link>
+        ))}
+      </div>
+
+      <p className={styles.intro}>{recipe.intro}</p>
+
+      <section>
+        <h2 className={styles.sectionHeading}>Ingredients</h2>
+        <RecipeIngredients ingredients={recipe.ingredients} />
+      </section>
+
+      <section>
+        <h2 className={styles.sectionHeading}>Method</h2>
+        <RecipeSteps steps={recipe.steps} />
+      </section>
+    </article>
+  )
+}
 
 export default RecipeDetail

--- a/src/pages/RecipeDetail/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.tsx
@@ -121,23 +121,14 @@ const RecipeDetail: FC = () => {
         priority
         maxWidth="var(--max-w-site)"
         className={styles.coverImage}
+        containerClassName={styles.coverImageWrapper}
       />
 
       <Typography variant="heading1" className={styles.title}>{recipe.title}</Typography>
 
-      <div className={styles.meta}>
-        <span>{recipe.authorName}</span>
-        <span className={styles.separator}>·</span>
-        <time dateTime={recipe.createdAt}>{formatDate(recipe.createdAt)}</time>
-      </div>
-
-      <div className={styles.metaBar}>
-        <span>Prep: {recipe.prepTime} min</span>
-        <span className={styles.separator}>·</span>
-        <span>Cook: {recipe.cookTime} min</span>
-        <span className={styles.separator}>·</span>
-        <span>Serves: {recipe.servings}</span>
-      </div>
+      <Typography variant="body">
+        <time dateTime={recipe.createdAt}>{formatDate(recipe.createdAt)}</time> · {recipe.prepTime} min prep · {recipe.cookTime} min cook · Serves {recipe.servings}
+      </Typography>
 
       <div className={styles.tags}>
         {recipe.tags.map((tag) => (
@@ -149,12 +140,12 @@ const RecipeDetail: FC = () => {
 
       <Typography variant="bodyLarge" className={styles.intro}>{recipe.intro}</Typography>
 
-      <section>
+      <section className={styles.section}>
         <Typography variant="heading2" className={styles.sectionHeading}>Ingredients</Typography>
         <RecipeIngredients ingredients={recipe.ingredients} />
       </section>
 
-      <section>
+      <section className={styles.section}>
         <Typography variant="heading2" className={styles.sectionHeading}>Method</Typography>
         <RecipeSteps steps={recipe.steps} />
       </section>

--- a/src/pages/RecipeDetail/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.tsx
@@ -1,5 +1,6 @@
 import Button from '@components/Button'
 import Image from '@components/Image'
+import Loading from '@components/Loading'
 import Typography from '@components/Typography'
 import NotFound from '@pages/NotFound'
 import { useContext, useEffect, useState, type FC } from 'react'
@@ -8,10 +9,9 @@ import { fetchRecipe } from '../../api/recipes'
 import RecipeIngredients from '../../components/RecipeIngredients'
 import RecipeSteps from '../../components/RecipeSteps'
 import { RecipeDataContext } from '../../contexts/RecipeDataContext'
-import type { Recipe } from '../../types/recipe'
+import { RECIPE_IMAGE_BASE, type Recipe } from '../../types/recipe'
 import styles from './RecipeDetail.module.css'
 
-const IMAGE_BASE = 'https://akli.dev/images'
 
 const formatDate = (dateString: string): string => {
   const date = new Date(dateString)
@@ -72,8 +72,8 @@ const RecipeDetail: FC = () => {
 
   if (loading) {
     return (
-      <div className={styles.loading} role="status" aria-label="Loading">
-        Loading...
+      <div className={styles.loading}>
+        <Loading />
       </div>
     )
   }
@@ -115,8 +115,8 @@ const RecipeDetail: FC = () => {
   return (
     <article className={styles.page}>
       <Image
-        src={`${IMAGE_BASE}/${recipe.coverImage.key}-medium.webp`}
-        srcSet={`${IMAGE_BASE}/${recipe.coverImage.key}-medium.webp 800w, ${IMAGE_BASE}/${recipe.coverImage.key}-full.webp 1200w`}
+        src={`${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-medium.webp`}
+        srcSet={`${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-medium.webp 800w, ${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-full.webp 1200w`}
         alt={recipe.coverImage.alt}
         priority
         maxWidth="var(--max-w-site)"

--- a/src/pages/RecipeDetail/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.tsx
@@ -1,4 +1,5 @@
 import Button from '@components/Button'
+import Image from '@components/Image'
 import NotFound from '@pages/NotFound'
 import { useContext, useEffect, useState, type FC } from 'react'
 import { Link, useParams } from 'react-router-dom'
@@ -112,11 +113,12 @@ const RecipeDetail: FC = () => {
 
   return (
     <article className={styles.page}>
-      <img
-        srcSet={`${IMAGE_BASE}/${recipe.coverImage.key}-medium.webp 800w, ${IMAGE_BASE}/${recipe.coverImage.key}-full.webp 1200w`}
+      <Image
         src={`${IMAGE_BASE}/${recipe.coverImage.key}-medium.webp`}
+        srcSet={`${IMAGE_BASE}/${recipe.coverImage.key}-medium.webp 800w, ${IMAGE_BASE}/${recipe.coverImage.key}-full.webp 1200w`}
         alt={recipe.coverImage.alt}
-        loading="eager"
+        priority
+        maxWidth="var(--max-w-site)"
         className={styles.coverImage}
       />
 

--- a/src/pages/RecipeDetail/index.ts
+++ b/src/pages/RecipeDetail/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RecipeDetail'

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -1,3 +1,7 @@
+.page {
+  padding-block-end: var(--space-12);
+}
+
 .heading {
   margin-block-end: var(--space-2);
 }

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -1,0 +1,110 @@
+.heading {
+  margin-block-end: var(--space-2);
+}
+
+.intro {
+  margin-block-end: var(--space-8);
+}
+
+.grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-6);
+}
+
+@media (min-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.gridItem {
+  list-style: none;
+}
+
+.skeleton {
+  aspect-ratio: 3 / 4;
+  background: var(--color-surface-alt);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}
+
+.empty {
+  text-align: center;
+  padding: var(--space-12) 0;
+}
+
+.retryButton {
+  margin-block-start: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-on-primary);
+  background: var(--color-primary);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  cursor: pointer;
+}
+
+.retryButton:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.clearButton {
+  display: inline-block;
+  margin-block-start: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  color: var(--color-link);
+  font-weight: var(--font-weight-semibold);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.clearButton:hover {
+  color: var(--color-link-hover);
+}
+
+.clearButton:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -60,43 +60,6 @@
   padding: var(--space-12) 0;
 }
 
-.retryButton {
-  margin-block-start: var(--space-4);
-  padding: var(--space-2) var(--space-4);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-on-primary);
-  background: var(--color-primary);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-none);
-  cursor: pointer;
-}
-
-.retryButton:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-  outline-offset: 2px;
-}
-
-.clearButton {
-  display: inline-block;
-  margin-block-start: var(--space-4);
-  padding: var(--space-2) var(--space-4);
-  color: var(--color-link);
-  font-weight: var(--font-weight-semibold);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-.clearButton:hover {
-  color: var(--color-link-hover);
-}
-
-.clearButton:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-  outline-offset: 2px;
-}
-
 .srOnly {
   position: absolute;
   width: 1px;

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -6,6 +6,12 @@
   margin-block-end: var(--space-8);
 }
 
+.loadingWrapper {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-12) 0;
+}
+
 .empty {
   text-align: center;
   padding: var(--space-12) 0;

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -27,10 +27,6 @@
   }
 }
 
-.gridItem {
-  list-style: none;
-}
-
 .skeleton {
   aspect-ratio: 3 / 4;
   background: var(--color-bg-subtle);

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -6,51 +6,6 @@
   margin-block-end: var(--space-8);
 }
 
-.grid {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-6);
-}
-
-@media (min-width: 640px) {
-  .grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (min-width: 1024px) {
-  .grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-.skeleton {
-  aspect-ratio: 3 / 4;
-  background: var(--color-bg-subtle);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-none);
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .skeleton {
-    animation: none;
-  }
-}
-
 .empty {
   text-align: center;
   padding: var(--space-12) 0;

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -33,7 +33,7 @@
 
 .skeleton {
   aspect-ratio: 3 / 4;
-  background: var(--color-surface-alt);
+  background: var(--color-bg-subtle);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-none);
   animation: pulse 1.5s ease-in-out infinite;

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import Recipes from './Recipes'
+import type { RecipeIndex, Tag } from '../../types/recipe'
+
+vi.mock('../../api/recipes', () => ({
+  fetchRecipes: vi.fn(),
+  fetchTags: vi.fn(),
+}))
+
+import { fetchRecipes, fetchTags } from '../../api/recipes'
+
+const mockRecipes: RecipeIndex[] = [
+  {
+    id: 'rec-001',
+    title: 'Classic Margherita Pizza',
+    slug: 'classic-margherita-pizza',
+    coverImage: { key: 'recipes/rec-001/cover', alt: 'Margherita pizza' },
+    tags: ['Italian', 'Quick'],
+    prepTime: 15,
+    cookTime: 12,
+    servings: 4,
+    createdAt: '2026-03-20T10:00:00Z',
+  },
+  {
+    id: 'rec-002',
+    title: 'Thai Green Curry',
+    slug: 'thai-green-curry',
+    coverImage: { key: 'recipes/rec-002/cover', alt: 'Thai green curry' },
+    tags: ['Thai', 'Spicy'],
+    prepTime: 20,
+    cookTime: 25,
+    servings: 2,
+    createdAt: '2026-03-18T10:00:00Z',
+  },
+  {
+    id: 'rec-003',
+    title: 'Italian Pasta Carbonara',
+    slug: 'italian-pasta-carbonara',
+    coverImage: { key: 'recipes/rec-003/cover', alt: 'Pasta carbonara' },
+    tags: ['Italian'],
+    prepTime: 10,
+    cookTime: 15,
+    servings: 3,
+    createdAt: '2026-03-15T10:00:00Z',
+  },
+]
+
+const mockTags: Tag[] = [
+  { tag: 'Italian', count: 2 },
+  { tag: 'Quick', count: 1 },
+  { tag: 'Thai', count: 1 },
+  { tag: 'Spicy', count: 1 },
+]
+
+const renderRecipes = (initialRoute = '/recipes') =>
+  render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <Recipes />
+    </MemoryRouter>
+  )
+
+describe('Recipes page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(fetchRecipes).mockResolvedValue(mockRecipes)
+    vi.mocked(fetchTags).mockResolvedValue(mockTags)
+  })
+
+  it('renders recipe grid after loading', async () => {
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Thai Green Curry')).toBeInTheDocument()
+    expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
+  })
+
+  it('shows skeleton placeholders while loading', () => {
+    vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
+    vi.mocked(fetchTags).mockReturnValue(new Promise(() => {}))
+
+    renderRecipes()
+
+    const skeletons = screen.getAllByRole('status', { name: /loading/i })
+    expect(skeletons.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('filters by tag via URL search param (?tag=Italian)', async () => {
+    renderRecipes('/recipes?tag=Italian')
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
+    expect(screen.queryByText('Thai Green Curry')).not.toBeInTheDocument()
+  })
+
+  it('searches by keyword (title match)', async () => {
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(searchInput, { target: { value: 'curry' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('Thai Green Curry')).toBeInTheDocument()
+      expect(screen.queryByText('Classic Margherita Pizza')).not.toBeInTheDocument()
+    })
+  })
+
+  it('applies combined tag + search filtering', async () => {
+    renderRecipes('/recipes?tag=Italian')
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(searchInput, { target: { value: 'carbonara' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
+      expect(screen.queryByText('Classic Margherita Pizza')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows "No recipes found" with clear button when filter has no matches', async () => {
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    const searchInput = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(searchInput, { target: { value: 'nonexistent dish xyz' } })
+
+    await waitFor(() => {
+      expect(screen.getByText(/no recipes found/i)).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
+  })
+
+  it('shows "Recipes coming soon" when no recipes exist', async () => {
+    vi.mocked(fetchRecipes).mockResolvedValue([])
+    vi.mocked(fetchTags).mockResolvedValue([])
+
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText(/recipes coming soon/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error state with retry button when API fails', async () => {
+    vi.mocked(fetchRecipes).mockRejectedValue(new Error('500 Internal Server Error'))
+    vi.mocked(fetchTags).mockRejectedValue(new Error('500 Internal Server Error'))
+
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+  })
+
+  it('has aria-live region for recipe count', async () => {
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    const liveRegion = screen.getByRole('status')
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite')
+  })
+})

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -1,15 +1,14 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import Recipes from './Recipes'
-import type { RecipeIndex, Tag } from '../../types/recipe'
-
 vi.mock('../../api/recipes', () => ({
   fetchRecipes: vi.fn(),
   fetchTags: vi.fn(),
 }))
 
 import { fetchRecipes, fetchTags } from '../../api/recipes'
+import type { RecipeIndex, Tag } from '../../types/recipe'
+import Recipes from './Recipes'
 
 const mockRecipes: RecipeIndex[] = [
   {

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -77,16 +77,14 @@ describe('Recipes page', () => {
     expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
   })
 
-  it('shows skeleton placeholders while loading', async () => {
+  it('shows skeleton placeholders while loading', () => {
     vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
     vi.mocked(fetchTags).mockReturnValue(new Promise(() => {}))
 
     renderRecipes()
 
-    await waitFor(() => {
-      const skeletons = screen.getAllByRole('status', { name: /loading/i })
-      expect(skeletons.length).toBeGreaterThanOrEqual(1)
-    })
+    const skeletons = screen.getAllByRole('status', { name: /loading/i })
+    expect(skeletons.length).toBeGreaterThanOrEqual(1)
   })
 
   it('filters by tag via URL search param (?tag=Italian)', async () => {

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -77,14 +77,16 @@ describe('Recipes page', () => {
     expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
   })
 
-  it('shows skeleton placeholders while loading', () => {
+  it('shows skeleton placeholders while loading', async () => {
     vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
     vi.mocked(fetchTags).mockReturnValue(new Promise(() => {}))
 
     renderRecipes()
 
-    const skeletons = screen.getAllByRole('status', { name: /loading/i })
-    expect(skeletons.length).toBeGreaterThanOrEqual(1)
+    await waitFor(() => {
+      const skeletons = screen.getAllByRole('status', { name: /loading/i })
+      expect(skeletons.length).toBeGreaterThanOrEqual(1)
+    })
   })
 
   it('filters by tag via URL search param (?tag=Italian)', async () => {

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -77,14 +77,13 @@ describe('Recipes page', () => {
     expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
   })
 
-  it('shows skeleton placeholders while loading', () => {
+  it('shows loading indicator while fetching', () => {
     vi.mocked(fetchRecipes).mockReturnValue(new Promise(() => {}))
     vi.mocked(fetchTags).mockReturnValue(new Promise(() => {}))
 
     renderRecipes()
 
-    const skeletons = screen.getAllByRole('status', { name: /loading/i })
-    expect(skeletons.length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
   })
 
   it('filters by tag via URL search param (?tag=Italian)', async () => {

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,5 +1,6 @@
 import Button from '@components/Button'
 import Grid from '@components/Grid'
+import Loading from '@components/Loading'
 import Typography from '@components/Typography'
 import { useState, useEffect, useCallback, useMemo, type FC } from 'react'
 import { useSearchParams } from 'react-router-dom'
@@ -69,16 +70,7 @@ const Recipes: FC = () => {
         <Typography variant="heading1" className={styles.heading}>
           Recipes
         </Typography>
-        <div className={styles.grid}>
-          {Array.from({ length: 6 }, (_, i) => (
-            <div
-              key={i}
-              className={styles.skeleton}
-              role="status"
-              aria-label="Loading"
-            />
-          ))}
-        </div>
+        <Loading />
       </>
     )
   }

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,5 +1,5 @@
 import Typography from '@components/Typography'
-import { useState, useEffect, useCallback, type FC } from 'react'
+import { useState, useEffect, useCallback, useMemo, type FC } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { fetchRecipes, fetchTags } from '../../api/recipes'
 import RecipeCard from '../../components/RecipeCard'
@@ -53,13 +53,17 @@ const Recipes: FC = () => {
     setSearchQuery('')
   }
 
-  const filteredRecipes = recipes.filter((recipe) => {
-    const matchesTag = !activeTag || recipe.tags.includes(activeTag)
-    const matchesSearch =
-      !searchQuery ||
-      recipe.title.toLowerCase().includes(searchQuery.toLowerCase())
-    return matchesTag && matchesSearch
-  })
+  const filteredRecipes = useMemo(
+    () =>
+      recipes.filter((recipe) => {
+        const matchesTag = !activeTag || recipe.tags.includes(activeTag)
+        const matchesSearch =
+          !searchQuery ||
+          recipe.title.toLowerCase().includes(searchQuery.toLowerCase())
+        return matchesTag && matchesSearch
+      }),
+    [recipes, activeTag, searchQuery],
+  )
 
   if (loading) {
     return (

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -23,7 +23,10 @@ const Recipes: FC = () => {
   const loadData = useCallback(async () => {
     setError(false)
     try {
-      const [recipesData, tagsData] = await Promise.all([fetchRecipes(), fetchTags()])
+      const [recipesData, tagsData] = await Promise.all([
+        fetchRecipes(),
+        fetchTags(),
+      ])
       setRecipes(recipesData)
       setTags(tagsData)
     } catch {
@@ -61,7 +64,7 @@ const Recipes: FC = () => {
           recipe.title.toLowerCase().includes(searchQuery.toLowerCase())
         return matchesTag && matchesSearch
       }),
-    [recipes, activeTag, searchQuery],
+    [recipes, activeTag, searchQuery]
   )
 
   if (recipes === null && !error) {
@@ -115,11 +118,16 @@ const Recipes: FC = () => {
         A collection of tried-and-tested recipes from my kitchen.
       </Typography>
 
-      <RecipeSearch onSearch={handleSearch} />
-      <RecipeTagFilter tags={tags} activeTag={activeTag} onTagClick={handleTagClick} />
+      <RecipeSearch value={searchQuery} onSearch={handleSearch} />
+      <RecipeTagFilter
+        tags={tags}
+        activeTag={activeTag}
+        onTagClick={handleTagClick}
+      />
 
       <div role="status" aria-live="polite" className={styles.srOnly}>
-        {filteredRecipes.length} {filteredRecipes.length === 1 ? 'recipe' : 'recipes'} found
+        {filteredRecipes.length}{' '}
+        {filteredRecipes.length === 1 ? 'recipe' : 'recipes'} found
       </div>
 
       {filteredRecipes.length === 0 ? (

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -14,16 +14,12 @@ const Recipes: FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTag = searchParams.get('tag')
 
-  const [recipes, setRecipes] = useState<RecipeIndex[]>([])
+  const [recipes, setRecipes] = useState<RecipeIndex[] | null>(null)
   const [tags, setTags] = useState<Tag[]>([])
-  const [loading, setLoading] = useState(true)
-  const [showSkeleton, setShowSkeleton] = useState(false)
   const [error, setError] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
 
   const loadData = useCallback(async () => {
-    setLoading(true)
-    setShowSkeleton(false)
     setError(false)
     try {
       const [recipesData, tagsData] = await Promise.all([fetchRecipes(), fetchTags()])
@@ -31,20 +27,12 @@ const Recipes: FC = () => {
       setTags(tagsData)
     } catch {
       setError(true)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
   useEffect(() => {
     loadData()
   }, [loadData])
-
-  useEffect(() => {
-    if (!loading) return
-    const timer = setTimeout(() => setShowSkeleton(true), 200)
-    return () => clearTimeout(timer)
-  }, [loading])
 
   const handleTagClick = (tag: string) => {
     if (activeTag === tag) {
@@ -65,7 +53,7 @@ const Recipes: FC = () => {
 
   const filteredRecipes = useMemo(
     () =>
-      recipes.filter((recipe) => {
+      (recipes ?? []).filter((recipe) => {
         const matchesTag = !activeTag || recipe.tags.includes(activeTag)
         const matchesSearch =
           !searchQuery ||
@@ -75,8 +63,7 @@ const Recipes: FC = () => {
     [recipes, activeTag, searchQuery],
   )
 
-  if (loading) {
-    if (!showSkeleton) return null
+  if (recipes === null && !error) {
     return (
       <>
         <Typography variant="heading1" className={styles.heading}>
@@ -114,7 +101,7 @@ const Recipes: FC = () => {
     )
   }
 
-  if (recipes.length === 0) {
+  if (recipes !== null && recipes.length === 0) {
     return (
       <>
         <Typography variant="heading1" className={styles.heading}>

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -70,7 +70,9 @@ const Recipes: FC = () => {
         <Typography variant="heading1" className={styles.heading}>
           Recipes
         </Typography>
-        <Loading />
+        <div className={styles.loadingWrapper}>
+          <Loading />
+        </div>
       </>
     )
   }

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,4 +1,5 @@
 import Button from '@components/Button'
+import Grid from '@components/Grid'
 import Typography from '@components/Typography'
 import { useState, useEffect, useCallback, useMemo, type FC } from 'react'
 import { useSearchParams } from 'react-router-dom'
@@ -139,13 +140,11 @@ const Recipes: FC = () => {
           </Button>
         </div>
       ) : (
-        <ul className={styles.grid}>
+        <Grid columns={3}>
           {filteredRecipes.map((recipe) => (
-            <li key={recipe.id} className={styles.gridItem}>
-              <RecipeCard recipe={recipe} />
-            </li>
+            <RecipeCard key={recipe.id} recipe={recipe} />
           ))}
-        </ul>
+        </Grid>
       )}
     </>
   )

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,3 +1,5 @@
-const Recipes = () => <div>Recipes page</div>
+const Recipes = () => {
+  return null
+}
 
 export default Recipes

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,5 +1,153 @@
-const Recipes = () => {
-  return null
+import Typography from '@components/Typography'
+import { useState, useEffect, useCallback, type FC } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { fetchRecipes, fetchTags } from '../../api/recipes'
+import RecipeCard from '../../components/RecipeCard'
+import RecipeSearch from '../../components/RecipeSearch'
+import RecipeTagFilter from '../../components/RecipeTagFilter'
+import type { RecipeIndex, Tag } from '../../types/recipe'
+import styles from './Recipes.module.css'
+
+const Recipes: FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const activeTag = searchParams.get('tag')
+
+  const [recipes, setRecipes] = useState<RecipeIndex[]>([])
+  const [tags, setTags] = useState<Tag[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const loadData = useCallback(async () => {
+    setLoading(true)
+    setError(false)
+    try {
+      const [recipesData, tagsData] = await Promise.all([fetchRecipes(), fetchTags()])
+      setRecipes(recipesData)
+      setTags(tagsData)
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  const handleTagClick = (tag: string) => {
+    if (activeTag === tag) {
+      setSearchParams({})
+    } else {
+      setSearchParams({ tag })
+    }
+  }
+
+  const handleSearch = useCallback((query: string) => {
+    setSearchQuery(query)
+  }, [])
+
+  const handleClearFilters = () => {
+    setSearchParams({})
+    setSearchQuery('')
+  }
+
+  const filteredRecipes = recipes.filter((recipe) => {
+    const matchesTag = !activeTag || recipe.tags.includes(activeTag)
+    const matchesSearch =
+      !searchQuery ||
+      recipe.title.toLowerCase().includes(searchQuery.toLowerCase())
+    return matchesTag && matchesSearch
+  })
+
+  if (loading) {
+    return (
+      <>
+        <Typography variant="heading1" className={styles.heading}>
+          Recipes
+        </Typography>
+        <div className={styles.grid}>
+          {Array.from({ length: 6 }, (_, i) => (
+            <div
+              key={i}
+              className={styles.skeleton}
+              role="status"
+              aria-label="Loading"
+            />
+          ))}
+        </div>
+      </>
+    )
+  }
+
+  if (error) {
+    return (
+      <>
+        <Typography variant="heading1" className={styles.heading}>
+          Recipes
+        </Typography>
+        <div className={styles.empty}>
+          <Typography variant="bodyLarge">
+            Something went wrong loading recipes.
+          </Typography>
+          <button type="button" onClick={loadData} className={styles.retryButton}>
+            Retry
+          </button>
+        </div>
+      </>
+    )
+  }
+
+  if (recipes.length === 0) {
+    return (
+      <>
+        <Typography variant="heading1" className={styles.heading}>
+          Recipes
+        </Typography>
+        <Typography variant="bodyLarge">Recipes coming soon</Typography>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Typography variant="heading1" className={styles.heading}>
+        Recipes
+      </Typography>
+      <Typography variant="bodyLarge" className={styles.intro}>
+        A collection of tried-and-tested recipes from my kitchen.
+      </Typography>
+
+      <RecipeSearch onSearch={handleSearch} />
+      <RecipeTagFilter tags={tags} activeTag={activeTag} onTagClick={handleTagClick} />
+
+      <div role="status" aria-live="polite" className={styles.srOnly}>
+        {filteredRecipes.length} {filteredRecipes.length === 1 ? 'recipe' : 'recipes'} found
+      </div>
+
+      {filteredRecipes.length === 0 ? (
+        <div className={styles.empty}>
+          <Typography variant="bodyLarge">No recipes found</Typography>
+          <button
+            type="button"
+            onClick={handleClearFilters}
+            className={styles.clearButton}
+          >
+            Clear filter
+          </button>
+        </div>
+      ) : (
+        <ul className={styles.grid}>
+          {filteredRecipes.map((recipe) => (
+            <li key={recipe.id} className={styles.gridItem}>
+              <RecipeCard recipe={recipe} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  )
 }
 
 export default Recipes

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,0 +1,3 @@
+const Recipes = () => <div>Recipes page</div>
+
+export default Recipes

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -110,7 +110,7 @@ const Recipes: FC = () => {
   }
 
   return (
-    <>
+    <div className={styles.page}>
       <Typography variant="heading1" className={styles.heading}>
         Recipes
       </Typography>
@@ -144,7 +144,7 @@ const Recipes: FC = () => {
           ))}
         </Grid>
       )}
-    </>
+    </div>
   )
 }
 

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -17,11 +17,13 @@ const Recipes: FC = () => {
   const [recipes, setRecipes] = useState<RecipeIndex[]>([])
   const [tags, setTags] = useState<Tag[]>([])
   const [loading, setLoading] = useState(true)
+  const [showSkeleton, setShowSkeleton] = useState(false)
   const [error, setError] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
 
   const loadData = useCallback(async () => {
     setLoading(true)
+    setShowSkeleton(false)
     setError(false)
     try {
       const [recipesData, tagsData] = await Promise.all([fetchRecipes(), fetchTags()])
@@ -37,6 +39,12 @@ const Recipes: FC = () => {
   useEffect(() => {
     loadData()
   }, [loadData])
+
+  useEffect(() => {
+    if (!loading) return
+    const timer = setTimeout(() => setShowSkeleton(true), 200)
+    return () => clearTimeout(timer)
+  }, [loading])
 
   const handleTagClick = (tag: string) => {
     if (activeTag === tag) {
@@ -68,6 +76,7 @@ const Recipes: FC = () => {
   )
 
   if (loading) {
+    if (!showSkeleton) return null
     return (
       <>
         <Typography variant="heading1" className={styles.heading}>

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -1,3 +1,4 @@
+import Button from '@components/Button'
 import Typography from '@components/Typography'
 import { useState, useEffect, useCallback, useMemo, type FC } from 'react'
 import { useSearchParams } from 'react-router-dom'
@@ -95,9 +96,9 @@ const Recipes: FC = () => {
           <Typography variant="bodyLarge">
             Something went wrong loading recipes.
           </Typography>
-          <button type="button" onClick={loadData} className={styles.retryButton}>
+          <Button variant="secondary" onClick={loadData}>
             Retry
-          </button>
+          </Button>
         </div>
       </>
     )
@@ -133,13 +134,9 @@ const Recipes: FC = () => {
       {filteredRecipes.length === 0 ? (
         <div className={styles.empty}>
           <Typography variant="bodyLarge">No recipes found</Typography>
-          <button
-            type="button"
-            onClick={handleClearFilters}
-            className={styles.clearButton}
-          >
+          <Button variant="secondary" onClick={handleClearFilters}>
             Clear filter
-          </button>
+          </Button>
         </div>
       ) : (
         <ul className={styles.grid}>

--- a/src/pages/Recipes/index.ts
+++ b/src/pages/Recipes/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Recipes'

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,3 +1,5 @@
+export const RECIPE_IMAGE_BASE = 'https://akli.dev/images'
+
 export interface RecipeImage {
   key: string
   alt: string

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,0 +1,43 @@
+export interface RecipeImage {
+  key: string
+  alt: string
+}
+
+export interface Ingredient {
+  item: string
+  quantity: string
+  unit: string
+}
+
+export interface Step {
+  order: number
+  text: string
+  image?: RecipeImage
+}
+
+export interface Tag {
+  tag: string
+  count: number
+}
+
+export interface RecipeIndex {
+  id: string
+  title: string
+  slug: string
+  coverImage: RecipeImage
+  tags: string[]
+  prepTime: number
+  cookTime: number
+  servings: number
+  createdAt: string
+}
+
+export interface Recipe extends RecipeIndex {
+  intro: string
+  ingredients: Ingredient[]
+  steps: Step[]
+  authorId: string
+  authorName: string
+  updatedAt: string
+  status: string
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -98,6 +98,14 @@ export default defineConfig(({ isSsrBuild }) => ({
       '@hooks': '/src/hooks',
     },
   },
+  server: {
+    proxy: {
+      '/recipes': {
+        target: 'https://api.akli.dev',
+        changeOrigin: true,
+      },
+    },
+  },
   ssr: {
     noExternal: true,
     external: ['node:fs', 'node:path'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -100,9 +100,10 @@ export default defineConfig(({ isSsrBuild }) => ({
   },
   server: {
     proxy: {
-      '/recipes': {
+      '/api': {
         target: 'https://api.akli.dev',
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
## Summary
Complete recipe frontend for akli.dev:

- **API service layer** with typed fetch wrappers for recipes, recipe detail, and tags
- **Recipe listing page** (`/recipes`) with search, tag filtering, responsive grid, loading/error/empty states
- **Recipe detail page** (`/recipes/:slug`) with SSR for SEO, Open Graph meta tags, cover srcSet, ingredients, steps with optional images
- **Homepage callout** ("Favourite Recipes") showing up to 3 latest recipes
- **7 new components**: RecipeCard, RecipeSearch, RecipeTagFilter, RecipeIngredients, RecipeSteps, RecipesCta, plus Loading spinner redesign
- **SSR pipeline**: Lambda handler fetches recipe data before render, entry-server passes data via RecipeDataContext, dynamic OG/Twitter meta tags
- **Dev proxy**: Vite proxy for `/api` prefix to bypass CORS in local development

### Issues completed
- #107 Create recipe API service layer and types
- #108 Add recipe routes to App router
- #109 Add SSR data fetching for recipe detail pages
- #110 Build recipe listing page with search and tag filtering
- #111 Build recipe detail page
- #112 Add homepage recipes callout section
- #113 Write component tests for recipe frontend (covered by TDD)
- #114 Manual QA and refinements

## Test plan
- [ ] `pnpm test` — 315 tests pass across 41 suites
- [ ] `pnpm lint` — clean
- [ ] Visit `/recipes`, `/recipes/:slug`, and homepage CTA in dev and production

🤖 Generated with [Claude Code](https://claude.com/claude-code)