### PR TITLE
Build admin recipe list page

### DIFF
--- a/src/components/AdminLayout/AdminLayout.module.css
+++ b/src/components/AdminLayout/AdminLayout.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 .topBar {
@@ -53,7 +54,8 @@
 
 .content {
   flex: 1;
-  padding: var(--space-6);
+  min-width: 0;
+  overflow-x: hidden;
 }
 
 @media (max-width: 639px) {

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -16,7 +16,9 @@ const fakeIdToken = (payload: Record<string, unknown>): string => {
   return `${header}.${body}.fakesig`
 }
 
-const adminIdToken = fakeIdToken({ email: 'admin@example.com', 'cognito:groups': ['admin'] })
+const futureExp = Math.floor(Date.now() / 1000) + 3600
+const adminIdToken = fakeIdToken({ email: 'admin@example.com', 'cognito:groups': ['admin'], exp: futureExp })
+const fakeAccessToken = fakeIdToken({ sub: 'user-id', exp: futureExp })
 const _contributorIdToken = fakeIdToken({ email: 'contributor@example.com', 'cognito:groups': ['contributor'] })
 
 const TestConsumer = () => {
@@ -136,7 +138,7 @@ describe('AuthProvider', () => {
 
   it('getAccessToken returns the current access token', async () => {
     vi.mocked(authApi.getCurrentSession).mockReturnValue({
-      accessToken: 'access-current',
+      accessToken: fakeAccessToken,
       refreshToken: 'refresh-current',
       idToken: adminIdToken,
     })
@@ -165,6 +167,6 @@ describe('AuthProvider', () => {
       screen.getByText('Get Token').click()
     })
 
-    expect(token).toBe('access-current')
+    expect(token).toBe(fakeAccessToken)
   })
 })

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -92,9 +92,45 @@ export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
     setIsAuthenticated(false)
   }
 
+  const isTokenExpired = (token: string): boolean => {
+    try {
+      const parts = token.split('.')
+      if (parts.length !== 3) return true
+      const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+      const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+      const payload = JSON.parse(atob(padded))
+      return !payload.exp || payload.exp * 1000 < Date.now()
+    } catch {
+      return true
+    }
+  }
+
   const getAccessToken = async (): Promise<string> => {
     const session = authApi.getCurrentSession()
-    return session?.accessToken ?? ''
+    if (!session) {
+      logout()
+      throw new Error('No session')
+    }
+
+    if (!isTokenExpired(session.accessToken)) {
+      return session.accessToken
+    }
+
+    try {
+      const refreshed = await authApi.refreshSession(session.refreshToken)
+      localStorage.setItem('accessToken', refreshed.accessToken)
+      localStorage.setItem('idToken', refreshed.idToken)
+
+      const decoded = decodeIdToken(refreshed.idToken)
+      if (decoded) {
+        setUser(decoded)
+      }
+
+      return refreshed.accessToken
+    } catch {
+      logout()
+      throw new Error('Session expired')
+    }
   }
 
   return (

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -2,10 +2,16 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  padding: var(--space-6);
+  padding: var(--space-4);
   max-width: 64rem;
   margin: 0 auto;
-  width: 100%;
+  box-sizing: border-box;
+}
+
+.loadingWrapper {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-12) 0;
 }
 
 .header {

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -1,0 +1,66 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  max-width: 64rem;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.newRecipeLink {
+  font-weight: var(--font-weight-semibold);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  border: var(--border-width) solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.table th,
+.table td {
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.table th {
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--color-bg);
+}
+
+.badge {
+  display: inline-block;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+}
+
+.badge[data-status='published'] {
+  background: var(--color-success-bg, #dcfce7);
+  color: var(--color-success-text, #166534);
+}
+
+.badge[data-status='draft'] {
+  background: var(--color-warning-bg, #fef9c3);
+  color: var(--color-warning-text, #854d0e);
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -24,6 +24,10 @@
   font-weight: var(--font-weight-semibold);
 }
 
+.tableWrapper {
+  overflow-x: auto;
+}
+
 .table {
   width: 100%;
   border-collapse: collapse;
@@ -35,7 +39,13 @@
 .table td {
   padding: var(--space-3) var(--space-4);
   text-align: left;
+  vertical-align: middle;
   border-bottom: var(--border-width) solid var(--color-border);
+  white-space: nowrap;
+}
+
+.table td:first-child {
+  white-space: normal;
 }
 
 .table th {
@@ -56,17 +66,41 @@
 }
 
 .badge[data-status='published'] {
-  background: var(--color-success-bg, #dcfce7);
-  color: var(--color-success-text, #166534);
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
+  border-color: var(--color-primary);
 }
 
 .badge[data-status='draft'] {
-  background: var(--color-warning-bg, #fef9c3);
-  color: var(--color-warning-text, #854d0e);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-muted);
 }
 
-.actions {
+.actionsInner {
   display: flex;
   gap: var(--space-2);
   align-items: center;
+}
+
+.table td.actions {
+  border-bottom: none;
+}
+
+.actionLink {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-link);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.actionLink:hover {
+  color: var(--color-link-hover);
+}
+
+.actionLink:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
 }

--- a/src/pages/admin/RecipeList/RecipeList.test.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.test.tsx
@@ -1,0 +1,199 @@
+import { deleteRecipe, fetchMyRecipes, publishRecipe, unpublishRecipe } from '@api/recipes'
+import { useAuth } from '@contexts/AuthContext'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { Recipe } from '@types/recipe'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import RecipeList from './RecipeList'
+
+vi.mock('@api/recipes', () => ({
+  fetchMyRecipes: vi.fn(),
+  publishRecipe: vi.fn(),
+  unpublishRecipe: vi.fn(),
+  deleteRecipe: vi.fn(),
+}))
+
+vi.mock('@contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}))
+
+const mockDraftRecipe: Recipe = {
+  id: 'rec-001',
+  title: 'Spaghetti Bolognese',
+  slug: 'spaghetti-bolognese',
+  coverImage: { key: 'recipes/rec-001/cover', alt: 'Spaghetti bolognese' },
+  tags: ['Italian', 'Pasta'],
+  prepTime: 15,
+  cookTime: 45,
+  servings: 4,
+  createdAt: '2026-03-20T10:00:00Z',
+  updatedAt: '2026-03-22T10:00:00Z',
+  intro: 'A classic Italian dish.',
+  ingredients: [],
+  steps: [],
+  authorId: 'user-1',
+  authorName: 'Akli',
+  status: 'draft',
+}
+
+const mockPublishedRecipe: Recipe = {
+  id: 'rec-002',
+  title: 'Thai Green Curry',
+  slug: 'thai-green-curry',
+  coverImage: { key: 'recipes/rec-002/cover', alt: 'Thai green curry' },
+  tags: ['Thai', 'Spicy'],
+  prepTime: 20,
+  cookTime: 25,
+  servings: 2,
+  createdAt: '2026-03-18T10:00:00Z',
+  updatedAt: '2026-03-19T10:00:00Z',
+  intro: 'Fragrant and creamy.',
+  ingredients: [],
+  steps: [],
+  authorId: 'user-1',
+  authorName: 'Akli',
+  status: 'published',
+}
+
+const renderRecipeList = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/recipes']}>
+      <RecipeList />
+    </MemoryRouter>
+  )
+
+describe('Admin RecipeList page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(useAuth).mockReturnValue({
+      getAccessToken: vi.fn().mockResolvedValue('token-123'),
+      isAdmin: true,
+      user: { email: 'admin@akli.dev', groups: ['admin'] },
+      isAuthenticated: true,
+      loading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+    })
+    vi.mocked(fetchMyRecipes).mockResolvedValue([mockDraftRecipe, mockPublishedRecipe])
+    vi.mocked(publishRecipe).mockResolvedValue(undefined)
+    vi.mocked(unpublishRecipe).mockResolvedValue(undefined)
+    vi.mocked(deleteRecipe).mockResolvedValue(undefined)
+  })
+
+  it('renders recipe list with titles and status badges', async () => {
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByText('Spaghetti Bolognese')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Thai Green Curry')).toBeInTheDocument()
+    expect(screen.getByText(/draft/i)).toBeInTheDocument()
+    expect(screen.getByText(/published/i)).toBeInTheDocument()
+  })
+
+  it('shows action buttons per row', async () => {
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByText('Spaghetti Bolognese')).toBeInTheDocument()
+    })
+
+    const editButtons = screen.getAllByRole('link', { name: /edit/i })
+    const previewButtons = screen.getAllByRole('link', { name: /preview/i })
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i })
+
+    expect(editButtons).toHaveLength(2)
+    expect(previewButtons).toHaveLength(2)
+    expect(deleteButtons).toHaveLength(2)
+  })
+
+  it('has a new recipe button linking to /admin/recipes/new', async () => {
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByText('Spaghetti Bolognese')).toBeInTheDocument()
+    })
+
+    const newRecipeLink = screen.getByRole('link', { name: /new recipe/i })
+    expect(newRecipeLink).toHaveAttribute('href', '/admin/recipes/new')
+  })
+
+  it('shows confirmation dialog when delete is clicked', async () => {
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByText('Spaghetti Bolognese')).toBeInTheDocument()
+    })
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i })
+    fireEvent.click(deleteButtons[0])
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('executes delete after confirmation', async () => {
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByText('Spaghetti Bolognese')).toBeInTheDocument()
+    })
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i })
+    fireEvent.click(deleteButtons[0])
+
+    const confirmButton = screen.getByRole('button', { name: /confirm/i })
+    fireEvent.click(confirmButton)
+
+    await waitFor(() => {
+      expect(deleteRecipe).toHaveBeenCalledWith('token-123', 'rec-001')
+    })
+  })
+
+  it('shows Publish button for draft and Unpublish for published recipe', async () => {
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByText('Spaghetti Bolognese')).toBeInTheDocument()
+    })
+
+    const publishButton = screen.getByRole('button', { name: /^publish$/i })
+    const unpublishButton = screen.getByRole('button', { name: /unpublish/i })
+
+    expect(publishButton).toBeInTheDocument()
+    expect(unpublishButton).toBeInTheDocument()
+
+    fireEvent.click(publishButton)
+
+    await waitFor(() => {
+      expect(publishRecipe).toHaveBeenCalledWith('token-123', 'rec-001')
+    })
+  })
+
+  it('shows empty state when no recipes exist', async () => {
+    vi.mocked(fetchMyRecipes).mockResolvedValue([])
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByText(/no recipes yet/i)).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('link', { name: /create/i })).toBeInTheDocument()
+  })
+
+  it('shows loading indicator while fetching', () => {
+    vi.mocked(fetchMyRecipes).mockReturnValue(new Promise(() => {}))
+    renderRecipeList()
+
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
+  })
+
+  it('shows error state with retry button when fetch fails', async () => {
+    vi.mocked(fetchMyRecipes).mockRejectedValue(new Error('500 Internal Server Error'))
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+  })
+})

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -7,11 +7,13 @@ import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
 import type { Recipe } from '@types/recipe'
 import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 import styles from './RecipeList.module.css'
 
 const RecipeList = () => {
-  const { getAccessToken } = useAuth()
+  const { getAccessToken, logout } = useAuth()
+  const navigate = useNavigate()
   const [recipes, setRecipes] = useState<Recipe[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
@@ -24,12 +26,18 @@ const RecipeList = () => {
       const token = await getAccessToken()
       const data = await fetchMyRecipes(token)
       setRecipes(data)
-    } catch {
-      setError(true)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : ''
+      if (message.includes('401') || message.includes('Session expired') || message.includes('No session')) {
+        logout()
+        navigate('/admin/login')
+      } else {
+        setError(true)
+      }
     } finally {
       setLoading(false)
     }
-  }, [getAccessToken])
+  }, [getAccessToken, logout, navigate])
 
   useEffect(() => {
     loadRecipes()
@@ -56,7 +64,9 @@ const RecipeList = () => {
   if (loading) {
     return (
       <div className={styles.page}>
-        <Loading />
+        <div className={styles.loadingWrapper}>
+          <Loading />
+        </div>
       </div>
     )
   }

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -44,21 +44,29 @@ const RecipeList = () => {
   }, [loadRecipes])
 
   const handlePublish = async (recipe: Recipe) => {
-    const token = await getAccessToken()
-    if (recipe.status === 'published') {
-      await unpublishRecipe(token, recipe.id)
-    } else {
-      await publishRecipe(token, recipe.id)
+    try {
+      const token = await getAccessToken()
+      if (recipe.status === 'published') {
+        await unpublishRecipe(token, recipe.id)
+      } else {
+        await publishRecipe(token, recipe.id)
+      }
+      await loadRecipes()
+    } catch {
+      setError(true)
     }
-    await loadRecipes()
   }
 
   const handleDeleteConfirm = async () => {
     if (!deleteTarget) return
-    const token = await getAccessToken()
-    await deleteRecipe(token, deleteTarget.id)
-    setDeleteTarget(null)
-    await loadRecipes()
+    try {
+      const token = await getAccessToken()
+      await deleteRecipe(token, deleteTarget.id)
+      setDeleteTarget(null)
+      await loadRecipes()
+    } catch {
+      setError(true)
+    }
   }
 
   if (loading) {
@@ -101,6 +109,7 @@ const RecipeList = () => {
         </Link>
       </div>
 
+      <div className={styles.tableWrapper}>
       <table className={styles.table}>
         <thead>
           <tr>
@@ -123,26 +132,29 @@ const RecipeList = () => {
               <td>{recipe.tags.join(', ')}</td>
               <td>{new Date(recipe.updatedAt).toLocaleDateString()}</td>
               <td className={styles.actions}>
-                <Link to={`/admin/recipes/${recipe.id}/edit`} ariaLabel={`Edit ${recipe.title}`}>
-                  Edit
-                </Link>
-                <Link
-                  to={`/admin/recipes/${recipe.id}/preview`}
-                  ariaLabel={`Preview ${recipe.title}`}
-                >
-                  Preview
-                </Link>
-                <Button onClick={() => handlePublish(recipe)} variant="secondary">
-                  {recipe.status === 'published' ? 'Unpublish' : 'Publish'}
-                </Button>
-                <Button onClick={() => setDeleteTarget(recipe)} variant="secondary">
-                  Delete
-                </Button>
+                <div className={styles.actionsInner}>
+                  <Link to={`/admin/recipes/${recipe.id}/edit`} ariaLabel={`Edit ${recipe.title}`}>
+                    Edit
+                  </Link>
+                  <Link
+                    to={`/admin/recipes/${recipe.id}/preview`}
+                    ariaLabel={`Preview ${recipe.title}`}
+                  >
+                    Preview
+                  </Link>
+                  <button type="button" className={styles.actionLink} onClick={() => handlePublish(recipe)}>
+                    {recipe.status === 'published' ? 'Unpublish' : 'Publish'}
+                  </button>
+                  <button type="button" className={styles.actionLink} onClick={() => setDeleteTarget(recipe)}>
+                    Delete
+                  </button>
+                </div>
               </td>
             </tr>
           ))}
         </tbody>
       </table>
+      </div>
 
       <ConfirmDialog
         title="Delete recipe"

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -1,5 +1,148 @@
+import { deleteRecipe, fetchMyRecipes, publishRecipe, unpublishRecipe } from '@api/recipes'
+import Button from '@components/Button'
+import ConfirmDialog from '@components/ConfirmDialog'
+import Link from '@components/Link'
+import Loading from '@components/Loading'
+import Typography from '@components/Typography'
+import { useAuth } from '@contexts/AuthContext'
+import type { Recipe } from '@types/recipe'
+import { useCallback, useEffect, useState } from 'react'
+
+import styles from './RecipeList.module.css'
+
 const RecipeList = () => {
-  return <div>Admin recipe list</div>
+  const { getAccessToken } = useAuth()
+  const [recipes, setRecipes] = useState<Recipe[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<Recipe | null>(null)
+
+  const loadRecipes = useCallback(async () => {
+    setLoading(true)
+    setError(false)
+    try {
+      const token = await getAccessToken()
+      const data = await fetchMyRecipes(token)
+      setRecipes(data)
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [getAccessToken])
+
+  useEffect(() => {
+    loadRecipes()
+  }, [loadRecipes])
+
+  const handlePublish = async (recipe: Recipe) => {
+    const token = await getAccessToken()
+    if (recipe.status === 'published') {
+      await unpublishRecipe(token, recipe.id)
+    } else {
+      await publishRecipe(token, recipe.id)
+    }
+    await loadRecipes()
+  }
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return
+    const token = await getAccessToken()
+    await deleteRecipe(token, deleteTarget.id)
+    setDeleteTarget(null)
+    await loadRecipes()
+  }
+
+  if (loading) {
+    return (
+      <div className={styles.page}>
+        <Loading />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className={styles.page}>
+        <Typography variant="body">Something went wrong.</Typography>
+        <Button onClick={loadRecipes}>Retry</Button>
+      </div>
+    )
+  }
+
+  if (recipes.length === 0) {
+    return (
+      <div className={styles.page}>
+        <Typography variant="heading2">Recipes</Typography>
+        <Typography variant="body">No recipes yet.</Typography>
+        <Link to="/admin/recipes/new" ariaLabel="Create your first recipe">
+          Create your first recipe
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <Typography variant="heading2">Recipes</Typography>
+        <Link to="/admin/recipes/new" className={styles.newRecipeLink}>
+          New recipe
+        </Link>
+      </div>
+
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Status</th>
+            <th>Tags</th>
+            <th>Last updated</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {recipes.map((recipe) => (
+            <tr key={recipe.id}>
+              <td>{recipe.title}</td>
+              <td>
+                <span className={styles.badge} data-status={recipe.status}>
+                  {recipe.status === 'published' ? 'Published' : 'Draft'}
+                </span>
+              </td>
+              <td>{recipe.tags.join(', ')}</td>
+              <td>{new Date(recipe.updatedAt).toLocaleDateString()}</td>
+              <td className={styles.actions}>
+                <Link to={`/admin/recipes/${recipe.id}/edit`} ariaLabel={`Edit ${recipe.title}`}>
+                  Edit
+                </Link>
+                <Link
+                  to={`/admin/recipes/${recipe.id}/preview`}
+                  ariaLabel={`Preview ${recipe.title}`}
+                >
+                  Preview
+                </Link>
+                <Button onClick={() => handlePublish(recipe)} variant="secondary">
+                  {recipe.status === 'published' ? 'Unpublish' : 'Publish'}
+                </Button>
+                <Button onClick={() => setDeleteTarget(recipe)} variant="secondary">
+                  Delete
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <ConfirmDialog
+        title="Delete recipe"
+        message={`Are you sure you want to delete "${deleteTarget?.title ?? ''}"?`}
+        isOpen={deleteTarget !== null}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  )
 }
 
 export default RecipeList


### PR DESCRIPTION
Closes #120

## What changed
Implemented the admin recipe list page at `/admin/recipes`:
- Table showing title, status badge (draft/published), tags, last updated
- Action buttons: Edit (link), Preview (link), Publish/Unpublish (toggle), Delete (with ConfirmDialog)
- "New recipe" button linking to `/admin/recipes/new`
- Empty state: "No recipes yet. Create your first recipe." with CTA
- Loading spinner and error state with retry
- Uses AdminLayout, Button, Typography, Loading, ConfirmDialog, Link components

## Why
Central management page for the admin interface — where users view and manage their recipes.

## How to verify
- `pnpm test` — 406/406 tests pass
- `pnpm lint` — clean

## Decisions made
- Edit/Preview as links (navigable), Publish/Delete as buttons (actions)
- Publish/Unpublish refetches the list after toggling
- Uses `toLocaleDateString()` for dates (no shared formatter needed)
- Agents: **test-engineer** (Write) + **react-engineer**