### PR TITLE
Build user management page

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -70,3 +70,14 @@ export const isSessionError = (err: unknown): boolean => {
   const message = err instanceof Error ? err.message : ''
   return /session expired|no session|401/i.test(message)
 }
+
+export const handleSessionError = (
+  err: unknown,
+  logout: () => void,
+  navigate: (path: string) => void
+): boolean => {
+  if (!isSessionError(err)) return false
+  logout()
+  navigate('/admin/login')
+  return true
+}

--- a/src/api/users.test.ts
+++ b/src/api/users.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchUsers, inviteUser, removeUser } from './users'
+import { fetchUsers, inviteUser, removeUser, UserExistsError } from './users'
 
 beforeEach(() => {
   vi.restoreAllMocks()
@@ -68,6 +68,21 @@ describe('inviteUser', () => {
         }),
         body: JSON.stringify({ email: 'new@example.com', role: 'editor' }),
       })
+    )
+  })
+
+  it('throws UserExistsError when the response is 409', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        statusText: 'Conflict',
+      })
+    )
+
+    await expect(inviteUser('token-123', 'dup@example.com', 'contributor')).rejects.toBeInstanceOf(
+      UserExistsError
     )
   })
 })

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -2,6 +2,13 @@ import type { AdminUser } from '@models/auth'
 
 const API_BASE = import.meta.env.VITE_API_BASE ?? 'https://api.akli.dev'
 
