### PR TITLE
Recipe editor: remaining ACs from #121 + data router migration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,55 +1,7 @@
-import Header from '@components/Header'
-import Layout from '@components/Layout'
-import Loading from '@components/Loading'
-import ProtectedRoute from '@components/ProtectedRoute'
-import Apps from '@pages/Apps'
-import Blog from '@pages/Blog'
-import BlogPost from '@pages/Blog/BlogPost'
-import Home from '@pages/Home'
-import NotFound from '@pages/NotFound'
-import RecipeDetail from '@pages/RecipeDetail'
-import Recipes from '@pages/Recipes'
-import { lazy, Suspense } from 'react'
-import { Routes, Route } from 'react-router-dom'
+import { useRoutes } from 'react-router-dom'
 
-const Login = lazy(() => import('@pages/admin/Login'))
-const RecipeList = lazy(() => import('@pages/admin/RecipeList'))
-const RecipeEditor = lazy(() => import('@pages/admin/RecipeEditor'))
-const RecipePreview = lazy(() => import('@pages/admin/RecipePreview'))
-const UserManagement = lazy(() => import('@pages/admin/UserManagement'))
+import { routes } from './routes'
 
-const App = () => {
-  return (
-    <>
-      <Header />
-      <Layout>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/apps" element={<Apps />} />
-          <Route path="/blog" element={<Blog />} />
-          <Route path="/blog/:slug" element={<BlogPost />} />
-          <Route path="/recipes" element={<Recipes />} />
-          <Route path="/recipes/:slug" element={<RecipeDetail />} />
-          <Route
-            path="/admin/*"
-            element={
-              <Suspense fallback={<div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--space-12) 0' }}><Loading /></div>}>
-                <Routes>
-                  <Route path="login" element={<Login />} />
-                  <Route path="recipes" element={<ProtectedRoute><RecipeList /></ProtectedRoute>} />
-                  <Route path="recipes/new" element={<ProtectedRoute><RecipeEditor /></ProtectedRoute>} />
-                  <Route path="recipes/:id/edit" element={<ProtectedRoute><RecipeEditor /></ProtectedRoute>} />
-                  <Route path="recipes/:id/preview" element={<ProtectedRoute><RecipePreview /></ProtectedRoute>} />
-                  <Route path="users" element={<ProtectedRoute requiredRole="admin"><UserManagement /></ProtectedRoute>} />
-                </Routes>
-              </Suspense>
-            }
-          />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </Layout>
-    </>
-  )
-}
+const App = () => useRoutes(routes)
 
 export default App

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -65,3 +65,8 @@ export const logout = (): void => {
   localStorage.removeItem('refreshToken')
   localStorage.removeItem('idToken')
 }
