### PR TITLE
Build login page with new-password challenge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ const App = () => {
           <Route
             path="/admin/*"
             element={
-              <Suspense fallback={<Loading />}>
+              <Suspense fallback={<div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--space-12) 0' }}><Loading /></div>}>
                 <Routes>
                   <Route path="login" element={<Login />} />
                   <Route path="recipes" element={<ProtectedRoute><RecipeList /></ProtectedRoute>} />

--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -80,7 +80,7 @@ describe('completeNewPassword', () => {
       })
     )
 
-    const result = await completeNewPassword('session-abc', 'newPass123!')
+    const result = await completeNewPassword('test@example.com', 'session-abc', 'newPass123!')
 
     expect(result).toEqual({
       accessToken: 'access-new',

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -15,13 +15,14 @@ export const login = async (email: string, password: string): Promise<AuthResult
 }
 
 export const completeNewPassword = async (
+  email: string,
   session: string,
   newPassword: string
 ): Promise<AuthTokens> => {
   const response = await fetch(`${API_BASE}/auth/confirm-new-password`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ session, newPassword }),
+    body: JSON.stringify({ email, session, newPassword }),
   })
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`)

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -4,10 +4,16 @@
   height: 1em;
   vertical-align: middle;
   border-radius: var(--radius-none);
-  border: var(--border-width-thick) solid var(--color-border-subtle);
+  border: var(--border-width-thick) solid var(--color-border);
   border-block-start-color: var(--color-primary);
   border-inline-end-color: var(--color-primary);
   animation: spin 0.8s linear infinite;
+}
+
+.small {
+  width: 0.75em;
+  height: 0.75em;
+  border-width: 2px;
 }
 
 @keyframes spin {

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,12 +1,21 @@
+import type { FC } from 'react'
 import styles from './Loading.module.css'
 
-const Loading = () => {
+export interface LoadingProps {
+  size?: 'default' | 'small'
+}
+
+const Loading: FC<LoadingProps> = ({ size = 'default' }) => {
+  const className = size === 'small'
+    ? `${styles.spinner} ${styles.small}`
+    : styles.spinner
+
   return (
     <span
       role="status"
       aria-live="polite"
       aria-label="Loading content"
-      className={styles.spinner}
+      className={className}
     />
   )
 }

--- a/src/pages/admin/Login/Login.module.css
+++ b/src/pages/admin/Login/Login.module.css
@@ -1,0 +1,57 @@
+.page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: var(--space-4);
+  background: var(--color-bg);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  width: 100%;
+  max-width: 24rem;
+  padding: var(--space-6);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+}
+
+.input {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-base);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+.input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.error {
+  font-size: var(--font-size-sm);
+  color: var(--color-error, #dc2626);
+  font-weight: var(--font-weight-medium);
+}
+
+.title {
+  text-align: center;
+}

--- a/src/pages/admin/Login/Login.module.css
+++ b/src/pages/admin/Login/Login.module.css
@@ -1,10 +1,8 @@
 .page {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  min-height: 100vh;
-  padding: var(--space-4);
-  background: var(--color-bg);
+  padding: var(--space-12) var(--space-4) var(--space-4);
 }
 
 .form {

--- a/src/pages/admin/Login/Login.test.tsx
+++ b/src/pages/admin/Login/Login.test.tsx
@@ -131,7 +131,8 @@ describe('Login page', () => {
     fillAndSubmitLoginForm('admin@example.com', 'password123')
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /log in/i })).toBeDisabled()
+      const submitButton = screen.getByRole('button', { name: /loading/i })
+      expect(submitButton).toBeDisabled()
     })
   })
 

--- a/src/pages/admin/Login/Login.test.tsx
+++ b/src/pages/admin/Login/Login.test.tsx
@@ -1,0 +1,218 @@
+import { completeNewPassword } from '@api/auth'
+import { useAuth } from '@contexts/AuthContext'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { AuthChallenge, AuthTokens } from '@types/auth'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Login from './Login'
+
+vi.mock('@contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}))
+
+vi.mock('@api/auth', () => ({
+  completeNewPassword: vi.fn(),
+}))
+
+const mockedUseAuth = vi.mocked(useAuth)
+const mockedCompleteNewPassword = vi.mocked(completeNewPassword)
+
+const mockTokens: AuthTokens = {
+  accessToken: 'access-token',
+  idToken: 'id-token',
+  refreshToken: 'refresh-token',
+}
+
+const mockChallenge: AuthChallenge = {
+  challengeName: 'NEW_PASSWORD_REQUIRED',
+  session: 'sess-123',
+}
+
+const LocationDisplay = () => {
+  const location = useLocation()
+  return (
+    <div data-testid="location">
+      {location.pathname}
+      {location.search}
+    </div>
+  )
+}
+
+const renderLogin = (initialPath = '/admin/login') => {
+  const mockLogin = vi.fn()
+
+  mockedUseAuth.mockReturnValue({
+    user: null,
+    isAuthenticated: false,
+    isAdmin: false,
+    loading: false,
+    login: mockLogin,
+    logout: vi.fn(),
+    getAccessToken: vi.fn(),
+  })
+
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/admin/login" element={<Login />} />
+        <Route path="/admin/recipes" element={<div>Recipes page</div>} />
+        <Route path="/admin/users" element={<div>Users page</div>} />
+      </Routes>
+      <LocationDisplay />
+    </MemoryRouter>
+  )
+
+  return { mockLogin }
+}
+
+const fillAndSubmitLoginForm = (
+  email: string,
+  password: string
+) => {
+  fireEvent.change(screen.getByLabelText(/email/i), { target: { value: email } })
+  fireEvent.change(screen.getByLabelText(/password/i), { target: { value: password } })
+  fireEvent.click(screen.getByRole('button', { name: /log in/i }))
+}
+
+describe('Login page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('renders login form with email input, password input, and submit button', () => {
+    renderLogin()
+
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument()
+  })
+
+  it('redirects to /admin/recipes on successful login', async () => {
+    const { mockLogin } = renderLogin()
+    mockLogin.mockResolvedValue(mockTokens)
+
+    fillAndSubmitLoginForm('admin@example.com', 'password123')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/admin/recipes')
+    })
+  })
+
+  it('redirects to original URL from ?redirect param on successful login', async () => {
+    const { mockLogin } = renderLogin('/admin/login?redirect=/admin/users')
+    mockLogin.mockResolvedValue(mockTokens)
+
+    fillAndSubmitLoginForm('admin@example.com', 'password123')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/admin/users')
+    })
+  })
+
+  it('shows error message for invalid credentials', async () => {
+    const { mockLogin } = renderLogin()
+    mockLogin.mockRejectedValue(new Error('401 Unauthorized'))
+
+    fillAndSubmitLoginForm('wrong@example.com', 'wrongpass')
+
+    await waitFor(() => {
+      expect(screen.getByText('Incorrect email or password')).toBeInTheDocument()
+    })
+
+    const errorMessage = screen.getByText('Incorrect email or password')
+    expect(errorMessage).toHaveAttribute('id')
+  })
+
+  it('disables submit button while loading', async () => {
+    const { mockLogin } = renderLogin()
+    mockLogin.mockReturnValue(new Promise(() => {}))
+
+    fillAndSubmitLoginForm('admin@example.com', 'password123')
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /log in/i })).toBeDisabled()
+    })
+  })
+
+  it('shows new password form on NEW_PASSWORD_REQUIRED challenge', async () => {
+    const { mockLogin } = renderLogin()
+    mockLogin.mockResolvedValue(mockChallenge)
+
+    fillAndSubmitLoginForm('admin@example.com', 'temppass')
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/new password/i)).toBeInTheDocument()
+    })
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /set new password/i })).toBeInTheDocument()
+  })
+
+  it('shows error when new passwords do not match', async () => {
+    const { mockLogin } = renderLogin()
+    mockLogin.mockResolvedValue(mockChallenge)
+
+    fillAndSubmitLoginForm('admin@example.com', 'temppass')
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/new password/i)).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText(/new password/i), { target: { value: 'NewPass123!' } })
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'DifferentPass456!' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /set new password/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Passwords do not match')).toBeInTheDocument()
+    })
+  })
+
+  it('redirects after successful new password completion', async () => {
+    const { mockLogin } = renderLogin()
+    mockLogin.mockResolvedValue(mockChallenge)
+    mockedCompleteNewPassword.mockResolvedValue(mockTokens)
+
+    fillAndSubmitLoginForm('admin@example.com', 'temppass')
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/new password/i)).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText(/new password/i), { target: { value: 'NewPass123!' } })
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'NewPass123!' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /set new password/i }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location')).toHaveTextContent('/admin/recipes')
+    })
+  })
+
+  it('shows generic error message on network error', async () => {
+    const { mockLogin } = renderLogin()
+    mockLogin.mockRejectedValue(new TypeError('Failed to fetch'))
+
+    fillAndSubmitLoginForm('admin@example.com', 'password123')
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Something went wrong. Please try again.')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('has associated label elements for email and password inputs', () => {
+    renderLogin()
+
+    const emailInput = screen.getByLabelText(/email/i)
+    const passwordInput = screen.getByLabelText(/password/i)
+
+    expect(emailInput.tagName).toBe('INPUT')
+    expect(passwordInput.tagName).toBe('INPUT')
+    expect(emailInput).toHaveAttribute('type', 'email')
+    expect(passwordInput).toHaveAttribute('type', 'password')
+  })
+})

--- a/src/pages/admin/Login/Login.tsx
+++ b/src/pages/admin/Login/Login.tsx
@@ -1,6 +1,6 @@
-
 import { completeNewPassword } from '@api/auth'
 import Button from '@components/Button'
+import Loading from '@components/Loading'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
 import type { AuthChallenge } from '@types/auth'
@@ -47,7 +47,10 @@ const Login = () => {
     } catch (err) {
       if (err instanceof TypeError) {
         setError('Something went wrong. Please try again.')
-      } else if (err instanceof Error && (err.message.includes('401') || err.message.includes('Unauthorized'))) {
+      } else if (
+        err instanceof Error &&
+        (err.message.includes('401') || err.message.includes('Unauthorized'))
+      ) {
         setError('Incorrect email or password')
       } else {
         setError('Something went wrong. Please try again.')
@@ -69,7 +72,7 @@ const Login = () => {
     setLoading(true)
 
     try {
-      await completeNewPassword(challenge!.session, newPassword)
+      await completeNewPassword(email, challenge!.session, newPassword)
       navigate(redirectTo)
     } catch {
       setError('Something went wrong. Please try again.')
@@ -120,8 +123,8 @@ const Login = () => {
             </p>
           )}
 
-          <Button type="submit" onClick={() => {}} disabled={loading}>
-            Set new password
+          <Button type="submit" disabled={loading}>
+            {loading ? <Loading size="small" /> : 'Set new password'}
           </Button>
         </form>
       </div>
@@ -146,6 +149,7 @@ const Login = () => {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             aria-describedby={error ? 'form-error' : undefined}
+            required
           />
         </div>
 
@@ -160,6 +164,7 @@ const Login = () => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             aria-describedby={error ? 'form-error' : undefined}
+            required
           />
         </div>
 
@@ -169,8 +174,8 @@ const Login = () => {
           </p>
         )}
 
-        <Button type="submit" onClick={() => {}} disabled={loading}>
-          Log in
+        <Button type="submit" disabled={loading}>
+          {loading ? <Loading size="small" /> : 'Log in'}
         </Button>
       </form>
     </div>

--- a/src/pages/admin/Login/Login.tsx
+++ b/src/pages/admin/Login/Login.tsx
@@ -1,5 +1,180 @@
+
+import { completeNewPassword } from '@api/auth'
+import Button from '@components/Button'
+import Typography from '@components/Typography'
+import { useAuth } from '@contexts/AuthContext'
+import type { AuthChallenge } from '@types/auth'
+import { type FormEvent, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import styles from './Login.module.css'
+
+const isChallenge = (result: unknown): result is AuthChallenge =>
+  typeof result === 'object' &&
+  result !== null &&
+  'challengeName' in result &&
+  (result as AuthChallenge).challengeName === 'NEW_PASSWORD_REQUIRED'
+
 const Login = () => {
-  return <div>Login page</div>
+  const { login } = useAuth()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const [challenge, setChallenge] = useState<AuthChallenge | null>(null)
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+
+  const redirectTo = searchParams.get('redirect') ?? '/admin/recipes'
+
+  const handleLogin = async (e: FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+
+    try {
+      const result = await login(email, password)
+
+      if (isChallenge(result)) {
+        setChallenge(result)
+      } else {
+        navigate(redirectTo)
+      }
+    } catch (err) {
+      if (err instanceof TypeError) {
+        setError('Something went wrong. Please try again.')
+      } else if (err instanceof Error && (err.message.includes('401') || err.message.includes('Unauthorized'))) {
+        setError('Incorrect email or password')
+      } else {
+        setError('Something went wrong. Please try again.')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleNewPassword = async (e: FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match')
+      return
+    }
+
+    setLoading(true)
+
+    try {
+      await completeNewPassword(challenge!.session, newPassword)
+      navigate(redirectTo)
+    } catch {
+      setError('Something went wrong. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (challenge) {
+    return (
+      <div className={styles.page}>
+        <form className={styles.form} onSubmit={handleNewPassword}>
+          <Typography variant="heading2" className={styles.title}>
+            Set new password
+          </Typography>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="new-password">
+              New password
+            </label>
+            <input
+              id="new-password"
+              className={styles.input}
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              aria-describedby={error ? 'form-error' : undefined}
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="confirm-password">
+              Confirm password
+            </label>
+            <input
+              id="confirm-password"
+              className={styles.input}
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              aria-describedby={error ? 'form-error' : undefined}
+            />
+          </div>
+
+          {error && (
+            <p id="form-error" className={styles.error}>
+              {error}
+            </p>
+          )}
+
+          <Button type="submit" onClick={() => {}} disabled={loading}>
+            Set new password
+          </Button>
+        </form>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.page}>
+      <form className={styles.form} onSubmit={handleLogin}>
+        <Typography variant="heading2" className={styles.title}>
+          Log in
+        </Typography>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="email">
+            Email
+          </label>
+          <input
+            id="email"
+            className={styles.input}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            aria-describedby={error ? 'form-error' : undefined}
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="password">
+            Password
+          </label>
+          <input
+            id="password"
+            className={styles.input}
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            aria-describedby={error ? 'form-error' : undefined}
+          />
+        </div>
+
+        {error && (
+          <p id="form-error" className={styles.error}>
+            {error}
+          </p>
+        )}
+
+        <Button type="submit" onClick={() => {}} disabled={loading}>
+          Log in
+        </Button>
+      </form>
+    </div>
+  )
 }
 
 export default Login


### PR DESCRIPTION
Closes #119

## What changed
Implemented the Login page with:
- Email/password form with proper labels and aria-describedby error linking
- Loading state (disabled button) during authentication
- Error messages: "Incorrect email or password" (401), "Something went wrong" (network)
- NEW_PASSWORD_REQUIRED challenge flow: switches to new password + confirm form
- Password mismatch client-side validation
- Redirect to original URL via ?redirect query param (defaults to /admin/recipes)

## Why
The login page is the entry point to the admin interface — users need to authenticate before accessing protected routes.

## How to verify
- `pnpm test` — 397/397 tests pass
- `pnpm lint` — clean

## Decisions made
- Uses `useAuth().login` for auth, `completeNewPassword` from `@api/auth` for challenge
- Distinguishes network errors (TypeError) from auth errors (401) for appropriate messaging
- Neo-brutalist centred form with design tokens
- Agents: **test-engineer** (Write) + **react-engineer**