### PR TITLE
Write component tests for admin interface

### DIFF
--- a/src/components/ImageUpload/ImageUpload.test.tsx
+++ b/src/components/ImageUpload/ImageUpload.test.tsx
@@ -1,6 +1,7 @@
 import { getUploadUrl } from '@api/recipes'
 import ImageUpload from '@components/ImageUpload'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 
 vi.mock('@api/recipes', () => ({
@@ -135,5 +136,60 @@ describe('ImageUpload', () => {
     render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} currentKey="img/existing.jpg" />)
 
     expect(screen.getByRole('button', { name: /replace/i })).toBeInTheDocument()
+  })
+
+  it('clicking the Upload button opens the file picker', async () => {
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
+
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} />)
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /upload/i }))
+
+    expect(clickSpy).toHaveBeenCalled()
+  })
+
+  it('clicking the Replace button opens the file picker', async () => {
+    const clickSpy = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
+
+    render(
+      <ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} currentKey="img/existing.jpg" />
+    )
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /replace/i }))
+
+    expect(clickSpy).toHaveBeenCalled()
+  })
+
+  it('clicking Retry after a failed upload re-attempts the upload', async () => {
+    mockGetUploadUrl.mockRejectedValueOnce(new Error('Network error'))
+
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} />)
+
+    const file = new File(['x'], 'photo.png', { type: 'image/png' })
+    Object.defineProperty(file, 'size', { value: 1024 })
+
+    const input = screen.getByLabelText(/upload/i) || document.querySelector('input[type="file"]')
+    fireEvent.change(input!, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    })
+
+    // Set the second attempt to succeed
+    mockGetUploadUrl.mockResolvedValue({
+      uploadUrl: 'https://s3.example.com/upload',
+      key: 'img/123.jpg',
+    })
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }))
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: /retry/i }))
+
+    await waitFor(() => {
+      expect(mockGetUploadUrl).toHaveBeenCalledTimes(2)
+    })
+    expect(mockOnUpload).toHaveBeenCalledWith('img/123.jpg')
   })
 })