+
+export const isSessionError = (err: unknown): boolean => {
+  const message = err instanceof Error ? err.message : ''
+  return /session expired|no session|401/i.test(message)
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, ReactElement, type CSSProperties } from 'react'
+import { ReactNode, ReactElement } from 'react'
 import styles from './Button.module.css'
 
 interface ButtonProps {
@@ -10,7 +10,6 @@ interface ButtonProps {
   ariaLabel?: string
   ariaPressed?: 'true' | 'false'
   className?: string
-  style?: CSSProperties
 }
 
 const Button = ({
@@ -22,7 +21,6 @@ const Button = ({
   ariaLabel,
   ariaPressed,
   className: extraClassName,
-  style,
 }: ButtonProps): ReactElement => {
   const className = [styles.button, styles[variant], extraClassName].filter(Boolean).join(' ')
 
@@ -34,7 +32,6 @@ const Button = ({
       disabled={disabled}
       aria-label={ariaLabel}
       aria-pressed={ariaPressed}
-      style={style}
     >
       {children}
     </button>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, ReactElement } from 'react'
+import { ReactNode, ReactElement, type CSSProperties } from 'react'
 import styles from './Button.module.css'
 
 interface ButtonProps {
@@ -10,6 +10,7 @@ interface ButtonProps {
   ariaLabel?: string
   ariaPressed?: 'true' | 'false'
   className?: string
+  style?: CSSProperties
 }
 
 const Button = ({
@@ -21,6 +22,7 @@ const Button = ({
   ariaLabel,
   ariaPressed,
   className: extraClassName,
+  style,
 }: ButtonProps): ReactElement => {
   const className = [styles.button, styles[variant], extraClassName].filter(Boolean).join(' ')
 
@@ -32,6 +34,7 @@ const Button = ({
       disabled={disabled}
       aria-label={ariaLabel}
       aria-pressed={ariaPressed}
+      style={style}
     >
       {children}
     </button>

--- a/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -11,11 +11,21 @@ export interface ConfirmDialogProps {
   onConfirm: () => void
   onCancel: () => void
   isOpen: boolean
+  confirmLabel?: string
+  cancelLabel?: string
 }
 
 const TITLE_ID = 'confirm-dialog-title'
 
-const ConfirmDialog: FC<ConfirmDialogProps> = ({ title, message, onConfirm, onCancel, isOpen }) => {
+const ConfirmDialog: FC<ConfirmDialogProps> = ({
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  isOpen,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+}) => {
   const dialogRef = useRef<HTMLDivElement>(null)
 
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
@@ -69,10 +79,10 @@ const ConfirmDialog: FC<ConfirmDialogProps> = ({ title, message, onConfirm, onCa
         </Typography>
         <div className={styles.actions}>
           <Button onClick={onCancel} variant="secondary">
-            Cancel
+            {cancelLabel}
           </Button>
           <Button onClick={onConfirm} variant="primary">
-            Confirm
+            {confirmLabel}
           </Button>
         </div>
       </div>

--- a/src/components/IngredientList/IngredientList.module.css
+++ b/src/components/IngredientList/IngredientList.module.css
@@ -49,6 +49,11 @@
   gap: var(--space-1);
 }
 
+.actionButton {
+  min-width: 44px;
+  min-height: 44px;
+}
+
 @media (min-width: 768px) {
   .row {
     grid-template-columns: 5rem 5rem 1fr auto;

--- a/src/components/IngredientList/IngredientList.test.tsx
+++ b/src/components/IngredientList/IngredientList.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import IngredientList from './IngredientList'
+import styles from './IngredientList.module.css'
 
 const makeIngredient = (item: string, quantity = '', unit = ''): Ingredient => ({
   item,
@@ -99,44 +100,36 @@ describe('IngredientList', () => {
   })
 
   describe('accessibility — touch targets', () => {
-    const parsePx = (value: string): number => {
-      const parsed = parseFloat(value)
-      return Number.isNaN(parsed) ? 0 : parsed
-    }
-
-    it('move up buttons meet the 44x44px minimum touch target', () => {
+    // Note: jsdom does not apply CSS Modules styles to computed style, so we
+    // assert the button carries the action-button class, which is styled to
+    // the 44x44px minimum in IngredientList.module.css.
+    it('move up buttons carry the action-button class (44x44px min)', () => {
       const onChange = vi.fn()
       render(<IngredientList ingredients={twoIngredients} onChange={onChange} />)
 
       const moveUpButtons = screen.getAllByRole('button', { name: /move up/i })
       moveUpButtons.forEach((button) => {
-        const computed = getComputedStyle(button)
-        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
-        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+        expect(button).toHaveClass(styles.actionButton)
       })
     })
 
-    it('move down buttons meet the 44x44px minimum touch target', () => {
+    it('move down buttons carry the action-button class (44x44px min)', () => {
       const onChange = vi.fn()
       render(<IngredientList ingredients={twoIngredients} onChange={onChange} />)
 
       const moveDownButtons = screen.getAllByRole('button', { name: /move down/i })
       moveDownButtons.forEach((button) => {
-        const computed = getComputedStyle(button)
-        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
-        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+        expect(button).toHaveClass(styles.actionButton)
       })
     })
 
-    it('remove buttons meet the 44x44px minimum touch target', () => {
+    it('remove buttons carry the action-button class (44x44px min)', () => {
       const onChange = vi.fn()
       render(<IngredientList ingredients={twoIngredients} onChange={onChange} />)
 
       const removeButtons = screen.getAllByRole('button', { name: /remove ingredient/i })
       removeButtons.forEach((button) => {
-        const computed = getComputedStyle(button)
-        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
-        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+        expect(button).toHaveClass(styles.actionButton)
       })
     })
   })

--- a/src/components/IngredientList/IngredientList.test.tsx
+++ b/src/components/IngredientList/IngredientList.test.tsx
@@ -97,4 +97,47 @@ describe('IngredientList', () => {
     expect(moveUpButtons.length).toBeGreaterThan(0)
     expect(moveDownButtons.length).toBeGreaterThan(0)
   })
+
+  describe('accessibility — touch targets', () => {
+    const parsePx = (value: string): number => {
+      const parsed = parseFloat(value)
+      return Number.isNaN(parsed) ? 0 : parsed
+    }
+
+    it('move up buttons meet the 44x44px minimum touch target', () => {
+      const onChange = vi.fn()
+      render(<IngredientList ingredients={twoIngredients} onChange={onChange} />)
+
+      const moveUpButtons = screen.getAllByRole('button', { name: /move up/i })
+      moveUpButtons.forEach((button) => {
+        const computed = getComputedStyle(button)
+        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
+        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+      })
+    })
+
+    it('move down buttons meet the 44x44px minimum touch target', () => {
+      const onChange = vi.fn()
+      render(<IngredientList ingredients={twoIngredients} onChange={onChange} />)
+
+      const moveDownButtons = screen.getAllByRole('button', { name: /move down/i })
+      moveDownButtons.forEach((button) => {
+        const computed = getComputedStyle(button)
+        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
+        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+      })
+    })
+
+    it('remove buttons meet the 44x44px minimum touch target', () => {
+      const onChange = vi.fn()
+      render(<IngredientList ingredients={twoIngredients} onChange={onChange} />)
+
+      const removeButtons = screen.getAllByRole('button', { name: /remove ingredient/i })
+      removeButtons.forEach((button) => {
+        const computed = getComputedStyle(button)
+        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
+        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+      })
+    })
+  })
 })

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -1,16 +1,19 @@
 import Button from '@components/Button'
 import { useReorderableList } from '@hooks/useReorderableList'
 import type { Ingredient } from '@models/recipe'
-import type { FC } from 'react'
+import type { CSSProperties, FC } from 'react'
 
 import styles from './IngredientList.module.css'
 
 export interface IngredientListProps {
   ingredients: Ingredient[]
   onChange: (ingredients: Ingredient[]) => void
+  onAnnounce?: (message: string) => void
 }
 
-const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange }) => {
+const TOUCH_TARGET: CSSProperties = { minWidth: '44px', minHeight: '44px' }
+
+const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnnounce }) => {
   const { add, remove, update, moveUp, moveDown } = useReorderableList(ingredients, onChange)
 
   const handleFieldChange = (index: number, field: keyof Ingredient, value: string) => {
@@ -19,6 +22,25 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange }) => {
 
   const handleAdd = () => {
     add({ item: '', quantity: '', unit: '' })
+    onAnnounce?.('Ingredient added')
+  }
+
+  const handleRemove = (index: number) => {
+    if (ingredients.length <= 1) return
+    remove(index)
+    onAnnounce?.('Ingredient removed')
+  }
+
+  const handleMoveUp = (index: number) => {
+    if (index <= 0) return
+    moveUp(index)
+    onAnnounce?.(`Ingredient ${index + 1} moved up`)
+  }
+
+  const handleMoveDown = (index: number) => {
+    if (index >= ingredients.length - 1) return
+    moveDown(index)
+    onAnnounce?.(`Ingredient ${index + 1} moved down`)
   }
 
   return (
@@ -57,26 +79,29 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange }) => {
           </label>
           <div className={styles.actions}>
             <Button
-              onClick={() => moveUp(index)}
+              onClick={() => handleMoveUp(index)}
               ariaLabel={`Move up ingredient ${index + 1}`}
               variant="secondary"
               disabled={index === 0}
+              style={TOUCH_TARGET}
             >
               ↑
             </Button>
             <Button
-              onClick={() => moveDown(index)}
+              onClick={() => handleMoveDown(index)}
               ariaLabel={`Move down ingredient ${index + 1}`}
               variant="secondary"
               disabled={index === ingredients.length - 1}
+              style={TOUCH_TARGET}
             >
               ↓
             </Button>
             <Button
-              onClick={() => remove(index)}
+              onClick={() => handleRemove(index)}
               ariaLabel={`Remove ingredient ${index + 1}`}
               variant="secondary"
               disabled={ingredients.length <= 1}
+              style={TOUCH_TARGET}
             >
               Remove
             </Button>

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -24,19 +24,16 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
   }
 
   const handleRemove = (index: number) => {
-    if (ingredients.length <= 1) return
     remove(index)
     onAnnounce?.('Ingredient removed')
   }
 
   const handleMoveUp = (index: number) => {
-    if (index <= 0) return
     moveUp(index)
     onAnnounce?.(`Ingredient ${index + 1} moved up`)
   }
 
   const handleMoveDown = (index: number) => {
-    if (index >= ingredients.length - 1) return
     moveDown(index)
     onAnnounce?.(`Ingredient ${index + 1} moved down`)
   }

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -1,7 +1,7 @@
 import Button from '@components/Button'
 import { useReorderableList } from '@hooks/useReorderableList'
 import type { Ingredient } from '@models/recipe'
-import type { CSSProperties, FC } from 'react'
+import type { FC } from 'react'
 
 import styles from './IngredientList.module.css'
 
@@ -10,8 +10,6 @@ export interface IngredientListProps {
   onChange: (ingredients: Ingredient[]) => void
   onAnnounce?: (message: string) => void
 }
-
-const TOUCH_TARGET: CSSProperties = { minWidth: '44px', minHeight: '44px' }
 
 const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnnounce }) => {
   const { add, remove, update, moveUp, moveDown } = useReorderableList(ingredients, onChange)
@@ -83,7 +81,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
               ariaLabel={`Move up ingredient ${index + 1}`}
               variant="secondary"
               disabled={index === 0}
-              style={TOUCH_TARGET}
+              className={styles.actionButton}
             >
               ↑
             </Button>
@@ -92,7 +90,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
               ariaLabel={`Move down ingredient ${index + 1}`}
               variant="secondary"
               disabled={index === ingredients.length - 1}
-              style={TOUCH_TARGET}
+              className={styles.actionButton}
             >
               ↓
             </Button>
@@ -101,7 +99,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
               ariaLabel={`Remove ingredient ${index + 1}`}
               variant="secondary"
               disabled={ingredients.length <= 1}
-              style={TOUCH_TARGET}
+              className={styles.actionButton}
             >
               Remove
             </Button>

--- a/src/components/StepList/StepList.module.css
+++ b/src/components/StepList/StepList.module.css
@@ -87,3 +87,8 @@
     padding-top: var(--space-2);
   }
 }
+
+.actionButton {
+  min-width: 44px;
+  min-height: 44px;
+}

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import StepList from './StepList'
+import styles from './StepList.module.css'
 
 const makeStep = (order: number, text: string): Step => ({ order, text })
 
@@ -69,44 +70,36 @@ describe('StepList', () => {
   })
 
   describe('accessibility — touch targets', () => {
-    const parsePx = (value: string): number => {
-      const parsed = parseFloat(value)
-      return Number.isNaN(parsed) ? 0 : parsed
-    }
-
-    it('move up buttons meet the 44x44px minimum touch target', () => {
+    // Note: jsdom does not apply CSS Modules styles to computed style, so we
+    // assert the button carries the action-button class, which is styled to
+    // the 44x44px minimum in StepList.module.css.
+    it('move up buttons carry the action-button class (44x44px min)', () => {
       const onChange = vi.fn()
       render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
 
       const moveUpButtons = screen.getAllByRole('button', { name: /move up/i })
       moveUpButtons.forEach((button) => {
-        const computed = getComputedStyle(button)
-        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
-        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+        expect(button).toHaveClass(styles.actionButton)
       })
     })
 
-    it('move down buttons meet the 44x44px minimum touch target', () => {
+    it('move down buttons carry the action-button class (44x44px min)', () => {
       const onChange = vi.fn()
       render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
 
       const moveDownButtons = screen.getAllByRole('button', { name: /move down/i })
       moveDownButtons.forEach((button) => {
-        const computed = getComputedStyle(button)
-        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
-        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+        expect(button).toHaveClass(styles.actionButton)
       })
     })
 
-    it('remove buttons meet the 44x44px minimum touch target', () => {
+    it('remove buttons carry the action-button class (44x44px min)', () => {
       const onChange = vi.fn()
       render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
 
       const removeButtons = screen.getAllByRole('button', { name: /remove step/i })
       removeButtons.forEach((button) => {
-        const computed = getComputedStyle(button)
-        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
-        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+        expect(button).toHaveClass(styles.actionButton)
       })
     })
   })

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -67,4 +67,47 @@ describe('StepList', () => {
       { order: 2, text: 'Preheat oven' },
     ])
   })
+
+  describe('accessibility — touch targets', () => {
+    const parsePx = (value: string): number => {
+      const parsed = parseFloat(value)
+      return Number.isNaN(parsed) ? 0 : parsed
+    }
+
+    it('move up buttons meet the 44x44px minimum touch target', () => {
+      const onChange = vi.fn()
+      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+
+      const moveUpButtons = screen.getAllByRole('button', { name: /move up/i })
+      moveUpButtons.forEach((button) => {
+        const computed = getComputedStyle(button)
+        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
+        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+      })
+    })
+
+    it('move down buttons meet the 44x44px minimum touch target', () => {
+      const onChange = vi.fn()
+      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+
+      const moveDownButtons = screen.getAllByRole('button', { name: /move down/i })
+      moveDownButtons.forEach((button) => {
+        const computed = getComputedStyle(button)
+        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
+        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+      })
+    })
+
+    it('remove buttons meet the 44x44px minimum touch target', () => {
+      const onChange = vi.fn()
+      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+
+      const removeButtons = screen.getAllByRole('button', { name: /remove step/i })
+      removeButtons.forEach((button) => {
+        const computed = getComputedStyle(button)
+        expect(parsePx(computed.minWidth)).toBeGreaterThanOrEqual(44)
+        expect(parsePx(computed.minHeight)).toBeGreaterThanOrEqual(44)
+      })
+    })
+  })
 })

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -42,19 +42,16 @@ const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken, onAn
   }
 
   const handleRemove = (index: number) => {
-    if (steps.length <= 1) return
     remove(index)
     onAnnounce?.('Step removed')
   }
 
   const handleMoveUp = (index: number) => {
-    if (index <= 0) return
     moveUp(index)
     onAnnounce?.(`Step ${index + 1} moved up`)
   }
 
   const handleMoveDown = (index: number) => {
-    if (index >= steps.length - 1) return
     moveDown(index)
     onAnnounce?.(`Step ${index + 1} moved down`)
   }

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -2,7 +2,7 @@ import Button from '@components/Button'
 import ImageUpload from '@components/ImageUpload'
 import { useReorderableList } from '@hooks/useReorderableList'
 import type { RecipeImage, Step } from '@models/recipe'
-import { useCallback, type CSSProperties, type FC } from 'react'
+import { useCallback, type FC } from 'react'
 
 import styles from './StepList.module.css'
 
@@ -13,8 +13,6 @@ export interface StepListProps {
   getToken?: () => Promise<string>
   onAnnounce?: (message: string) => void
 }
-
-const TOUCH_TARGET: CSSProperties = { minWidth: '44px', minHeight: '44px' }
 
 const renumber = (steps: Step[]): Step[] =>
   steps.map((step, i) => ({ ...step, order: i + 1 }))
@@ -100,7 +98,7 @@ const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken, onAn
               ariaLabel={`Move up step ${index + 1}`}
               variant="secondary"
               disabled={index === 0}
-              style={TOUCH_TARGET}
+              className={styles.actionButton}
             >
               ↑
             </Button>
@@ -109,7 +107,7 @@ const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken, onAn
               ariaLabel={`Move down step ${index + 1}`}
               variant="secondary"
               disabled={index === steps.length - 1}
-              style={TOUCH_TARGET}
+              className={styles.actionButton}
             >
               ↓
             </Button>
@@ -118,7 +116,7 @@ const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken, onAn
               ariaLabel={`Remove step ${index + 1}`}
               variant="secondary"
               disabled={steps.length <= 1}
-              style={TOUCH_TARGET}
+              className={styles.actionButton}
             >
               Remove
             </Button>

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -2,7 +2,7 @@ import Button from '@components/Button'
 import ImageUpload from '@components/ImageUpload'
 import { useReorderableList } from '@hooks/useReorderableList'
 import type { RecipeImage, Step } from '@models/recipe'
-import { useCallback, type FC } from 'react'
+import { useCallback, type CSSProperties, type FC } from 'react'
 
 import styles from './StepList.module.css'
 
@@ -11,12 +11,15 @@ export interface StepListProps {
   onChange: (steps: Step[]) => void
   recipeId?: string
   getToken?: () => Promise<string>
+  onAnnounce?: (message: string) => void
 }
+
+const TOUCH_TARGET: CSSProperties = { minWidth: '44px', minHeight: '44px' }
 
 const renumber = (steps: Step[]): Step[] =>
   steps.map((step, i) => ({ ...step, order: i + 1 }))
 
-const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken }) => {
+const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken, onAnnounce }) => {
   const onChangeRenumbered = useCallback(
     (next: Step[]) => onChange(renumber(next)),
     [onChange]
@@ -37,6 +40,25 @@ const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken }) =>
 
   const handleAdd = () => {
     add({ order: steps.length + 1, text: '' })
+    onAnnounce?.('Step added')
+  }
+
+  const handleRemove = (index: number) => {
+    if (steps.length <= 1) return
+    remove(index)
+    onAnnounce?.('Step removed')
+  }
+
+  const handleMoveUp = (index: number) => {
+    if (index <= 0) return
+    moveUp(index)
+    onAnnounce?.(`Step ${index + 1} moved up`)
+  }
+
+  const handleMoveDown = (index: number) => {
+    if (index >= steps.length - 1) return
+    moveDown(index)
+    onAnnounce?.(`Step ${index + 1} moved down`)
   }
 
   return (
@@ -74,26 +96,29 @@ const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken }) =>
           </div>
           <div className={styles.actions}>
             <Button
-              onClick={() => moveUp(index)}
+              onClick={() => handleMoveUp(index)}
               ariaLabel={`Move up step ${index + 1}`}
               variant="secondary"
               disabled={index === 0}
+              style={TOUCH_TARGET}
             >
               ↑
             </Button>
             <Button
-              onClick={() => moveDown(index)}
+              onClick={() => handleMoveDown(index)}
               ariaLabel={`Move down step ${index + 1}`}
               variant="secondary"
               disabled={index === steps.length - 1}
+              style={TOUCH_TARGET}
             >
               ↓
             </Button>
             <Button
-              onClick={() => remove(index)}
+              onClick={() => handleRemove(index)}
               ariaLabel={`Remove step ${index + 1}`}
               variant="secondary"
               disabled={steps.length <= 1}
+              style={TOUCH_TARGET}
             >
               Remove
             </Button>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -108,7 +108,6 @@ export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const getAccessToken = async (): Promise<string> => {
     const session = authApi.getCurrentSession()
     if (!session) {
-      logout()
       throw new Error('No session')
     }
 
@@ -128,7 +127,6 @@ export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
       return refreshed.accessToken
     } catch {
-      logout()
       throw new Error('Session expired')
     }
   }

--- a/src/entry-client.tsx
+++ b/src/entry-client.tsx
@@ -1,19 +1,18 @@
-import ScrollToTop from '@components/ScrollToTop'
 import { AuthProvider } from '@contexts/AuthContext'
 import { StrictMode } from 'react'
 import { hydrateRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
-import App from './App'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+
+import { routes } from './routes'
 import './index.css'
+
+const router = createBrowserRouter(routes)
 
 hydrateRoot(
   document.getElementById('root')!,
   <StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <ScrollToTop />
-        <App />
-      </AuthProvider>
-    </BrowserRouter>
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
   </StrictMode>
 )

--- a/src/entry-server.test.tsx
+++ b/src/entry-server.test.tsx
@@ -185,17 +185,19 @@ describe('entry-server render', () => {
     it('rejects or signals an error when the render crashes', async () => {
       vi.resetModules()
 
-      vi.doMock('./App', () => ({
-        default: () => {
-          throw new Error('Simulated render crash')
-        },
+      const CrashingComponent = () => {
+        throw new Error('Simulated render crash')
+      }
+
+      vi.doMock('./routes', () => ({
+        routes: [{ path: '*', element: <CrashingComponent /> }],
       }))
 
       const { render: renderWithError } = await import('./entry-server')
 
       await expect(renderWithError('/')).rejects.toThrow()
 
-      vi.doUnmock('./App')
+      vi.doUnmock('./routes')
       vi.resetModules()
     })
   })

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -3,11 +3,15 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { PassThrough } from 'node:stream'
 import { renderToPipeableStream } from 'react-dom/server'
-import { StaticRouter } from 'react-router-dom'
-import App from './App'
+import {
+  createStaticHandler,
+  createStaticRouter,
+  StaticRouterProvider,
+} from 'react-router-dom'
 import { RecipeDataContext } from './contexts/RecipeDataContext'
 import type { RecipeData } from './contexts/RecipeDataContext'
 import { getMetaTags, escapeHtml } from './meta'
+import { routes } from './routes'
 
 // Read the client-built index.html (copied into dist/server/ by build:prod).
 // Has hashed CSS/JS asset links. Falls back to minimal template for tests.
@@ -80,18 +84,25 @@ const buildHeadHtml = (routePath: string, data?: RecipeData): string => {
   return lines.join('\n    ')
 }
 
+const handler = createStaticHandler(routes)
 
-export const render = (url: string, data?: RecipeData): Promise<string> =>
-  new Promise<string>((resolve, reject) => {
-    const head = buildHeadHtml(url, data)
-    const beforeHtml = templateBeforeOutlet.replace('<!--ssr-head-->', head)
+export const render = async (url: string, data?: RecipeData): Promise<string> => {
+  const request = new Request(`http://localhost${url}`)
+  const context = await handler.query(request)
 
+  if (context instanceof Response) {
+    throw new Error(`Unexpected redirect response during SSR: ${context.status}`)
+  }
+
+  const router = createStaticRouter(handler.dataRoutes, context)
+  const head = buildHeadHtml(url, data)
+  const beforeHtml = templateBeforeOutlet.replace('<!--ssr-head-->', head)
+
+  return new Promise<string>((resolve, reject) => {
     const { pipe } = renderToPipeableStream(
-      <StaticRouter location={url}>
-        <RecipeDataContext.Provider value={data ?? {}}>
-          <App />
-        </RecipeDataContext.Provider>
-      </StaticRouter>,
+      <RecipeDataContext.Provider value={data ?? {}}>
+        <StaticRouterProvider router={router} context={context} />
+      </RecipeDataContext.Provider>,
       {
         onAllReady() {
           const reactStream = new PassThrough({ encoding: 'utf-8' })
@@ -117,3 +128,4 @@ export const render = (url: string, data?: RecipeData): Promise<string> =>
       }
     )
   })
+}

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -88,3 +88,17 @@
   gap: var(--space-3);
   padding: var(--space-6) 0;
 }
+
+.sessionBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+  padding: var(--space-4);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  background: var(--color-warning, var(--color-surface));
+  color: var(--color-text);
+  box-shadow: var(--shadow-sm);
+}

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -1,9 +1,16 @@
 import { createRecipe, fetchMyRecipes, fetchTags, updateRecipe } from '@api/recipes'
 import { useAuth } from '@contexts/AuthContext'
 import type { Recipe } from '@models/recipe'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import {
+  createMemoryRouter,
+  Link,
+  MemoryRouter,
+  Route,
+  RouterProvider,
+  Routes,
+} from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import RecipeEditor from './RecipeEditor'
@@ -313,6 +320,260 @@ describe('RecipeEditor page', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('textbox', { name: /title/i })).toHaveFocus()
+    })
+  })
+
+  describe('unsaved-changes confirmation', () => {
+    it('does not prevent beforeunload when the form is pristine', async () => {
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
+      })
+
+      const event = new Event('beforeunload', { cancelable: true })
+      window.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('prevents beforeunload once the user has made edits (dirty form)', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByRole('textbox', { name: /title/i }), 'My Recipe')
+
+      const event = new Event('beforeunload', { cancelable: true })
+      window.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(true)
+    })
+
+    it('does not prevent beforeunload after a successful save (form becomes pristine)', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByRole('textbox', { name: /title/i }), 'My Recipe')
+      await user.type(screen.getByRole('textbox', { name: /intro/i }), 'A great recipe')
+      await user.type(screen.getAllByRole('textbox', { name: /item/i })[0], 'Flour')
+      await user.type(screen.getAllByRole('textbox', { name: /step.*text/i })[0], 'Mix it all')
+
+      await user.click(screen.getByRole('button', { name: /save as draft/i }))
+
+      await waitFor(() => {
+        expect(createRecipe).toHaveBeenCalled()
+      })
+
+      const event = new Event('beforeunload', { cancelable: true })
+      window.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('blocks React Router navigation and shows a confirmation dialogue when the form is dirty', async () => {
+      const user = userEvent.setup()
+
+      const EditorWithBackLink = () => (
+        <>
+          <Link to="/admin/recipes">Back to list</Link>
+          <RecipeEditor />
+        </>
+      )
+
+      const router = createMemoryRouter(
+        [
+          { path: '/admin/recipes/new', element: <EditorWithBackLink /> },
+          { path: '/admin/recipes', element: <div>Recipe list page</div> },
+        ],
+        { initialEntries: ['/admin/recipes/new'] }
+      )
+
+      render(<RouterProvider router={router} />)
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByRole('textbox', { name: /title/i }), 'My Recipe')
+
+      await user.click(screen.getByRole('link', { name: /back to list/i }))
+
+      const dialog = await screen.findByRole('dialog')
+      expect(dialog).toBeInTheDocument()
+      expect(within(dialog).getByText(/unsaved changes/i)).toBeInTheDocument()
+      // We should still be on the editor page — navigation blocked
+      expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
+    })
+  })
+
+  describe('dynamic list announcements (aria-live)', () => {
+    const findLiveRegionWith = (pattern: RegExp) => {
+      const statusRegions = screen.getAllByRole('status')
+      const match = statusRegions.find(
+        (region) =>
+          region.getAttribute('aria-live') === 'polite' && pattern.test(region.textContent ?? '')
+      )
+      if (!match) {
+        throw new Error(
+          `No aria-live="polite" region with text matching ${pattern}. Regions: ${statusRegions
+            .map((r) => r.textContent)
+            .join(' | ')}`
+        )
+      }
+      return match
+    }
+
+    it('announces when an ingredient is added', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add ingredient/i })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /add ingredient/i }))
+
+      await waitFor(() => {
+        expect(findLiveRegionWith(/ingredient added/i)).toBeInTheDocument()
+      })
+    })
+
+    it('announces when an ingredient is removed', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add ingredient/i })).toBeInTheDocument()
+      })
+
+      // Need at least 2 ingredients to remove — add one first
+      await user.click(screen.getByRole('button', { name: /add ingredient/i }))
+
+      const removeButtons = screen.getAllByRole('button', { name: /remove ingredient/i })
+      await user.click(removeButtons[0])
+
+      await waitFor(() => {
+        expect(findLiveRegionWith(/ingredient removed/i)).toBeInTheDocument()
+      })
+    })
+
+    it('announces when an ingredient is reordered', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add ingredient/i })).toBeInTheDocument()
+      })
+
+      // Need at least 2 ingredients to reorder
+      await user.click(screen.getByRole('button', { name: /add ingredient/i }))
+
+      const moveDownButtons = screen.getAllByRole('button', { name: /move down ingredient/i })
+      await user.click(moveDownButtons[0])
+
+      await waitFor(() => {
+        expect(findLiveRegionWith(/ingredient.*moved/i)).toBeInTheDocument()
+      })
+    })
+
+    it('announces when a step is added', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add step/i })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /add step/i }))
+
+      await waitFor(() => {
+        expect(findLiveRegionWith(/step added/i)).toBeInTheDocument()
+      })
+    })
+
+    it('announces when a step is removed', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add step/i })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /add step/i }))
+
+      const removeButtons = screen.getAllByRole('button', { name: /remove step/i })
+      await user.click(removeButtons[0])
+
+      await waitFor(() => {
+        expect(findLiveRegionWith(/step removed/i)).toBeInTheDocument()
+      })
+    })
+
+    it('announces when a step is reordered', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add step/i })).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /add step/i }))
+
+      const moveDownButtons = screen.getAllByRole('button', { name: /move down step/i })
+      await user.click(moveDownButtons[0])
+
+      await waitFor(() => {
+        expect(findLiveRegionWith(/step.*moved/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('session expiry mid-edit', () => {
+    it('preserves form state and shows a session-expired message when getAccessToken throws', async () => {
+      vi.mocked(useAuth).mockReturnValue({
+        getAccessToken: vi.fn().mockRejectedValue(new Error('Session expired')),
+        isAdmin: true,
+        user: { email: 'admin@akli.dev', groups: ['admin'] },
+        isAuthenticated: true,
+        loading: false,
+        login: vi.fn(),
+        logout: vi.fn(),
+      })
+
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
+      })
+
+      const titleInput = screen.getByRole('textbox', { name: /title/i })
+      const introInput = screen.getByRole('textbox', { name: /intro/i })
+      await user.type(titleInput, 'My Recipe')
+      await user.type(introInput, 'A great recipe')
+      await user.type(screen.getAllByRole('textbox', { name: /item/i })[0], 'Flour')
+      await user.type(screen.getAllByRole('textbox', { name: /step.*text/i })[0], 'Mix it all')
+
+      await user.click(screen.getByRole('button', { name: /save as draft/i }))
+
+      // The session-expired banner is visible to the user
+      await waitFor(() => {
+        expect(
+          screen.getByText(/session expired.*please log in again/i)
+        ).toBeInTheDocument()
+      })
+
+      // Form state is preserved — the editor did not unmount and inputs still hold their values
+      expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('My Recipe')
+      expect(screen.getByRole('textbox', { name: /intro/i })).toHaveValue('A great recipe')
     })
   })
 })

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -3,14 +3,7 @@ import { useAuth } from '@contexts/AuthContext'
 import type { Recipe } from '@models/recipe'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {
-  createMemoryRouter,
-  Link,
-  MemoryRouter,
-  Route,
-  RouterProvider,
-  Routes,
-} from 'react-router-dom'
+import { createMemoryRouter, Link, RouterProvider } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import RecipeEditor from './RecipeEditor'
@@ -46,15 +39,16 @@ const mockRecipe: Recipe = {
   status: 'draft',
 }
 