+export class UserExistsError extends Error {
+  constructor(message = 'User already exists') {
+    super(message)
+    this.name = 'UserExistsError'
+  }
+}
+
 export const fetchUsers = async (token: string): Promise<AdminUser[]> => {
   const response = await fetch(`${API_BASE}/auth/users`, {
     headers: { Authorization: `Bearer ${token}` },
@@ -26,6 +33,9 @@ export const inviteUser = async (
     body: JSON.stringify({ email, role }),
   })
   if (!response.ok) {
+    if (response.status === 409) {
+      throw new UserExistsError()
+    }
     throw new Error(`${response.status} ${response.statusText}`)
   }
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,7 +2,7 @@ import { ReactNode, ReactElement } from 'react'
 import styles from './Button.module.css'
 
 interface ButtonProps {
-  onClick: () => void
+  onClick?: () => void
   children: ReactNode
   type?: 'button' | 'submit' | 'reset'
   variant?: 'primary' | 'secondary'

--- a/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -27,15 +27,23 @@ const renderProtectedRoute = (initialPath: string, requiredRole?: string) =>
   render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
+        <Route path="/admin/login" element={<div>Login page</div>} />
         <Route
-          path="/admin/*"
+          path="/admin/recipes"
+          element={
+            <ProtectedRoute>
+              <div>Recipes page</div>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/admin/users"
           element={
             <ProtectedRoute requiredRole={requiredRole}>
               <div>Protected content</div>
             </ProtectedRoute>
           }
         />
-        <Route path="/admin/login" element={<div>Login page</div>} />
       </Routes>
       <LocationDisplay />
     </MemoryRouter>
@@ -55,7 +63,7 @@ describe('ProtectedRoute', () => {
 
     renderProtectedRoute('/admin/recipes')
 
-    expect(screen.queryByText('Protected content')).not.toBeInTheDocument()
+    expect(screen.queryByText('Recipes page')).not.toBeInTheDocument()
     expect(screen.getByTestId('location')).toHaveTextContent('/admin/login')
   })
 
@@ -90,7 +98,7 @@ describe('ProtectedRoute', () => {
 
     renderProtectedRoute('/admin/recipes')
 
-    expect(screen.getByText('Protected content')).toBeInTheDocument()
+    expect(screen.getByText('Recipes page')).toBeInTheDocument()
   })
 
   it('shows loading spinner while checking auth', () => {
@@ -107,7 +115,7 @@ describe('ProtectedRoute', () => {
     renderProtectedRoute('/admin/recipes')
 
     expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
-    expect(screen.queryByText('Protected content')).not.toBeInTheDocument()
+    expect(screen.queryByText('Recipes page')).not.toBeInTheDocument()
   })
 
   it('redirects non-admin from admin-only route', () => {

--- a/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -14,7 +14,13 @@ const mockedUseAuth = vi.mocked(useAuth)
 
 const LocationDisplay = () => {
   const location = useLocation()
-  return <div data-testid="location">{location.pathname}{location.search}</div>
+  const state = location.state as { accessDenied?: boolean } | null
+  return (
+    <div data-testid="location" data-access-denied={state?.accessDenied ? 'true' : 'false'}>
+      {location.pathname}
+      {location.search}
+    </div>
+  )
 }
 
 const renderProtectedRoute = (initialPath: string, requiredRole?: string) =>
@@ -119,5 +125,21 @@ describe('ProtectedRoute', () => {
 
     expect(screen.queryByText('Protected content')).not.toBeInTheDocument()
     expect(screen.getByTestId('location')).toHaveTextContent('/admin/recipes')
+  })
+
+  it('passes accessDenied state when redirecting a non-admin from an admin-only route', () => {
+    mockedUseAuth.mockReturnValue({
+      isAuthenticated: true,
+      isAdmin: false,
+      user: { email: 'test@example.com', groups: ['contributor'] },
+      loading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+      getAccessToken: vi.fn(),
+    })
+
+    renderProtectedRoute('/admin/users', 'admin')
+
+    expect(screen.getByTestId('location')).toHaveAttribute('data-access-denied', 'true')
   })
 })

--- a/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -21,7 +21,7 @@ const ProtectedRoute: FC<ProtectedRouteProps> = ({ children, requiredRole }) => 
   }
 
   if (requiredRole === 'admin' && !isAdmin) {
-    return <Navigate to="/admin/recipes" replace />
+    return <Navigate to="/admin/recipes" replace state={{ accessDenied: true }} />
   }
 
   return <>{children}</>

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,20 +1,26 @@
 import Button from '@components/Button'
-import { useEffect, type FC } from 'react'
+import { useEffect, useRef, type FC } from 'react'
 
 
 import styles from './Toast.module.css'
 
-export interface ToastProps {
+export interface ToastState {
   message: string
   type: 'success' | 'error'
+}
+
+export interface ToastProps extends ToastState {
   onDismiss: () => void
 }
 
 const Toast: FC<ToastProps> = ({ message, type, onDismiss }) => {
+  const onDismissRef = useRef(onDismiss)
+  onDismissRef.current = onDismiss
+
   useEffect(() => {
-    const timer = setTimeout(onDismiss, 5000)
+    const timer = setTimeout(() => onDismissRef.current(), 5000)
     return () => clearTimeout(timer)
-  }, [onDismiss])
+  }, [])
 
   return (
     <div

--- a/src/components/Toast/index.ts
+++ b/src/components/Toast/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Toast'
-export type { ToastProps } from './Toast'
+export type { ToastProps, ToastState } from './Toast'

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import * as authApi from '@api/auth'
 import type { AuthResult, AuthTokens, User } from '@models/auth'
-import { createContext, useContext, useState, type FC, type ReactNode } from 'react'
+import { createContext, useCallback, useContext, useMemo, useState, type FC, type ReactNode } from 'react'
 
 export interface AuthContextValue {
   user: User | null
@@ -68,7 +68,7 @@ export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   const isAdmin = user?.groups.includes('admin') ?? false
 
-  const login = async (email: string, password: string): Promise<AuthResult> => {
+  const login = useCallback(async (email: string, password: string): Promise<AuthResult> => {
     const result = await authApi.login(email, password)
 
     if (isTokenResult(result)) {
@@ -84,28 +84,15 @@ export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
     }
 
     return result
-  }
+  }, [])
 
-  const logout = (): void => {
+  const logout = useCallback((): void => {
     authApi.logout()
     setUser(null)
     setIsAuthenticated(false)
-  }
+  }, [])
 
-  const isTokenExpired = (token: string): boolean => {
-    try {
-      const parts = token.split('.')
-      if (parts.length !== 3) return true
-      const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
-      const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
-      const payload = JSON.parse(atob(padded))
-      return !payload.exp || payload.exp * 1000 < Date.now()
-    } catch {
-      return true
-    }
-  }
-
-  const getAccessToken = async (): Promise<string> => {
+  const getAccessToken = useCallback(async (): Promise<string> => {
     const session = authApi.getCurrentSession()
     if (!session) {
       throw new Error('No session')
@@ -129,13 +116,25 @@ export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
     } catch {
       throw new Error('Session expired')
     }
-  }
+  }, [])
 
-  return (
-    <AuthContext.Provider
-      value={{ user, isAuthenticated, isAdmin, loading, login, logout, getAccessToken }}
-    >
-      {children}
-    </AuthContext.Provider>
+  const value = useMemo(
+    () => ({ user, isAuthenticated, isAdmin, loading, login, logout, getAccessToken }),
+    [user, isAuthenticated, isAdmin, loading, login, logout, getAccessToken]
   )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+const isTokenExpired = (token: string): boolean => {
+  try {
+    const parts = token.split('.')
+    if (parts.length !== 3) return true
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+    const payload = JSON.parse(atob(padded))
+    return !payload.exp || payload.exp * 1000 < Date.now()
+  } catch {
+    return true
+  }
 }

--- a/src/pages/admin/RecipeList/RecipeList.test.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.test.tsx
@@ -63,6 +63,15 @@ const renderRecipeList = () =>
     </MemoryRouter>
   )
 
+const renderRecipeListWithAccessDenied = () =>
+  render(
+    <MemoryRouter
+      initialEntries={[{ pathname: '/admin/recipes', state: { accessDenied: true } }]}
+    >
+      <RecipeList />
+    </MemoryRouter>
+  )
+
 describe('Admin RecipeList page', () => {
   beforeEach(() => {
     vi.resetAllMocks()
@@ -195,5 +204,17 @@ describe('Admin RecipeList page', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
     })
+  })
+
+  it('shows an "Access denied" toast when navigated here with accessDenied state', async () => {
+    renderRecipeListWithAccessDenied()
+
+    const toast = await screen.findByText(/access denied/i)
+    expect(toast).toBeInTheDocument()
+
+    // The toast should use role="status" for accessibility (aria-live)
+    const statuses = await screen.findAllByRole('status')
+    const accessDeniedStatus = statuses.find((el) => /access denied/i.test(el.textContent ?? ''))
+    expect(accessDeniedStatus).toBeDefined()
   })
 })

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -1,24 +1,36 @@
-import { isSessionError } from '@api/auth'
+import { handleSessionError } from '@api/auth'
 import { deleteRecipe, fetchMyRecipes, publishRecipe, unpublishRecipe } from '@api/recipes'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
 import Link from '@components/Link'
 import Loading from '@components/Loading'
+import Toast, { type ToastState } from '@components/Toast'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
 import type { Recipe } from '@models/recipe'
 import { useCallback, useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import styles from './RecipeList.module.css'
 
 const RecipeList = () => {
   const { getAccessToken, logout } = useAuth()
   const navigate = useNavigate()
+  const location = useLocation()
   const [recipes, setRecipes] = useState<Recipe[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<Recipe | null>(null)
+  const [toast, setToast] = useState<ToastState | null>(null)
+
+  useEffect(() => {
+    const state = location.state as { accessDenied?: boolean } | null
+    if (state?.accessDenied) {
+      setToast({ message: 'Access denied', type: 'error' })
+      navigate(location.pathname, { replace: true, state: null })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const loadRecipes = useCallback(async () => {
     setLoading(true)
@@ -28,10 +40,7 @@ const RecipeList = () => {
       const data = await fetchMyRecipes(token)
       setRecipes(data)
     } catch (err) {
-      if (isSessionError(err)) {
-        logout()
-        navigate('/admin/login')
-      } else {
+      if (!handleSessionError(err, logout, navigate)) {
         setError(true)
       }
     } finally {
@@ -69,100 +78,109 @@ const RecipeList = () => {
     }
   }
 
-  if (loading) {
-    return (
-      <div className={styles.page}>
+  const renderContent = () => {
+    if (loading) {
+      return (
         <div className={styles.loadingWrapper}>
           <Loading />
         </div>
-      </div>
-    )
-  }
+      )
+    }
 
-  if (error) {
-    return (
-      <div className={styles.page}>
-        <Typography variant="body">Something went wrong.</Typography>
-        <Button onClick={loadRecipes}>Retry</Button>
-      </div>
-    )
-  }
+    if (error) {
+      return (
+        <>
+          <Typography variant="body">Something went wrong.</Typography>
+          <Button onClick={loadRecipes}>Retry</Button>
+        </>
+      )
+    }
 
-  if (recipes.length === 0) {
+    if (recipes.length === 0) {
+      return (
+        <>
+          <Typography variant="heading2">Recipes</Typography>
+          <Typography variant="body">No recipes yet.</Typography>
+          <Link to="/admin/recipes/new" ariaLabel="Create your first recipe">
+            Create your first recipe
+          </Link>
+        </>
+      )
+    }
+
     return (
-      <div className={styles.page}>
-        <Typography variant="heading2">Recipes</Typography>
-        <Typography variant="body">No recipes yet.</Typography>
-        <Link to="/admin/recipes/new" ariaLabel="Create your first recipe">
-          Create your first recipe
-        </Link>
-      </div>
+      <>
+        <div className={styles.header}>
+          <Typography variant="heading2">Recipes</Typography>
+          <Link to="/admin/recipes/new" className={styles.newRecipeLink}>
+            New recipe
+          </Link>
+        </div>
+
+        <div className={styles.tableWrapper}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Status</th>
+                <th>Tags</th>
+                <th>Last updated</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recipes.map((recipe) => (
+                <tr key={recipe.id}>
+                  <td>{recipe.title}</td>
+                  <td>
+                    <span className={styles.badge} data-status={recipe.status}>
+                      {recipe.status === 'published' ? 'Published' : 'Draft'}
+                    </span>
+                  </td>
+                  <td>{recipe.tags.join(', ')}</td>
+                  <td>{new Date(recipe.updatedAt).toLocaleDateString()}</td>
+                  <td className={styles.actions}>
+                    <div className={styles.actionsInner}>
+                      <Link to={`/admin/recipes/${recipe.id}/edit`} ariaLabel={`Edit ${recipe.title}`}>
+                        Edit
+                      </Link>
+                      <Link
+                        to={`/admin/recipes/${recipe.id}/preview`}
+                        ariaLabel={`Preview ${recipe.title}`}
+                      >
+                        Preview
+                      </Link>
+                      <button type="button" className={styles.actionLink} onClick={() => handlePublish(recipe)}>
+                        {recipe.status === 'published' ? 'Unpublish' : 'Publish'}
+                      </button>
+                      <button type="button" className={styles.actionLink} onClick={() => setDeleteTarget(recipe)}>
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <ConfirmDialog
+          title="Delete recipe"
+          message={`Are you sure you want to delete "${deleteTarget?.title ?? ''}"?`}
+          isOpen={deleteTarget !== null}
+          onConfirm={handleDeleteConfirm}
+          onCancel={() => setDeleteTarget(null)}
+        />
+      </>
     )
   }
 
   return (
     <div className={styles.page}>
-      <div className={styles.header}>
-        <Typography variant="heading2">Recipes</Typography>
-        <Link to="/admin/recipes/new" className={styles.newRecipeLink}>
-          New recipe
-        </Link>
-      </div>
-
-      <div className={styles.tableWrapper}>
-      <table className={styles.table}>
-        <thead>
-          <tr>
-            <th>Title</th>
-            <th>Status</th>
-            <th>Tags</th>
-            <th>Last updated</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {recipes.map((recipe) => (
-            <tr key={recipe.id}>
-              <td>{recipe.title}</td>
-              <td>
-                <span className={styles.badge} data-status={recipe.status}>
-                  {recipe.status === 'published' ? 'Published' : 'Draft'}
-                </span>
-              </td>
-              <td>{recipe.tags.join(', ')}</td>
-              <td>{new Date(recipe.updatedAt).toLocaleDateString()}</td>
-              <td className={styles.actions}>
-                <div className={styles.actionsInner}>
-                  <Link to={`/admin/recipes/${recipe.id}/edit`} ariaLabel={`Edit ${recipe.title}`}>
-                    Edit
-                  </Link>
-                  <Link
-                    to={`/admin/recipes/${recipe.id}/preview`}
-                    ariaLabel={`Preview ${recipe.title}`}
-                  >
-                    Preview
-                  </Link>
-                  <button type="button" className={styles.actionLink} onClick={() => handlePublish(recipe)}>
-                    {recipe.status === 'published' ? 'Unpublish' : 'Publish'}
-                  </button>
-                  <button type="button" className={styles.actionLink} onClick={() => setDeleteTarget(recipe)}>
-                    Delete
-                  </button>
-                </div>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      </div>
-
-      <ConfirmDialog
-        title="Delete recipe"
-        message={`Are you sure you want to delete "${deleteTarget?.title ?? ''}"?`}
-        isOpen={deleteTarget !== null}
-        onConfirm={handleDeleteConfirm}
-        onCancel={() => setDeleteTarget(null)}
-      />
+      {renderContent()}
+      {toast && (
+        <Toast message={toast.message} type={toast.type} onDismiss={() => setToast(null)} />
+      )}
     </div>
   )
 }

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -1,0 +1,137 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  max-width: 64rem;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.loadingWrapper {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-12) 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.inviteForm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.label {
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-sm);
+}
+
+.input {
+  padding: var(--space-2) var(--space-3);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font: inherit;
+  min-height: 44px;
+}
+
+.input:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.input[aria-invalid='true'] {
+  border-color: var(--color-error);
+}
+
+.fieldError {
+  color: var(--color-error);
+}
+
+.formActions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.tableWrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  border: var(--border-width) solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.table th,
+.table td {
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  vertical-align: middle;
+  border-bottom: var(--border-width) solid var(--color-border);
+  white-space: nowrap;
+}
+
+.table th {
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--color-bg);
+}
+
+.badge {
+  display: inline-block;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+}
+
+.badge[data-role='admin'] {
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
+  border-color: var(--color-primary);
+}
+
+.badge[data-role='contributor'] {
+  background: var(--color-bg-subtle);
+  color: var(--color-text-muted);
+}
+
+.status {
+  display: inline-block;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.status[data-status='confirmed'] {
+  color: var(--color-text);
+}
+
+.actions {
+  text-align: right;
+}

--- a/src/pages/admin/UserManagement/UserManagement.test.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.test.tsx
@@ -88,8 +88,8 @@ describe('Admin UserManagement page', () => {
       expect(screen.getAllByText(/contributor/i).length).toBeGreaterThanOrEqual(2)
 
       // Status values
-      expect(screen.getAllByText(/confirmed/i).length).toBeGreaterThanOrEqual(2)
-      expect(screen.getByText(/pending/i)).toBeInTheDocument()
+      expect(screen.getAllByText('Confirmed').length).toBeGreaterThanOrEqual(2)
+      expect(screen.getByText('Pending')).toBeInTheDocument()
     })
 
     it('calls fetchUsers with the current access token on mount', async () => {

--- a/src/pages/admin/UserManagement/UserManagement.test.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.test.tsx
@@ -1,0 +1,285 @@
+import { fetchUsers, inviteUser, removeUser, UserExistsError } from '@api/users'
+import { useAuth } from '@contexts/AuthContext'
+import type { AdminUser } from '@models/auth'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import UserManagement from './UserManagement'
+
+vi.mock('@api/users', () => ({
+  fetchUsers: vi.fn(),
+  inviteUser: vi.fn(),
+  removeUser: vi.fn(),
+  UserExistsError: class UserExistsError extends Error {
+    constructor(message = 'User already exists') {
+      super(message)
+      this.name = 'UserExistsError'
+    }
+  },
+}))
+
+vi.mock('@contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}))
+
+const adminUser: AdminUser = {
+  email: 'admin@akli.dev',
+  userId: 'user-admin',
+  role: 'admin',
+  status: 'confirmed',
+}
+
+const contributorUser: AdminUser = {
+  email: 'contrib@akli.dev',
+  userId: 'user-contrib',
+  role: 'contributor',
+  status: 'confirmed',
+}
+
+const pendingUser: AdminUser = {
+  email: 'pending@akli.dev',
+  userId: 'user-pending',
+  role: 'contributor',
+  status: 'pending',
+}
+
+const renderUserManagement = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/users']}>
+      <UserManagement />
+    </MemoryRouter>
+  )
+
+describe('Admin UserManagement page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(useAuth).mockReturnValue({
+      getAccessToken: vi.fn().mockResolvedValue('token-123'),
+      isAdmin: true,
+      user: { email: 'admin@akli.dev', groups: ['admin'] },
+      isAuthenticated: true,
+      loading: false,
+      login: vi.fn(),
+      logout: vi.fn(),
+    })
+    vi.mocked(fetchUsers).mockResolvedValue([adminUser, contributorUser, pendingUser])
+    vi.mocked(inviteUser).mockResolvedValue(undefined)
+    vi.mocked(removeUser).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('user table (AC2)', () => {
+    it('renders a row for each user with email, role badge, and status', async () => {
+      renderUserManagement()
+
+      await waitFor(() => {
+        expect(screen.getByText('admin@akli.dev')).toBeInTheDocument()
+      })
+      expect(screen.getByText('contrib@akli.dev')).toBeInTheDocument()
+      expect(screen.getByText('pending@akli.dev')).toBeInTheDocument()
+
+      // Role badges (at least one admin, two contributor)
+      expect(screen.getAllByText(/admin/i).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/contributor/i).length).toBeGreaterThanOrEqual(2)
+
+      // Status values
+      expect(screen.getAllByText(/confirmed/i).length).toBeGreaterThanOrEqual(2)
+      expect(screen.getByText(/pending/i)).toBeInTheDocument()
+    })
+
+    it('calls fetchUsers with the current access token on mount', async () => {
+      renderUserManagement()
+
+      await waitFor(() => {
+        expect(fetchUsers).toHaveBeenCalledWith('token-123')
+      })
+    })
+  })
+
+  describe('loading and error states (AC9)', () => {
+    it('shows a loading indicator while fetching users', () => {
+      vi.mocked(fetchUsers).mockReturnValue(new Promise(() => {}))
+      renderUserManagement()
+
+      expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
+    })
+
+    it('shows an error state with a retry button when fetchUsers rejects', async () => {
+      vi.mocked(fetchUsers).mockRejectedValueOnce(new Error('500 Internal Server Error'))
+      renderUserManagement()
+
+      const retryButton = await screen.findByRole('button', { name: /retry/i })
+      expect(retryButton).toBeInTheDocument()
+    })
+
+    it('re-fetches users when retry is clicked', async () => {
+      vi.mocked(fetchUsers).mockRejectedValueOnce(new Error('500 Internal Server Error'))
+      renderUserManagement()
+
+      const retryButton = await screen.findByRole('button', { name: /retry/i })
+
+      vi.mocked(fetchUsers).mockResolvedValueOnce([adminUser])
+      fireEvent.click(retryButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('admin@akli.dev')).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('invite flow (AC3, AC4, AC5, AC6)', () => {
+    it('opens an invite form with email input and role select when the Invite button is clicked', async () => {
+      const user = userEvent.setup()
+      renderUserManagement()
+
+      await waitFor(() => {
+        expect(screen.getByText('admin@akli.dev')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /invite user/i }))
+
+      expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/role/i)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /send invite/i })).toBeInTheDocument()
+    })
+
+    it('disables the submit button while the email is invalid', async () => {
+      const user = userEvent.setup()
+      renderUserManagement()
+
+      await waitFor(() => {
+        expect(screen.getByText('admin@akli.dev')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /invite user/i }))
+
+      const submitButton = screen.getByRole('button', { name: /send invite/i })
+      expect(submitButton).toBeDisabled()
+
+      const emailInput = screen.getByLabelText(/email/i)
+      await user.type(emailInput, 'not-an-email')
+      expect(submitButton).toBeDisabled()
+
+      await user.clear(emailInput)
+      await user.type(emailInput, 'new@akli.dev')
+      expect(submitButton).toBeEnabled()
+    })
+
+    it('submits the invite and shows a success toast with the invited email', async () => {
+      const user = userEvent.setup()
+      renderUserManagement()
+
+      await waitFor(() => {
+        expect(screen.getByText('admin@akli.dev')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /invite user/i }))
+
+      await user.type(screen.getByLabelText(/email/i), 'new@akli.dev')
+      await user.selectOptions(screen.getByLabelText(/role/i), 'contributor')
+      await user.click(screen.getByRole('button', { name: /send invite/i }))
+
+      await waitFor(() => {
+        expect(inviteUser).toHaveBeenCalledWith('token-123', 'new@akli.dev', 'contributor')
+      })
+
+      const toast = await screen.findByRole('status')
+      expect(toast).toHaveTextContent(/invite sent to new@akli\.dev/i)
+    })
+
+    it('shows an inline "User already exists" error when inviteUser rejects with UserExistsError', async () => {
+      vi.mocked(inviteUser).mockRejectedValueOnce(new UserExistsError())
+
+      const user = userEvent.setup()
+      renderUserManagement()
+
+      await waitFor(() => {
+        expect(screen.getByText('admin@akli.dev')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByRole('button', { name: /invite user/i }))
+      await user.type(screen.getByLabelText(/email/i), 'contrib@akli.dev')
+      await user.click(screen.getByRole('button', { name: /send invite/i }))
+
+      expect(await screen.findByText(/user already exists/i)).toBeInTheDocument()
+      // No success toast
+      expect(screen.queryByText(/invite sent to/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('remove flow (AC7, AC8)', () => {
+    it('does not render a remove button for the current user', async () => {
+      renderUserManagement()
+
+      await waitFor(() => {
+        expect(screen.getByText('admin@akli.dev')).toBeInTheDocument()
+      })
+
+      const adminRow = screen.getByText('admin@akli.dev').closest('tr')
+      expect(adminRow).not.toBeNull()
+
+      const removeButton = within(adminRow as HTMLElement).queryByRole('button', {
+        name: /remove/i,
+      })
+      expect(removeButton).toBeNull()
+    })
+
+    it('opens a confirmation dialog when remove is clicked for another user', async () => {
+      const user = userEvent.setup()
+      renderUserManagement()
+
+      await waitFor(() => {
+        expect(screen.getByText('contrib@akli.dev')).toBeInTheDocument()
+      })
+
+      const contribRow = screen.getByText('contrib@akli.dev').closest('tr')
+      const removeButton = within(contribRow as HTMLElement).getByRole('button', {
+        name: /remove/i,
+      })
+
+      await user.click(removeButton)
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    it('calls removeUser after confirming and shows a success toast', async () => {
+      const user = userEvent.setup()
+      renderUserManagement()
+
+      await waitFor(() => {
+        expect(screen.getByText('contrib@akli.dev')).toBeInTheDocument()
+      })
+
+      const contribRow = screen.getByText('contrib@akli.dev').closest('tr')
+      const removeButton = within(contribRow as HTMLElement).getByRole('button', {
+        name: /remove/i,
+      })
+      await user.click(removeButton)
+
+      const confirmButton = screen.getByRole('button', { name: /confirm/i })
+
+      // After removal, fetchUsers should return the reduced list
+      vi.mocked(fetchUsers).mockResolvedValueOnce([adminUser, pendingUser])
+
+      await user.click(confirmButton)
+
+      await waitFor(() => {
+        expect(removeUser).toHaveBeenCalledWith('token-123', 'user-contrib')
+      })
+
+      // User disappears from the list
+      await waitFor(() => {
+        expect(screen.queryByText('contrib@akli.dev')).not.toBeInTheDocument()
+      })
+
+      // Success toast
+      const toasts = await screen.findAllByRole('status')
+      expect(toasts.some((t) => /removed|success/i.test(t.textContent ?? ''))).toBe(true)
+    })
+  })
+})

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -209,7 +209,7 @@ const UserManagement = () => {
                     </td>
                     <td>
                       <span className={styles.status} data-status={userRow.status}>
-                        {userRow.status === 'confirmed' ? 'Confirmed' : 'Invite sent'}
+                        {userRow.status === 'confirmed' ? 'Confirmed' : 'Pending'}
                       </span>
                     </td>
                     <td className={styles.actions}>

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -1,5 +1,259 @@
+import { handleSessionError } from '@api/auth'
+import { fetchUsers, inviteUser, removeUser, UserExistsError } from '@api/users'
+import Button from '@components/Button'
+import ConfirmDialog from '@components/ConfirmDialog'
+import Loading from '@components/Loading'
+import Toast, { type ToastState } from '@components/Toast'
+import Typography from '@components/Typography'
+import { useAuth } from '@contexts/AuthContext'
+import type { AdminRole, AdminUser } from '@models/auth'
+import { useCallback, useEffect, useId, useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import styles from './UserManagement.module.css'
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const isValidEmail = (value: string): boolean => EMAIL_PATTERN.test(value.trim())
+
 const UserManagement = () => {
-  return <div>User management</div>
+  const { getAccessToken, logout, user: currentUser } = useAuth()
+  const navigate = useNavigate()
+  const emailInputId = useId()
+  const roleInputId = useId()
+  const emailErrorId = useId()
+
+  const [users, setUsers] = useState<AdminUser[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [toast, setToast] = useState<ToastState | null>(null)
+
+  const [inviteFormOpen, setInviteFormOpen] = useState(false)
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [inviteRole, setInviteRole] = useState<AdminRole>('contributor')
+  const [inviteSubmitting, setInviteSubmitting] = useState(false)
+  const [inviteError, setInviteError] = useState<string | null>(null)
+
+  const [removeTarget, setRemoveTarget] = useState<AdminUser | null>(null)
+
+  const loadUsers = useCallback(async () => {
+    setLoading(true)
+    setError(false)
+    try {
+      const token = await getAccessToken()
+      const data = await fetchUsers(token)
+      setUsers(data)
+    } catch (err) {
+      if (!handleSessionError(err, logout, navigate)) {
+        setError(true)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [getAccessToken, logout, navigate])
+
+  useEffect(() => {
+    loadUsers()
+  }, [loadUsers])
+
+  const resetInviteForm = () => {
+    setInviteFormOpen(false)
+    setInviteEmail('')
+    setInviteRole('contributor')
+    setInviteError(null)
+  }
+
+  const handleInviteSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!isValidEmail(inviteEmail) || inviteSubmitting) return
+
+    const trimmedEmail = inviteEmail.trim()
+    setInviteSubmitting(true)
+    setInviteError(null)
+    try {
+      const token = await getAccessToken()
+      await inviteUser(token, trimmedEmail, inviteRole)
+      resetInviteForm()
+      setToast({ message: `Invite sent to ${trimmedEmail}`, type: 'success' })
+      await loadUsers()
+    } catch (err) {
+      if (err instanceof UserExistsError) {
+        setInviteError('User already exists')
+      } else if (!handleSessionError(err, logout, navigate)) {
+        setInviteError('Something went wrong. Please try again.')
+      }
+    } finally {
+      setInviteSubmitting(false)
+    }
+  }
+
+  const handleRemoveConfirm = async () => {
+    if (!removeTarget) return
+    const target = removeTarget
+    setRemoveTarget(null)
+    try {
+      const token = await getAccessToken()
+      await removeUser(token, target.userId)
+      setToast({ message: `User ${target.email} removed`, type: 'success' })
+      await loadUsers()
+    } catch (err) {
+      if (!handleSessionError(err, logout, navigate)) {
+        setToast({ message: 'Failed to remove user', type: 'error' })
+      }
+    }
+  }
+
+  const emailValid = isValidEmail(inviteEmail)
+  const submitDisabled = !emailValid || inviteSubmitting
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className={styles.loadingWrapper}>
+          <Loading />
+        </div>
+      )
+    }
+
+    if (error) {
+      return (
+        <>
+          <Typography variant="body">Something went wrong.</Typography>
+          <Button onClick={loadUsers}>Retry</Button>
+        </>
+      )
+    }
+
+    return (
+      <>
+        <div className={styles.header}>
+          <Typography variant="heading2">Users</Typography>
+          {!inviteFormOpen && (
+            <Button onClick={() => setInviteFormOpen(true)}>Invite user</Button>
+          )}
+        </div>
+
+        {inviteFormOpen && (
+          <form className={styles.inviteForm} onSubmit={handleInviteSubmit} noValidate>
+            <div className={styles.field}>
+              <label htmlFor={emailInputId} className={styles.label}>
+                Email
+              </label>
+              <input
+                id={emailInputId}
+                type="email"
+                value={inviteEmail}
+                onChange={(event) => {
+                  setInviteEmail(event.target.value)
+                  setInviteError(null)
+                }}
+                aria-invalid={inviteError !== null}
+                aria-describedby={inviteError ? emailErrorId : undefined}
+                className={styles.input}
+                autoComplete="email"
+                required
+              />
+              {inviteError && (
+                <Typography variant="caption" id={emailErrorId} className={styles.fieldError}>
+                  {inviteError}
+                </Typography>
+              )}
+            </div>
+
+            <div className={styles.field}>
+              <label htmlFor={roleInputId} className={styles.label}>
+                Role
+              </label>
+              <select
+                id={roleInputId}
+                value={inviteRole}
+                onChange={(event) => setInviteRole(event.target.value as AdminRole)}
+                className={styles.input}
+              >
+                <option value="contributor">Contributor</option>
+                <option value="admin">Admin</option>
+              </select>
+            </div>
+
+            <div className={styles.formActions}>
+              <Button onClick={resetInviteForm} variant="secondary">
+                Cancel
+              </Button>
+              <Button type="submit" disabled={submitDisabled}>
+                Send invite
+              </Button>
+            </div>
+          </form>
+        )}
+
+        <div className={styles.tableWrapper}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((userRow) => {
+                const isSelf = userRow.email === currentUser?.email
+                return (
+                  <tr key={userRow.userId}>
+                    <td>{userRow.email}</td>
+                    <td>
+                      <span className={styles.badge} data-role={userRow.role}>
+                        {userRow.role === 'admin' ? 'Admin' : 'Contributor'}
+                      </span>
+                    </td>
+                    <td>
+                      <span className={styles.status} data-status={userRow.status}>
+                        {userRow.status === 'confirmed' ? 'Confirmed' : 'Invite sent'}
+                      </span>
+                    </td>
+                    <td className={styles.actions}>
+                      {!isSelf && (
+                        <Button
+                          onClick={() => setRemoveTarget(userRow)}
+                          variant="secondary"
+                          ariaLabel={`Remove ${userRow.email}`}
+                        >
+                          Remove
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <ConfirmDialog
+          title="Remove user"
+          message={
+            removeTarget
+              ? `Are you sure you want to remove ${removeTarget.email}? They will lose access immediately.`
+              : ''
+          }
+          isOpen={removeTarget !== null}
+          onConfirm={handleRemoveConfirm}
+          onCancel={() => setRemoveTarget(null)}
+          confirmLabel="Confirm"
+        />
+      </>
+    )
+  }
+
+  return (
+    <div className={styles.page}>
+      {renderContent()}
+      {toast && (
+        <Toast message={toast.message} type={toast.type} onDismiss={() => setToast(null)} />
+      )}
+    </div>
+  )
 }
 
 export default UserManagement

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -16,9 +16,12 @@ export interface User {
   groups: string[]
 }
 
+export type AdminRole = 'admin' | 'contributor'
+export type AdminUserStatus = 'confirmed' | 'pending'
+
 export interface AdminUser {
   email: string
   userId: string
-  role: string
-  status: string
+  role: AdminRole
+  status: AdminUserStatus
 }


### PR DESCRIPTION
Closes #123

## What changed

- `src/pages/admin/UserManagement/UserManagement.tsx` — admin-only page with a users table (email, role badge, status), invite form with email + role, remove flow with confirm dialog, success/error toasts, loading spinner, session-error recovery
- `src/pages/admin/UserManagement/UserManagement.module.css` — neo-brutalist styling consistent with the other admin pages
- `src/components/ProtectedRoute/ProtectedRoute.tsx` — passes `state={{ accessDenied: true }}` when redirecting non-admins off admin-only routes
- `src/pages/admin/RecipeList/RecipeList.tsx` — reads the redirect state and shows an "Access denied" toast once on mount
- `src/types/auth.ts` — tightened `AdminUser.role` / `status` to string unions; exported `AdminRole` / `AdminUserStatus`
- `src/api/auth.ts` — added `handleSessionError(err, logout, navigate)` helper to dedupe the session-error recovery pattern across admin pages
- `src/components/Toast/Toast.tsx` — exported `ToastState` type; stabilised dismiss timer via ref so parent re-renders don't reset it
- `src/components/Button/Button.tsx` — `onClick` now optional (submit buttons legitimately don't need one)
- `src/contexts/AuthContext.tsx` — memoised `login` / `logout` / `getAccessToken` / value so consumers don't refetch on every provider re-render
- `src/components/ProtectedRoute/ProtectedRoute.test.tsx` — test routes restructured to match real app routing (fixes a pre-existing hang)

## Why

Last issue in the admin interface milestone. The PRD calls for admin-only user management: invite via Cognito admin API, remove with confirmation, list with status badges. ProtectedRoute and Toast touch-ups are load-bearing for the "access denied" UX.

## How to verify

- `pnpm test` → 477/477 passing
- Manual:
  - Log in as contributor → hit `/admin/users` → bounced to `/admin/recipes` with an "Access denied" toast
  - Log in as admin → `/admin/users` loads → invite a fresh email → toast + row appears as "Pending"
  - Invite a duplicate → inline "User already exists" error
  - Remove a user other than yourself → confirm dialog → toast, row disappears
  - Your own row has no Remove button

## Decisions made

- **Status label "Pending"** (not "Invite sent") — matches AC2 literally.
- **`handleSessionError` helper extraction** — the `if (isSessionError(err)) { logout(); navigate('/admin/login') }` block was about to appear in a fifth place with this PR. Extracted to `@api/auth` and applied to RecipeList too.
- **`AuthContext` memoisation** — flagged during /simplify because unmemoised context value would thrash every consumer's `loadX` callback and cause refetch loops. Small change, high payoff.
- **Recipe.status tightening reverted** — union cascade into out-of-scope test fixtures. Kept AdminUser tightening only.
- **Follow-ups deferred** — shared `FormField` / `Input` / `Select` components (third site now has inline form styles), `AdminListPage` shell, optimistic remove. Worth a separate refactor issue once a third admin list lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)