--- a/src/components/ImageUpload/ImageUpload.test.tsx
+++ b/src/components/ImageUpload/ImageUpload.test.tsx
@@ -29,6 +29,7 @@ describe('ImageUpload', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
   it('renders an upload area', () => {

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -1,6 +1,7 @@
 import type { Step } from '@models/recipe'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import StepList from './StepList'
@@ -67,6 +68,72 @@ describe('StepList', () => {
       { order: 1, text: 'Mix ingredients' },
       { order: 2, text: 'Preheat oven' },
     ])
+  })
+
+  it('after reordering two steps, the rendered step-number labels reflect the new order', async () => {
+    const user = userEvent.setup()
+    // A stateful wrapper re-renders with the updated steps prop so the user
+    // sees the numbering update as they would in the real app.
+    const Wrapper = () => {
+      const [steps, setSteps] = useState<Step[]>(twoSteps)
+      return <StepList steps={steps} onChange={setSteps} getToken={mockGetToken} />
+    }
+    render(<Wrapper />)
+
+    const moveDownButtons = screen.getAllByRole('button', { name: /move down/i })
+    await user.click(moveDownButtons[0])
+
+    // After reordering, the "Mix ingredients" textarea is at position 1 and
+    // "Preheat oven" at position 2
+    const textareas = screen.getAllByRole('textbox', { name: /^step \d+ text$/i })
+    expect(textareas[0]).toHaveValue('Mix ingredients')
+    expect(textareas[1]).toHaveValue('Preheat oven')
+
+    // And the numeric labels follow the new order
+    expect(screen.getByLabelText('Step 1 text')).toHaveValue('Mix ingredients')
+    expect(screen.getByLabelText('Step 2 text')).toHaveValue('Preheat oven')
+  })
+
+  describe('per-step image upload (when getToken is provided)', () => {
+    it('renders an image upload control and an alt-text input per step', () => {
+      const onChange = vi.fn()
+      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+
+      // Each step row exposes an Upload button (from ImageUpload) and an
+      // alt-text input
+      const uploadButtons = screen.getAllByRole('button', { name: /^upload$/i })
+      expect(uploadButtons).toHaveLength(2)
+
+      expect(screen.getByLabelText('Step 1 image alt text')).toBeInTheDocument()
+      expect(screen.getByLabelText('Step 2 image alt text')).toBeInTheDocument()
+    })
+
+    it('does not render the image upload control when getToken is not provided', () => {
+      const onChange = vi.fn()
+      render(<StepList steps={twoSteps} onChange={onChange} />)
+
+      expect(screen.queryByRole('button', { name: /^upload$/i })).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Step 1 image alt text')).not.toBeInTheDocument()
+    })
+
+    it('typing in the alt-text input calls onChange with the updated step', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      render(
+        <StepList
+          steps={[makeStep(1, 'Preheat oven')]}
+          onChange={onChange}
+          getToken={mockGetToken}
+        />
+      )
+
+      const altInput = screen.getByLabelText('Step 1 image alt text')
+      await user.type(altInput, 'A')
+
+      expect(onChange).toHaveBeenCalledWith([
+        { order: 1, text: 'Preheat oven', image: { key: '', alt: 'A' } },
+      ])
+    })
   })
 
   describe('accessibility — touch targets', () => {

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -72,8 +72,6 @@ describe('StepList', () => {
 
   it('after reordering two steps, the rendered step-number labels reflect the new order', async () => {
     const user = userEvent.setup()
-    // A stateful wrapper re-renders with the updated steps prop so the user
-    // sees the numbering update as they would in the real app.
     const Wrapper = () => {
       const [steps, setSteps] = useState<Step[]>(twoSteps)
       return <StepList steps={steps} onChange={setSteps} getToken={mockGetToken} />
@@ -83,13 +81,6 @@ describe('StepList', () => {
     const moveDownButtons = screen.getAllByRole('button', { name: /move down/i })
     await user.click(moveDownButtons[0])
 
-    // After reordering, the "Mix ingredients" textarea is at position 1 and
-    // "Preheat oven" at position 2
-    const textareas = screen.getAllByRole('textbox', { name: /^step \d+ text$/i })
-    expect(textareas[0]).toHaveValue('Mix ingredients')
-    expect(textareas[1]).toHaveValue('Preheat oven')
-
-    // And the numeric labels follow the new order
     expect(screen.getByLabelText('Step 1 text')).toHaveValue('Mix ingredients')
     expect(screen.getByLabelText('Step 2 text')).toHaveValue('Preheat oven')
   })
@@ -99,8 +90,6 @@ describe('StepList', () => {
       const onChange = vi.fn()
       render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
 
-      // Each step row exposes an Upload button (from ImageUpload) and an
-      // alt-text input
       const uploadButtons = screen.getAllByRole('button', { name: /^upload$/i })
       expect(uploadButtons).toHaveLength(2)
 

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -17,8 +17,10 @@ const fakeIdToken = (payload: Record<string, unknown>): string => {
 }
 
 const futureExp = Math.floor(Date.now() / 1000) + 3600
+const pastExp = Math.floor(Date.now() / 1000) - 3600
 const adminIdToken = fakeIdToken({ email: 'admin@example.com', 'cognito:groups': ['admin'], exp: futureExp })
 const fakeAccessToken = fakeIdToken({ sub: 'user-id', exp: futureExp })
+const expiredAccessToken = fakeIdToken({ sub: 'user-id', exp: pastExp })
 const _contributorIdToken = fakeIdToken({ email: 'contributor@example.com', 'cognito:groups': ['contributor'] })
 
 const TestConsumer = () => {
@@ -168,5 +170,87 @@ describe('AuthProvider', () => {
     })
 
     expect(token).toBe(fakeAccessToken)
+  })
+
+  it('getAccessToken auto-refreshes an expired access token and returns the new one', async () => {
+    const refreshedAccessToken = fakeIdToken({ sub: 'user-id', exp: futureExp, refreshed: true })
+    vi.mocked(authApi.getCurrentSession).mockReturnValue({
+      accessToken: expiredAccessToken,
+      refreshToken: 'refresh-current',
+      idToken: adminIdToken,
+    })
+    vi.mocked(authApi.refreshSession).mockResolvedValue({
+      accessToken: refreshedAccessToken,
+      idToken: adminIdToken,
+    })
+
+    let token: string | undefined
+    const TokenConsumer = () => {
+      const { getAccessToken } = useAuth()
+      return (
+        <button
+          onClick={async () => {
+            token = await getAccessToken()
+          }}
+        >
+          Get Token
+        </button>
+      )
+    }
+
+    render(
+      <AuthProvider>
+        <TokenConsumer />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      screen.getByText('Get Token').click()
+    })
+
+    expect(authApi.refreshSession).toHaveBeenCalledWith('refresh-current')
+    expect(token).toBe(refreshedAccessToken)
+  })
+
+  it('getAccessToken throws "Session expired" when refresh fails', async () => {
+    // Note: AuthContext throws here; the redirect-to-login behaviour on
+    // refresh failure is verified in ProtectedRoute's own tests.
+    vi.mocked(authApi.getCurrentSession).mockReturnValue({
+      accessToken: expiredAccessToken,
+      refreshToken: 'refresh-current',
+      idToken: adminIdToken,
+    })
+    vi.mocked(authApi.refreshSession).mockRejectedValue(new Error('401 Unauthorized'))
+
+    let caught: Error | undefined
+    const TokenConsumer = () => {
+      const { getAccessToken } = useAuth()
+      return (
+        <button
+          onClick={async () => {
+            try {
+              await getAccessToken()
+            } catch (err) {
+              caught = err as Error
+            }
+          }}
+        >
+          Get Token
+        </button>
+      )
+    }
+
+    render(
+      <AuthProvider>
+        <TokenConsumer />
+      </AuthProvider>
+    )
+
+    await act(async () => {
+      screen.getByText('Get Token').click()
+    })
+
+    expect(caught).toBeInstanceOf(Error)
+    expect(caught?.message).toBe('Session expired')
   })
 })

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -213,8 +213,6 @@ describe('AuthProvider', () => {
   })
 
   it('getAccessToken throws "Session expired" when refresh fails', async () => {
-    // Note: AuthContext throws here; the redirect-to-login behaviour on
-    // refresh failure is verified in ProtectedRoute's own tests.
     vi.mocked(authApi.getCurrentSession).mockReturnValue({
       accessToken: expiredAccessToken,
       refreshToken: 'refresh-current',

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -127,6 +127,84 @@ describe('RecipeEditor page', () => {
     })
   })
 
+  it('shows cover-image-required error when saving with no cover image', async () => {
+    const user = userEvent.setup()
+    renderEditor('/admin/recipes/new')
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save as draft/i })).toBeInTheDocument()
+    })
+
+    const titleInput = screen.getByRole('textbox', { name: /title/i })
+    const introInput = screen.getByRole('textbox', { name: /intro/i })
+    await user.type(titleInput, 'My Recipe')
+    await user.type(introInput, 'A great recipe')
+
+    const ingredientInputs = screen.getAllByRole('textbox', { name: /item/i })
+    await user.type(ingredientInputs[0], 'Flour')
+
+    const stepTextareas = screen.getAllByRole('textbox', { name: /step.*text/i })
+    await user.type(stepTextareas[0], 'Mix it all')
+
+    await user.click(screen.getByRole('button', { name: /save as draft/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/cover image is required/i)).toBeInTheDocument()
+    })
+
+    expect(createRecipe).not.toHaveBeenCalled()
+  })
+
+  it('shows alt-text-required error when saving with a cover image but no alt text', async () => {
+    const recipeWithoutAlt: Recipe = {
+      ...mockRecipe,
+      coverImage: { key: 'recipes/rec-001/cover', alt: '' },
+    }
+    vi.mocked(fetchMyRecipes).mockResolvedValue([recipeWithoutAlt])
+
+    const user = userEvent.setup()
+    renderEditor('/admin/recipes/rec-001/edit')
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+    })
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/alt text is required/i)).toBeInTheDocument()
+    })
+
+    expect(updateRecipe).not.toHaveBeenCalled()
+  })
+
+  it('editing the cover-image alt text updates the form value', async () => {
+    const user = userEvent.setup()
+    renderEditor('/admin/recipes/rec-001/edit')
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+    })
+
+    const altInput = screen.getByLabelText(/cover image alt text/i)
+    await user.clear(altInput)
+    await user.type(altInput, 'A steaming bowl of spaghetti bolognese')
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() => {
+      expect(updateRecipe).toHaveBeenCalledWith(
+        'token-123',
+        'rec-001',
+        expect.objectContaining({
+          coverImage: expect.objectContaining({
+            alt: 'A steaming bowl of spaghetti bolognese',
+          }),
+        })
+      )
+    })
+  })
+
   it('validates at least 1 ingredient with item filled', async () => {
     const user = userEvent.setup()
     renderEditor('/admin/recipes/new')

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -302,6 +302,35 @@ describe('RecipeEditor page', () => {
     expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
   })
 
+  it('tag input is wired into the editor — typing shows suggestions and pressing Enter adds a chip', async () => {
+    const user = userEvent.setup()
+    renderEditor('/admin/recipes/new')
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
+    })
+
+    // Wait for existing tags to load so the autocomplete has data
+    await waitFor(() => {
+      expect(fetchTags).toHaveBeenCalled()
+    })
+
+    const tagInput = screen.getByRole('combobox')
+    await user.type(tagInput, 'Ita')
+
+    // Autocomplete suggestion should surface the matching existing tag
+    const listbox = await screen.findByRole('listbox')
+    expect(within(listbox).getByText('Italian')).toBeInTheDocument()
+
+    // Pressing Enter commits the typed value as a tag
+    await user.keyboard('{Enter}')
+
+    // The tag chip is now rendered on the form
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /remove ita/i })).toBeInTheDocument()
+    })
+  })
+
   it('first invalid field is focused on validation failure', async () => {
     const user = userEvent.setup()
     renderEditor('/admin/recipes/new')

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -20,9 +20,8 @@ vi.mock('@contexts/AuthContext', () => ({
   useAuth: vi.fn(),
 }))
 
-// Mock ImageUpload so tests can trigger onUpload deterministically without
-// driving a real file input through getUploadUrl + fetch. Exposes a button
-// labelled "Simulate upload cover image" that invokes onUpload with a stub key.
+// Mocked so tests can trigger onUpload without driving a real file input
+// through getUploadUrl + fetch.
 vi.mock('@components/ImageUpload', () => ({
   default: ({
     onUpload,
@@ -31,10 +30,7 @@ vi.mock('@components/ImageUpload', () => ({
     onUpload: (key: string) => void
     imageType?: 'cover' | 'step'
   }) => (
-    <button
-      type="button"
-      onClick={() => onUpload(`recipes/test/${imageType}-${Date.now()}`)}
-    >
+    <button type="button" onClick={() => onUpload(`recipes/test/${imageType}-stub`)}>
       Simulate upload {imageType} image
     </button>
   ),
@@ -159,17 +155,6 @@ describe('RecipeEditor page', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /save as draft/i })).toBeInTheDocument()
     })
-
-    const titleInput = screen.getByRole('textbox', { name: /title/i })
-    const introInput = screen.getByRole('textbox', { name: /intro/i })
-    await user.type(titleInput, 'My Recipe')
-    await user.type(introInput, 'A great recipe')
-
-    const ingredientInputs = screen.getAllByRole('textbox', { name: /item/i })
-    await user.type(ingredientInputs[0], 'Flour')
-
-    const stepTextareas = screen.getAllByRole('textbox', { name: /step.*text/i })
-    await user.type(stepTextareas[0], 'Mix it all')
 
     await user.click(screen.getByRole('button', { name: /save as draft/i }))
 
@@ -413,15 +398,10 @@ describe('RecipeEditor page', () => {
     expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
   })
 
-  it('tag input is wired into the editor — typing shows suggestions and pressing Enter adds a chip', async () => {
+  it('tag input is wired into the editor — typing surfaces a suggestion and clicking it adds a chip', async () => {
     const user = userEvent.setup()
     renderEditor('/admin/recipes/new')
 
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
-    })
-
-    // Wait for existing tags to load so the autocomplete has data
     await waitFor(() => {
       expect(fetchTags).toHaveBeenCalled()
     })
@@ -429,16 +409,12 @@ describe('RecipeEditor page', () => {
     const tagInput = screen.getByRole('combobox')
     await user.type(tagInput, 'Ita')
 
-    // Autocomplete suggestion should surface the matching existing tag
     const listbox = await screen.findByRole('listbox')
-    expect(within(listbox).getByText('Italian')).toBeInTheDocument()
+    const suggestion = within(listbox).getByRole('option', { name: 'Italian' })
+    await user.click(suggestion)
 
-    // Pressing Enter commits the typed value as a tag
-    await user.keyboard('{Enter}')
-
-    // The tag chip is now rendered on the form
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /remove ita/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /remove italian/i })).toBeInTheDocument()
     })
   })
 

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -2,7 +2,7 @@ import { createRecipe, fetchMyRecipes, fetchTags, updateRecipe } from '@api/reci
 import { useAuth } from '@contexts/AuthContext'
 import type { Recipe } from '@models/recipe'
 import { render, screen, waitFor, within } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import userEvent, { type UserEvent } from '@testing-library/user-event'
 import { createMemoryRouter, Link, RouterProvider } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -19,6 +19,31 @@ vi.mock('@api/recipes', () => ({
 vi.mock('@contexts/AuthContext', () => ({
   useAuth: vi.fn(),
 }))
+
+// Mock ImageUpload so tests can trigger onUpload deterministically without
+// driving a real file input through getUploadUrl + fetch. Exposes a button
+// labelled "Simulate upload cover image" that invokes onUpload with a stub key.
+vi.mock('@components/ImageUpload', () => ({
+  default: ({
+    onUpload,
+    imageType = 'cover',
+  }: {
+    onUpload: (key: string) => void
+    imageType?: 'cover' | 'step'
+  }) => (
+    <button
+      type="button"
+      onClick={() => onUpload(`recipes/test/${imageType}-${Date.now()}`)}
+    >
+      Simulate upload {imageType} image
+    </button>
+  ),
+}))
+
+const fillValidCoverImage = async (user: UserEvent) => {
+  await user.click(screen.getByRole('button', { name: /simulate upload cover image/i }))
+  await user.type(screen.getByLabelText(/cover image alt text/i), 'Cover alt text')
+}
 
 const mockRecipe: Recipe = {
   id: 'rec-001',
@@ -267,6 +292,8 @@ describe('RecipeEditor page', () => {
     const stepTextareas = screen.getAllByRole('textbox', { name: /step.*text/i })
     await user.type(stepTextareas[0], 'Mix it all')
 
+    await fillValidCoverImage(user)
+
     await user.click(screen.getByRole('button', { name: /save as draft/i }))
 
     await waitFor(() => {
@@ -295,6 +322,8 @@ describe('RecipeEditor page', () => {
 
     const stepTextareas = screen.getAllByRole('textbox', { name: /step.*text/i })
     await user.type(stepTextareas[0], 'Mix it all')
+
+    await fillValidCoverImage(user)
 
     await user.click(screen.getByRole('button', { name: /publish/i }))
 
@@ -344,6 +373,8 @@ describe('RecipeEditor page', () => {
     const stepTextareas = screen.getAllByRole('textbox', { name: /step.*text/i })
     await user.type(stepTextareas[0], 'Mix it all')
 
+    await fillValidCoverImage(user)
+
     await user.click(screen.getByRole('button', { name: /save as draft/i }))
 
     await waitFor(() => {
@@ -371,6 +402,8 @@ describe('RecipeEditor page', () => {
 
     const stepTextareas = screen.getAllByRole('textbox', { name: /step.*text/i })
     await user.type(stepTextareas[0], 'Mix it all')
+
+    await fillValidCoverImage(user)
 
     await user.click(screen.getByRole('button', { name: /save as draft/i }))
 
@@ -466,6 +499,8 @@ describe('RecipeEditor page', () => {
       await user.type(screen.getByRole('textbox', { name: /intro/i }), 'A great recipe')
       await user.type(screen.getAllByRole('textbox', { name: /item/i })[0], 'Flour')
       await user.type(screen.getAllByRole('textbox', { name: /step.*text/i })[0], 'Mix it all')
+
+      await fillValidCoverImage(user)
 
       await user.click(screen.getByRole('button', { name: /save as draft/i }))
 
@@ -659,6 +694,8 @@ describe('RecipeEditor page', () => {
       await user.type(introInput, 'A great recipe')
       await user.type(screen.getAllByRole('textbox', { name: /item/i })[0], 'Flour')
       await user.type(screen.getAllByRole('textbox', { name: /step.*text/i })[0], 'Mix it all')
+
+      await fillValidCoverImage(user)
 
       await user.click(screen.getByRole('button', { name: /save as draft/i }))
 

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -299,13 +299,15 @@ const RecipeEditor: FC = () => {
         </div>
 
         <div className={styles.section}>
-          <ImageUpload
-            onUpload={setCoverImageKey}
-            currentKey={form.coverImageKey || undefined}
-            getToken={getAccessToken}
-            id={id}
-          />
-          {errors.coverImage && <span className={styles.error}>{errors.coverImage}</span>}
+          <div className={styles.field}>
+            <ImageUpload
+              onUpload={setCoverImageKey}
+              currentKey={form.coverImageKey || undefined}
+              getToken={getAccessToken}
+              id={id}
+            />
+            {errors.coverImage && <span className={styles.error}>{errors.coverImage}</span>}
+          </div>
 
           <div className={styles.field}>
             <label htmlFor="recipe-cover-alt">Cover image alt text</label>

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -21,6 +21,8 @@ interface FormErrors {
   intro?: string
   ingredients?: string
   steps?: string
+  coverImage?: string
+  coverImageAlt?: string
 }
 
 interface FormState {
@@ -167,6 +169,11 @@ const RecipeEditor: FC = () => {
     if (!form.steps.some((s) => s.text.trim())) {
       next.steps = 'At least one step with text is required'
     }
+    if (!form.coverImageKey.trim()) {
+      next.coverImage = 'Cover image is required'
+    } else if (!form.coverImageAlt.trim()) {
+      next.coverImageAlt = 'Alt text is required'
+    }
     return next
   }
 
@@ -298,6 +305,22 @@ const RecipeEditor: FC = () => {
             getToken={getAccessToken}
             id={id}
           />
+          {errors.coverImage && <span className={styles.error}>{errors.coverImage}</span>}
+
+          <div className={styles.field}>
+            <label htmlFor="recipe-cover-alt">Cover image alt text</label>
+            <input
+              id="recipe-cover-alt"
+              type="text"
+              value={form.coverImageAlt}
+              onChange={(e) => setField('coverImageAlt', e.target.value)}
+              className={styles.input}
+              aria-invalid={errors.coverImageAlt ? 'true' : undefined}
+            />
+            {errors.coverImageAlt && (
+              <span className={styles.error}>{errors.coverImageAlt}</span>
+            )}
+          </div>
         </div>
 
         <div className={styles.section}>

--- a/src/pages/admin/RecipeList/RecipeList.test.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.test.tsx
@@ -179,6 +179,22 @@ describe('Admin RecipeList page', () => {
     })
   })
 
+  it('clicking Unpublish on a published recipe calls unpublishRecipe', async () => {
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByText('Thai Green Curry')).toBeInTheDocument()
+    })
+
+    const unpublishButton = screen.getByRole('button', { name: /unpublish/i })
+    fireEvent.click(unpublishButton)
+
+    await waitFor(() => {
+      expect(unpublishRecipe).toHaveBeenCalledWith('token-123', 'rec-002')
+    })
+    expect(publishRecipe).not.toHaveBeenCalled()
+  })
+
   it('shows empty state when no recipes exist', async () => {
     vi.mocked(fetchMyRecipes).mockResolvedValue([])
     renderRecipeList()


### PR DESCRIPTION
Closes #124

## What changed

Closes coverage gaps identified by auditing the existing admin test files against the issue's acceptance criteria, and adds a small required-field rule to the recipe editor that the AC had called for but the earlier implementation had never delivered.

- **Tests added (14 total):**
  - `AuthContext`: auto-refreshes expired access tokens; throws `Session expired` when refresh fails.
  - `RecipeEditor`: tag autocomplete wired into the editor (typing surfaces a suggestion, clicking it adds a chip).
  - `RecipeEditor`: three TDD tests for the new cover-image + alt-text required validation.
  - `ImageUpload`: Upload button and Replace button open the file picker; Retry after a failed upload re-attempts.
  - `StepList`: renders per-step image upload + alt-text input when `getToken` is provided; does not render them when absent; alt-text edits fire `onChange`; step numbers update after reorder.
  - `RecipeList`: clicking Unpublish on a published recipe calls `unpublishRecipe`.
- **Implementation change** (`RecipeEditor.tsx`): `validate()` now requires a cover image and (once one is uploaded) alt text. A `Cover image alt text` input was added below the uploader. Six pre-existing happy-path tests were updated so their setup populates a valid cover image — they exercise their original save/publish assertions under the new contract.
- **PRD update** (committed directly to `main`, per convention): drag-and-drop file upload is listed as a v1 non-goal. The corresponding AC was removed from issue #124 before starting.

## Why

The milestone already wrote tests TDD-style alongside each prior issue, so most of the 17 ACs here were already covered. The audit was about catching what slipped through and making sure every AC has cited test coverage before the milestone closes. The cover-image-required validation was a genuine implementation gap surfaced during the AC walk — fixed in the same PR rather than raising a follow-up.

## How to verify

- `pnpm test` — expects 58 files / 491 tests green
- `pnpm lint` — 0 errors (5 pre-existing warnings unrelated to this work)
- Open `/admin/recipes/new` and try to save with no cover image → inline error under the uploader. Upload an image, leave alt text empty, save → inline error under the alt-text input.

## Decisions made

- The `throws on refresh failure` test covers AuthContext's actual contract (it throws); the `redirects to login when refresh fails` wording in the AC is satisfied by the existing ProtectedRoute tests, which assert the redirect when `isAuthenticated` becomes false.
- The `ImageUpload` mock in `RecipeEditor.test.tsx` is kept local — no second consumer yet to justify promoting it to a shared mock.
- `focusFirstError` was not extended for the new cover-image / alt-text errors — this matches the existing in-file precedent (ingredient/step errors aren't focused either).