-const renderEditor = (route = '/admin/recipes/new') =>
-  render(
-    <MemoryRouter initialEntries={[route]}>
-      <Routes>
-        <Route path="/admin/recipes/new" element={<RecipeEditor />} />
-        <Route path="/admin/recipes/:id/edit" element={<RecipeEditor />} />
-      </Routes>
-    </MemoryRouter>
+const renderEditor = (route = '/admin/recipes/new') => {
+  const router = createMemoryRouter(
+    [
+      { path: '/admin/recipes/new', element: <RecipeEditor /> },
+      { path: '/admin/recipes/:id/edit', element: <RecipeEditor /> },
+    ],
+    { initialEntries: [route] }
   )
+  return render(<RouterProvider router={router} />)
+}
 
 describe('RecipeEditor page', () => {
   beforeEach(() => {
@@ -275,9 +269,9 @@ describe('RecipeEditor page', () => {
     await user.click(screen.getByRole('button', { name: /save as draft/i }))
 
     await waitFor(() => {
-      expect(screen.getByRole('status')).toBeInTheDocument()
       expect(screen.getByText(/recipe saved/i)).toBeInTheDocument()
     })
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
   })
 
   it('shows error toast on API failure', async () => {
@@ -303,9 +297,9 @@ describe('RecipeEditor page', () => {
     await user.click(screen.getByRole('button', { name: /save as draft/i }))
 
     await waitFor(() => {
-      expect(screen.getByRole('status')).toBeInTheDocument()
       expect(screen.getByText(/error/i)).toBeInTheDocument()
     })
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
   })
 
   it('first invalid field is focused on validation failure', async () => {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -403,7 +403,6 @@ describe('RecipeEditor page', () => {
       const dialog = await screen.findByRole('dialog')
       expect(dialog).toBeInTheDocument()
       expect(within(dialog).getByText(/unsaved changes/i)).toBeInTheDocument()
-      // We should still be on the editor page — navigation blocked
       expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
     })
   })
@@ -448,7 +447,6 @@ describe('RecipeEditor page', () => {
         expect(screen.getByRole('button', { name: /add ingredient/i })).toBeInTheDocument()
       })
 
-      // Need at least 2 ingredients to remove — add one first
       await user.click(screen.getByRole('button', { name: /add ingredient/i }))
 
       const removeButtons = screen.getAllByRole('button', { name: /remove ingredient/i })
@@ -467,7 +465,6 @@ describe('RecipeEditor page', () => {
         expect(screen.getByRole('button', { name: /add ingredient/i })).toBeInTheDocument()
       })
 
-      // Need at least 2 ingredients to reorder
       await user.click(screen.getByRole('button', { name: /add ingredient/i }))
 
       const moveDownButtons = screen.getAllByRole('button', { name: /move down ingredient/i })
@@ -558,14 +555,12 @@ describe('RecipeEditor page', () => {
 
       await user.click(screen.getByRole('button', { name: /save as draft/i }))
 
-      // The session-expired banner is visible to the user
       await waitFor(() => {
         expect(
           screen.getByText(/session expired.*please log in again/i)
         ).toBeInTheDocument()
       })
 
-      // Form state is preserved — the editor did not unmount and inputs still hold their values
       expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('My Recipe')
       expect(screen.getByRole('textbox', { name: /intro/i })).toHaveValue('A great recipe')
     })

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -95,14 +95,13 @@ const RecipeEditor: FC = () => {
   const [submitting, setSubmitting] = useState(false)
   const [errors, setErrors] = useState<FormErrors>({})
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null)
-  const [announcement, setAnnouncement] = useState<{ message: string; nonce: number }>({
-    message: '',
-    nonce: 0,
-  })
+  const [announcement, setAnnouncement] = useState({ message: '', toggle: false })
   const [sessionExpired, setSessionExpired] = useState(false)
 
   const titleRef = useRef<HTMLInputElement>(null)
   const introRef = useRef<HTMLTextAreaElement>(null)
+  const pathnameRef = useRef(location.pathname)
+  pathnameRef.current = location.pathname
 
   const setField = useCallback(
     <K extends keyof Omit<FormState, 'dirty'>>(field: K, value: FormState[K]) => {
@@ -147,7 +146,7 @@ const RecipeEditor: FC = () => {
       } catch (err) {
         if (isSessionError(err)) {
           logout()
-          navigate(`/admin/login?redirect=${encodeURIComponent(location.pathname)}`)
+          navigate(`/admin/login?redirect=${encodeURIComponent(pathnameRef.current)}`)
           return
         }
         setToast({ message: 'Error loading recipe', type: 'error' })
@@ -156,7 +155,7 @@ const RecipeEditor: FC = () => {
       }
     }
     loadRecipe()
-  }, [id, getAccessToken, logout, navigate, location.pathname])
+  }, [id, getAccessToken, logout, navigate])
 
   const validate = (): FormErrors => {
     const next: FormErrors = {}
@@ -230,7 +229,7 @@ const RecipeEditor: FC = () => {
   }, [])
 
   const announce = useCallback((message: string) => {
-    setAnnouncement((prev) => ({ message, nonce: prev.nonce + 1 }))
+    setAnnouncement((prev) => ({ message, toggle: !prev.toggle }))
   }, [])
 
   const setIngredients = useCallback((next: Ingredient[]) => setField('ingredients', next), [setField])
@@ -401,9 +400,7 @@ const RecipeEditor: FC = () => {
       </form>
 
       <div className="sr-only" role="status" aria-live="polite">
-        {announcement.message
-          ? `${announcement.message}${announcement.nonce % 2 === 1 ? '\u200B' : ''}`
-          : ''}
+        {announcement.message && `${announcement.message}${announcement.toggle ? '\u200B' : ''}`}
       </div>
 
       {toast && (

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -1,15 +1,17 @@
 import { createRecipe, fetchMyRecipes, fetchTags, updateRecipe } from '@api/recipes'
 import Button from '@components/Button'
+import ConfirmDialog from '@components/ConfirmDialog'
 import ImageUpload from '@components/ImageUpload'
 import IngredientList from '@components/IngredientList'
+import Link from '@components/Link'
 import Loading from '@components/Loading'
 import StepList from '@components/StepList'
 import TagInput from '@components/TagInput'
 import Toast from '@components/Toast'
 import { useAuth } from '@contexts/AuthContext'
-import type { Ingredient, Step, Tag } from '@models/recipe'
-import { useCallback, useEffect, useRef, useState, type FC } from 'react'
-import { useParams } from 'react-router-dom'
+import type { Ingredient, Recipe, Step, Tag } from '@models/recipe'
+import { useCallback, useEffect, useReducer, useRef, useState, type FC } from 'react'
+import { useBlocker, useLocation, useParams } from 'react-router-dom'
 
 import styles from './RecipeEditor.module.css'
 
@@ -20,32 +22,106 @@ interface FormErrors {
   steps?: string
 }
 
+interface FormState {
+  title: string
+  intro: string
+  prepTime: number
+  cookTime: number
+  servings: number
+  tags: string[]
+  ingredients: Ingredient[]
+  steps: Step[]
+  coverImageKey: string
+  coverImageAlt: string
+  status: string
+  dirty: boolean
+}
+
+type FormAction =
+  | { type: 'SET_FIELD'; field: keyof Omit<FormState, 'dirty'>; value: FormState[keyof Omit<FormState, 'dirty'>] }
+  | { type: 'LOAD_RECIPE'; recipe: Recipe }
+  | { type: 'MARK_PRISTINE' }
+
+const initialFormState: FormState = {
+  title: '',
+  intro: '',
+  prepTime: 0,
+  cookTime: 0,
+  servings: 0,
+  tags: [],
+  ingredients: [{ item: '', quantity: '', unit: '' }],
+  steps: [{ order: 1, text: '' }],
+  coverImageKey: '',
+  coverImageAlt: '',
+  status: 'draft',
+  dirty: false,
+}
+
+const formReducer = (state: FormState, action: FormAction): FormState => {
+  switch (action.type) {
+    case 'SET_FIELD':
+      return { ...state, [action.field]: action.value, dirty: true }
+    case 'LOAD_RECIPE':
+      return {
+        title: action.recipe.title,
+        intro: action.recipe.intro,
+        prepTime: action.recipe.prepTime,
+        cookTime: action.recipe.cookTime,
+        servings: action.recipe.servings,
+        tags: action.recipe.tags,
+        ingredients: action.recipe.ingredients,
+        steps: action.recipe.steps,
+        coverImageKey: action.recipe.coverImage.key,
+        coverImageAlt: action.recipe.coverImage.alt,
+        status: action.recipe.status,
+        dirty: false,
+      }
+    case 'MARK_PRISTINE':
+      return { ...state, dirty: false }
+  }
+}
+
+const isSessionError = (err: unknown): boolean => {
+  const message = err instanceof Error ? err.message : ''
+  return /session expired|no session/i.test(message)
+}
+
 const RecipeEditor: FC = () => {
   const { id } = useParams<{ id: string }>()
   const isEditMode = Boolean(id)
   const { getAccessToken } = useAuth()
+  const location = useLocation()
 
-  const [title, setTitle] = useState('')
-  const [intro, setIntro] = useState('')
-  const [prepTime, setPrepTime] = useState(0)
-  const [cookTime, setCookTime] = useState(0)
-  const [servings, setServings] = useState(0)
-  const [tags, setTags] = useState<string[]>([])
+  const [form, dispatch] = useReducer(formReducer, initialFormState)
   const [existingTags, setExistingTags] = useState<string[]>([])
-  const [ingredients, setIngredients] = useState<Ingredient[]>([
-    { item: '', quantity: '', unit: '' },
-  ])
-  const [steps, setSteps] = useState<Step[]>([{ order: 1, text: '' }])
-  const [coverImageKey, setCoverImageKey] = useState('')
-  const [coverImageAlt, setCoverImageAlt] = useState('')
-  const [status, setStatus] = useState('draft')
   const [loading, setLoading] = useState(isEditMode)
   const [submitting, setSubmitting] = useState(false)
   const [errors, setErrors] = useState<FormErrors>({})
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null)
+  const [announcement, setAnnouncement] = useState('')
+  const [sessionExpired, setSessionExpired] = useState(false)
 
   const titleRef = useRef<HTMLInputElement>(null)
   const introRef = useRef<HTMLTextAreaElement>(null)
+
+  const setField = useCallback(
+    <K extends keyof Omit<FormState, 'dirty'>>(field: K, value: FormState[K]) => {
+      dispatch({ type: 'SET_FIELD', field, value })
+    },
+    []
+  )
+
+  const blocker = useBlocker(form.dirty)
+
+  useEffect(() => {
+    if (!form.dirty) return
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [form.dirty])
 
   useEffect(() => {
     const loadTags = async () => {
@@ -67,17 +143,7 @@ const RecipeEditor: FC = () => {
         const recipes = await fetchMyRecipes(token)
         const recipe = recipes.find((r) => r.id === id)
         if (!recipe) throw new Error('Recipe not found')
-        setTitle(recipe.title)
-        setIntro(recipe.intro)
-        setPrepTime(recipe.prepTime)
-        setCookTime(recipe.cookTime)
-        setServings(recipe.servings)
-        setTags(recipe.tags)
-        setIngredients(recipe.ingredients)
-        setSteps(recipe.steps)
-        setCoverImageKey(recipe.coverImage.key)
-        setCoverImageAlt(recipe.coverImage.alt)
-        setStatus(recipe.status)
+        dispatch({ type: 'LOAD_RECIPE', recipe })
       } catch {
         setToast({ message: 'Error loading recipe', type: 'error' })
       } finally {
@@ -89,12 +155,12 @@ const RecipeEditor: FC = () => {
 
   const validate = (): FormErrors => {
     const next: FormErrors = {}
-    if (!title.trim()) next.title = 'Title is required'
-    if (!intro.trim()) next.intro = 'Intro is required'
-    if (!ingredients.some((ing) => ing.item.trim())) {
+    if (!form.title.trim()) next.title = 'Title is required'
+    if (!form.intro.trim()) next.intro = 'Intro is required'
+    if (!form.ingredients.some((ing) => ing.item.trim())) {
       next.ingredients = 'At least one ingredient with an item is required'
     }
-    if (!steps.some((s) => s.text.trim())) {
+    if (!form.steps.some((s) => s.text.trim())) {
       next.steps = 'At least one step with text is required'
     }
     return next
@@ -121,15 +187,15 @@ const RecipeEditor: FC = () => {
     try {
       const token = await getAccessToken()
       const data = {
-        title,
-        intro,
-        prepTime,
-        cookTime,
-        servings,
-        tags,
-        ingredients,
-        steps,
-        coverImage: { key: coverImageKey, alt: coverImageAlt },
+        title: form.title,
+        intro: form.intro,
+        prepTime: form.prepTime,
+        cookTime: form.cookTime,
+        servings: form.servings,
+        tags: form.tags,
+        ingredients: form.ingredients,
+        steps: form.steps,
+        coverImage: { key: form.coverImageKey, alt: form.coverImageAlt },
         status: targetStatus,
       }
 
@@ -139,11 +205,16 @@ const RecipeEditor: FC = () => {
         await createRecipe(token, data)
       }
 
+      dispatch({ type: 'MARK_PRISTINE' })
       const message = targetStatus === 'published' ? 'Recipe published' : 'Recipe saved'
       setToast({ message, type: 'success' })
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'An error occurred'
-      setToast({ message: `Error: ${message}`, type: 'error' })
+      if (isSessionError(err)) {
+        setSessionExpired(true)
+      } else {
+        const message = err instanceof Error ? err.message : 'An error occurred'
+        setToast({ message: `Error: ${message}`, type: 'error' })
+      }
     } finally {
       setSubmitting(false)
     }
@@ -153,6 +224,15 @@ const RecipeEditor: FC = () => {
     setToast(null)
   }, [])
 
+  const announce = useCallback((message: string) => {
+    setAnnouncement(message)
+  }, [])
+
+  const setIngredients = useCallback((next: Ingredient[]) => setField('ingredients', next), [setField])
+  const setSteps = useCallback((next: Step[]) => setField('steps', next), [setField])
+  const setTags = useCallback((next: string[]) => setField('tags', next), [setField])
+  const setCoverImageKey = useCallback((key: string) => setField('coverImageKey', key), [setField])
+
   if (loading) {
     return (
       <div className={styles.loadingWrapper}>
@@ -161,8 +241,17 @@ const RecipeEditor: FC = () => {
     )
   }
 
+  const loginHref = `/admin/login?redirect=${encodeURIComponent(location.pathname)}`
+
   return (
     <div className={styles.container}>
+      {sessionExpired && (
+        <div className={styles.sessionBanner} role="alert">
+          <span>Session expired — please log in again</span>
+          <Link to={loginHref}>Log in again</Link>
+        </div>
+      )}
+
       <form
         className={styles.form}
         onSubmit={(e) => {
@@ -176,8 +265,8 @@ const RecipeEditor: FC = () => {
               ref={titleRef}
               id="recipe-title"
               type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
+              value={form.title}
+              onChange={(e) => setField('title', e.target.value)}
               className={styles.input}
               aria-invalid={errors.title ? 'true' : undefined}
             />
@@ -189,8 +278,8 @@ const RecipeEditor: FC = () => {
             <textarea
               ref={introRef}
               id="recipe-intro"
-              value={intro}
-              onChange={(e) => setIntro(e.target.value)}
+              value={form.intro}
+              onChange={(e) => setField('intro', e.target.value)}
               className={styles.textarea}
               aria-invalid={errors.intro ? 'true' : undefined}
             />
@@ -201,7 +290,7 @@ const RecipeEditor: FC = () => {
         <div className={styles.section}>
           <ImageUpload
             onUpload={setCoverImageKey}
-            currentKey={coverImageKey || undefined}
+            currentKey={form.coverImageKey || undefined}
             getToken={getAccessToken}
             id={id}
           />
@@ -214,8 +303,8 @@ const RecipeEditor: FC = () => {
               <input
                 id="recipe-prep-time"
                 type="number"
-                value={prepTime}
-                onChange={(e) => setPrepTime(Number(e.target.value))}
+                value={form.prepTime}
+                onChange={(e) => setField('prepTime', Number(e.target.value))}
                 className={styles.numberInput}
               />
             </div>
@@ -224,8 +313,8 @@ const RecipeEditor: FC = () => {
               <input
                 id="recipe-cook-time"
                 type="number"
-                value={cookTime}
-                onChange={(e) => setCookTime(Number(e.target.value))}
+                value={form.cookTime}
+                onChange={(e) => setField('cookTime', Number(e.target.value))}
                 className={styles.numberInput}
               />
             </div>
@@ -234,8 +323,8 @@ const RecipeEditor: FC = () => {
               <input
                 id="recipe-servings"
                 type="number"
-                value={servings}
-                onChange={(e) => setServings(Number(e.target.value))}
+                value={form.servings}
+                onChange={(e) => setField('servings', Number(e.target.value))}
                 className={styles.numberInput}
               />
             </div>
@@ -247,7 +336,7 @@ const RecipeEditor: FC = () => {
             <label htmlFor="recipe-tags">Tags</label>
             <TagInput
               inputId="recipe-tags"
-              tags={tags}
+              tags={form.tags}
               onChange={setTags}
               existingTags={existingTags}
               placeholder="Add a tag and press Enter"
@@ -256,16 +345,21 @@ const RecipeEditor: FC = () => {
         </div>
 
         <div className={styles.section}>
-          <IngredientList ingredients={ingredients} onChange={setIngredients} />
+          <IngredientList
+            ingredients={form.ingredients}
+            onChange={setIngredients}
+            onAnnounce={announce}
+          />
           {errors.ingredients && <span className={styles.error}>{errors.ingredients}</span>}
         </div>
 
         <div className={styles.section}>
           <StepList
-            steps={steps}
+            steps={form.steps}
             onChange={setSteps}
             recipeId={id}
             getToken={getAccessToken}
+            onAnnounce={announce}
           />
           {errors.steps && <span className={styles.error}>{errors.steps}</span>}
         </div>
@@ -273,7 +367,7 @@ const RecipeEditor: FC = () => {
         <div className={styles.actions}>
           {isEditMode ? (
             <Button
-              onClick={() => handleSubmit(status)}
+              onClick={() => handleSubmit(form.status)}
               type="button"
               disabled={submitting}
             >
@@ -301,9 +395,23 @@ const RecipeEditor: FC = () => {
         </div>
       </form>
 
+      <div className="sr-only" role="status" aria-live="polite">
+        {announcement}
+      </div>
+
       {toast && (
         <Toast message={toast.message} type={toast.type} onDismiss={handleDismissToast} />
       )}
+
+      <ConfirmDialog
+        isOpen={blocker.state === 'blocked'}
+        title="Unsaved changes"
+        message="Are you sure you want to leave this page? Your edits will be lost."
+        confirmLabel="Discard changes"
+        cancelLabel="Stay on this page"
+        onConfirm={() => blocker.proceed?.()}
+        onCancel={() => blocker.reset?.()}
+      />
     </div>
   )
 }

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -1,3 +1,4 @@
+import { isSessionError } from '@api/auth'
 import { createRecipe, fetchMyRecipes, fetchTags, updateRecipe } from '@api/recipes'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
@@ -11,7 +12,7 @@ import Toast from '@components/Toast'
 import { useAuth } from '@contexts/AuthContext'
 import type { Ingredient, Recipe, Step, Tag } from '@models/recipe'
 import { useCallback, useEffect, useReducer, useRef, useState, type FC } from 'react'
-import { useBlocker, useLocation, useParams } from 'react-router-dom'
+import { useBlocker, useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import styles from './RecipeEditor.module.css'
 
@@ -81,16 +82,12 @@ const formReducer = (state: FormState, action: FormAction): FormState => {
   }
 }
 
-const isSessionError = (err: unknown): boolean => {
-  const message = err instanceof Error ? err.message : ''
-  return /session expired|no session/i.test(message)
-}
-
 const RecipeEditor: FC = () => {
   const { id } = useParams<{ id: string }>()
   const isEditMode = Boolean(id)
-  const { getAccessToken } = useAuth()
+  const { getAccessToken, logout } = useAuth()
   const location = useLocation()
+  const navigate = useNavigate()
 
   const [form, dispatch] = useReducer(formReducer, initialFormState)
   const [existingTags, setExistingTags] = useState<string[]>([])
@@ -98,7 +95,10 @@ const RecipeEditor: FC = () => {
   const [submitting, setSubmitting] = useState(false)
   const [errors, setErrors] = useState<FormErrors>({})
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null)
-  const [announcement, setAnnouncement] = useState('')
+  const [announcement, setAnnouncement] = useState<{ message: string; nonce: number }>({
+    message: '',
+    nonce: 0,
+  })
   const [sessionExpired, setSessionExpired] = useState(false)
 
   const titleRef = useRef<HTMLInputElement>(null)
@@ -144,14 +144,19 @@ const RecipeEditor: FC = () => {
         const recipe = recipes.find((r) => r.id === id)
         if (!recipe) throw new Error('Recipe not found')
         dispatch({ type: 'LOAD_RECIPE', recipe })
-      } catch {
+      } catch (err) {
+        if (isSessionError(err)) {
+          logout()
+          navigate(`/admin/login?redirect=${encodeURIComponent(location.pathname)}`)
+          return
+        }
         setToast({ message: 'Error loading recipe', type: 'error' })
       } finally {
         setLoading(false)
       }
     }
     loadRecipe()
-  }, [id, getAccessToken])
+  }, [id, getAccessToken, logout, navigate, location.pathname])
 
   const validate = (): FormErrors => {
     const next: FormErrors = {}
@@ -225,7 +230,7 @@ const RecipeEditor: FC = () => {
   }, [])
 
   const announce = useCallback((message: string) => {
-    setAnnouncement(message)
+    setAnnouncement((prev) => ({ message, nonce: prev.nonce + 1 }))
   }, [])
 
   const setIngredients = useCallback((next: Ingredient[]) => setField('ingredients', next), [setField])
@@ -396,7 +401,9 @@ const RecipeEditor: FC = () => {
       </form>
 
       <div className="sr-only" role="status" aria-live="polite">
-        {announcement}
+        {announcement.message
+          ? `${announcement.message}${announcement.nonce % 2 === 1 ? '\u200B' : ''}`
+          : ''}
       </div>
 
       {toast && (

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -1,3 +1,4 @@
+import { isSessionError } from '@api/auth'
 import { deleteRecipe, fetchMyRecipes, publishRecipe, unpublishRecipe } from '@api/recipes'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
@@ -27,8 +28,7 @@ const RecipeList = () => {
       const data = await fetchMyRecipes(token)
       setRecipes(data)
     } catch (err) {
-      const message = err instanceof Error ? err.message : ''
-      if (message.includes('401') || message.includes('Session expired') || message.includes('No session')) {
+      if (isSessionError(err)) {
         logout()
         navigate('/admin/login')
       } else {

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -1,3 +1,4 @@
+import { isSessionError } from '@api/auth'
 import { fetchMyRecipes, publishRecipe } from '@api/recipes'
 import Link from '@components/Link'
 import Loading from '@components/Loading'
@@ -9,11 +10,6 @@ import { useCallback, useEffect, useState, type FC } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import styles from './RecipePreview.module.css'
-
-const isSessionError = (err: unknown): boolean => {
-  const message = err instanceof Error ? err.message : ''
-  return /session expired|no session/i.test(message)
-}
 
 const RecipePreview: FC = () => {
   const { id } = useParams<{ id: string }>()

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -6,13 +6,19 @@ import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
 import type { Recipe } from '@models/recipe'
 import { useCallback, useEffect, useState, type FC } from 'react'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 
 import styles from './RecipePreview.module.css'
 
+const isSessionError = (err: unknown): boolean => {
+  const message = err instanceof Error ? err.message : ''
+  return /session expired|no session/i.test(message)
+}
+
 const RecipePreview: FC = () => {
   const { id } = useParams<{ id: string }>()
-  const { getAccessToken } = useAuth()
+  const { getAccessToken, logout } = useAuth()
+  const navigate = useNavigate()
 
   const [recipe, setRecipe] = useState<Recipe | undefined>()
   const [loading, setLoading] = useState(true)
@@ -36,8 +42,14 @@ const RecipePreview: FC = () => {
         } else {
           setRecipe(found)
         }
-      } catch {
-        if (!cancelled) setNotFound(true)
+      } catch (err) {
+        if (cancelled) return
+        if (isSessionError(err)) {
+          logout()
+          navigate('/admin/login')
+          return
+        }
+        setNotFound(true)
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -48,7 +60,7 @@ const RecipePreview: FC = () => {
     return () => {
       cancelled = true
     }
-  }, [id, getAccessToken])
+  }, [id, getAccessToken, logout, navigate])
 
   const handlePublish = useCallback(async () => {
     if (!recipe) return

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,115 @@
+import Header from '@components/Header'
+import Layout from '@components/Layout'
+import Loading from '@components/Loading'
+import ProtectedRoute from '@components/ProtectedRoute'
+import ScrollToTop from '@components/ScrollToTop'
+import Apps from '@pages/Apps'
+import Blog from '@pages/Blog'
+import BlogPost from '@pages/Blog/BlogPost'
+import Home from '@pages/Home'
+import NotFound from '@pages/NotFound'
+import RecipeDetail from '@pages/RecipeDetail'
+import Recipes from '@pages/Recipes'
+import { lazy, Suspense, type ReactNode } from 'react'
+import { Outlet, type RouteObject } from 'react-router-dom'
+
+const Login = lazy(() => import('@pages/admin/Login'))
+const RecipeList = lazy(() => import('@pages/admin/RecipeList'))
+const RecipeEditor = lazy(() => import('@pages/admin/RecipeEditor'))
+const RecipePreview = lazy(() => import('@pages/admin/RecipePreview'))
+const UserManagement = lazy(() => import('@pages/admin/UserManagement'))
+
+const AdminSuspense = ({ children }: { children: ReactNode }) => (
+  <Suspense
+    fallback={
+      <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--space-12) 0' }}>
+        <Loading />
+      </div>
+    }
+  >
+    {children}
+  </Suspense>
+)
+
+const RootLayout = () => (
+  <>
+    <Header />
+    <ScrollToTop />
+    <Layout>
+      <Outlet />
+    </Layout>
+  </>
+)
+
+export const routes: RouteObject[] = [
+  {
+    element: <RootLayout />,
+    children: [
+      { path: '/', element: <Home /> },
+      { path: '/apps', element: <Apps /> },
+      { path: '/blog', element: <Blog /> },
+      { path: '/blog/:slug', element: <BlogPost /> },
+      { path: '/recipes', element: <Recipes /> },
+      { path: '/recipes/:slug', element: <RecipeDetail /> },
+      {
+        path: '/admin/login',
+        element: (
+          <AdminSuspense>
+            <Login />
+          </AdminSuspense>
+        ),
+      },
+      {
+        path: '/admin/recipes',
+        element: (
+          <AdminSuspense>
+            <ProtectedRoute>
+              <RecipeList />
+            </ProtectedRoute>
+          </AdminSuspense>
+        ),
+      },
+      {
+        path: '/admin/recipes/new',
+        element: (
+          <AdminSuspense>
+            <ProtectedRoute>
+              <RecipeEditor />
+            </ProtectedRoute>
+          </AdminSuspense>
+        ),
+      },
+      {
+        path: '/admin/recipes/:id/edit',
+        element: (
+          <AdminSuspense>
+            <ProtectedRoute>
+              <RecipeEditor />
+            </ProtectedRoute>
+          </AdminSuspense>
+        ),
+      },
+      {
+        path: '/admin/recipes/:id/preview',
+        element: (
+          <AdminSuspense>
+            <ProtectedRoute>
+              <RecipePreview />
+            </ProtectedRoute>
+          </AdminSuspense>
+        ),
+      },
+      {
+        path: '/admin/users',
+        element: (
+          <AdminSuspense>
+            <ProtectedRoute requiredRole="admin">
+              <UserManagement />
+            </ProtectedRoute>
+          </AdminSuspense>
+        ),
+      },
+      { path: '*', element: <NotFound /> },
+    ],
+  },
+]


### PR DESCRIPTION
Closes #141

## What changed

- **useReducer for form state** in `RecipeEditor.tsx` — consolidated 11 field `useState` hooks into a single `formReducer` with a `dirty` flag
- **Unsaved-changes prompts** — `beforeunload` handler registered only when dirty; `useBlocker` surfaces a `ConfirmDialog` on in-app navigation
- **aria-live polite announcements** for ingredient/step add/remove/reorder — `IngredientList` / `StepList` gained an optional `onAnnounce` prop wired through `useReorderableList`
- **Session expiry mid-edit** — save path catches `isSessionError(err)` (new shared helper in `@api/auth`), sets a banner with a "Log in again" link, and preserves form state instead of unmounting. Load path redirects to login since there's no state to preserve
- **44×44 min touch targets** on move-up/down/remove buttons via `.actionButton` CSS Modules class
- **Data router migration** — `<Routes>` + `<BrowserRouter>`/`<StaticRouter>` replaced with `createBrowserRouter` + `RouterProvider` (client) and `createStaticHandler` + `StaticRouterProvider` (SSR). Route definitions extracted to `src/routes.tsx`. Required for `useBlocker`

## Why

#121 shipped with 5 acceptance criteria unmet (surfaced during close-out tick-off). This PR addresses all of them plus the manual-QA pass. The data-router migration is forced by `useBlocker`'s requirement and positions the app on the React Router v7 recommended architecture.

## How to verify

- `pnpm test` (462 pass) and `pnpm lint` (0 errors)
- Log in to `/admin`, open an existing recipe, edit a field, then:
  - Hit browser back / close tab → native unsaved-changes prompt fires
  - Click an in-app nav link → `ConfirmDialog` appears with "Discard changes" / "Stay on this page"
  - Wait for token expiry, then Save → banner appears with form state intact
- Add/remove/reorder an ingredient or step with a screen reader on → "Ingredient added" / "Step 2 moved up" / etc. announced
- Tap move/remove buttons on a mobile device → minimum 44×44 hit area

## Decisions made

- **Data router migration rather than custom history-intercept**: user-approved after weighing blast radius vs. future idiomatic use of `useBlocker` / loaders / actions
- **Announcement re-announces via toggled zero-width space** rather than a `key`-forced remount — some screen readers treat a remounted live region as new and won't announce
- **`getAccessToken` no longer calls `logout()` on refresh failure** — callers (RecipeEditor load, RecipeList, RecipePreview) now handle session errors explicitly, which is what lets the editor save path preserve state and show the banner instead of being yanked out by ProtectedRoute
- **Manual QA**: not walked through in-browser this pass. The automated tests cover the AC behaviours; recommend a short smoke test on the merged epic branch before epic→main

🤖 Generated with [Claude Code](https://claude.com/claude-code)