### PR TITLE
Update API client: add createDraft, fetchAllRecipes, update types, remove createRecipe

### DIFF
--- a/src/api/recipes.test.ts
+++ b/src/api/recipes.test.ts
@@ -46,17 +46,11 @@ const mockTags: Tag[] = [
   { tag: 'Quick', count: 5 },
 ]
 
-// Type-level assertions — the Recipe 'status' field must be the narrowed
-// union 'draft' | 'published'. These compile-time checks are exempt from
-// the test-file eslint unused-vars rule via the `^_` prefix.
 const _statusOk: Recipe['status'] = 'draft'
 const _statusOk2: Recipe['status'] = 'published'
 // @ts-expect-error — 'archived' is not a valid status
 const _statusBad: Recipe['status'] = 'archived'
-
-// Runtime check that a Recipe literal with an optional `ttl` field is
-// accepted by the type (TS enforces this structurally).
-const _recipeWithTtl: Recipe & { ttl?: number } = { ...mockRecipe, ttl: 123 }
+const _recipeWithTtl: Recipe = { ...mockRecipe, ttl: 123 }
 
 beforeEach(() => {
   vi.restoreAllMocks()

--- a/src/api/recipes.test.ts
+++ b/src/api/recipes.test.ts
@@ -5,7 +5,6 @@ import {
   fetchRecipe,
   fetchTags,
   fetchMyRecipes,
-  createRecipe,
   updateRecipe,
   publishRecipe,
   unpublishRecipe,
@@ -46,6 +45,18 @@ const mockTags: Tag[] = [
   { tag: 'Italian', count: 3 },
   { tag: 'Quick', count: 5 },
 ]
+
+// Type-level assertions — the Recipe 'status' field must be the narrowed
+// union 'draft' | 'published'. These compile-time checks are exempt from
+// the test-file eslint unused-vars rule via the `^_` prefix.
+const _statusOk: Recipe['status'] = 'draft'
+const _statusOk2: Recipe['status'] = 'published'
+// @ts-expect-error — 'archived' is not a valid status
+const _statusBad: Recipe['status'] = 'archived'
+
+// Runtime check that a Recipe literal with an optional `ttl` field is
+// accepted by the type (TS enforces this structurally).
+const _recipeWithTtl: Recipe & { ttl?: number } = { ...mockRecipe, ttl: 123 }
 
 beforeEach(() => {
   vi.restoreAllMocks()
@@ -214,35 +225,89 @@ describe('authenticated recipe endpoints', () => {
     })
   })
 
-  describe('createRecipe', () => {
-    it('POST with token and data', async () => {
+  describe('createDraft', () => {
+    it('POST /recipes/drafts with token and returns { id, slug }', async () => {
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
-          json: () => Promise.resolve(mockRecipe),
+          json: () => Promise.resolve({ id: 'r1', slug: 'my-slug' }),
         })
       )
 
-      const data = { title: 'New Recipe' }
-      const result = await createRecipe('token-123', data)
+      const mod = await import('./recipes')
+      const result = await mod.createDraft('token-123')
 
-      expect(result).toEqual(mockRecipe)
+      expect(result).toEqual({ id: 'r1', slug: 'my-slug' })
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/recipes'),
+        expect.stringContaining('/recipes/drafts'),
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({
+            'Content-Type': 'application/json',
             Authorization: 'Bearer token-123',
           }),
-          body: JSON.stringify(data),
         })
       )
+    })
+
+    it('throws with 401 on unauthorised', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+        })
+      )
+
+      const mod = await import('./recipes')
+      await expect(mod.createDraft('bad-token')).rejects.toThrow('401')
+    })
+  })
+
+  describe('fetchAllRecipes', () => {
+    it('GET /recipes/admin with token and returns the array verbatim', async () => {
+      // Deployed backend returns a plain Recipe[] (not { recipes: Recipe[] }).
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve([mockRecipe]),
+        })
+      )
+
+      const mod = await import('./recipes')
+      const result = await mod.fetchAllRecipes('token-123')
+
+      expect(result).toEqual([mockRecipe])
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/recipes/admin'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer token-123',
+          }),
+        })
+      )
+    })
+
+    it('throws with 401 on unauthorised', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+        })
+      )
+
+      const mod = await import('./recipes')
+      await expect(mod.fetchAllRecipes('bad-token')).rejects.toThrow('401')
     })
   })
 
   describe('updateRecipe', () => {
-    it('PUT with token, id, and data', async () => {
+    it('PATCH with token, id, and data', async () => {
       vi.stubGlobal(
         'fetch',
         vi.fn().mockResolvedValue({
@@ -258,7 +323,7 @@ describe('authenticated recipe endpoints', () => {
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('/recipes/r1'),
         expect.objectContaining({
-          method: 'PUT',
+          method: 'PATCH',
           headers: expect.objectContaining({
             Authorization: 'Bearer token-123',
           }),
@@ -269,14 +334,16 @@ describe('authenticated recipe endpoints', () => {
   })
 
   describe('publishRecipe', () => {
-    it('PATCH with token', async () => {
+    it('PATCH and returns the updated Recipe with status=published', async () => {
+      const published: Recipe = { ...mockRecipe, status: 'published' }
       vi.stubGlobal(
         'fetch',
-        vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(undefined) })
+        vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(published) })
       )
 
-      await publishRecipe('token-123', 'r1')
+      const result = await publishRecipe('token-123', 'r1')
 
+      expect(result).toEqual(published)
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('/recipes/r1/publish'),
         expect.objectContaining({
@@ -287,17 +354,32 @@ describe('authenticated recipe endpoints', () => {
         })
       )
     })
+
+    it('throws with 401 on unauthorised', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+        })
+      )
+
+      await expect(publishRecipe('bad-token', 'r1')).rejects.toThrow('401')
+    })
   })
 
   describe('unpublishRecipe', () => {
-    it('PATCH with token', async () => {
+    it('PATCH and returns the updated Recipe with status=draft', async () => {
+      const draft: Recipe = { ...mockRecipe, status: 'draft' }
       vi.stubGlobal(
         'fetch',
-        vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(undefined) })
+        vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(draft) })
       )
 
-      await unpublishRecipe('token-123', 'r1')
+      const result = await unpublishRecipe('token-123', 'r1')
 
+      expect(result).toEqual(draft)
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('/recipes/r1/unpublish'),
         expect.objectContaining({
@@ -307,6 +389,19 @@ describe('authenticated recipe endpoints', () => {
           }),
         })
       )
+    })
+
+    it('throws with 401 on unauthorised', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+        })
+      )
+
+      await expect(unpublishRecipe('bad-token', 'r1')).rejects.toThrow('401')
     })
   })
 
@@ -356,5 +451,12 @@ describe('authenticated recipe endpoints', () => {
         })
       )
     })
+  })
+})
+
+describe('createRecipe removal', () => {
+  it('does not export createRecipe', async () => {
+    const mod = await import('./recipes')
+    expect('createRecipe' in mod).toBe(false)
   })
 })

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -36,14 +36,23 @@ export const fetchMyRecipes = async (token: string): Promise<Recipe[]> => {
   return response.json()
 }
 
-export const createRecipe = async (token: string, data: Partial<Recipe>): Promise<Recipe> => {
-  const response = await fetch(`${API_BASE}/recipes`, {
+export const createDraft = async (token: string): Promise<{ id: string; slug: string }> => {
+  const response = await fetch(`${API_BASE}/recipes/drafts`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify(data),
+  })
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+  return response.json()
+}
+
+export const fetchAllRecipes = async (token: string): Promise<Recipe[]> => {
+  const response = await fetch(`${API_BASE}/recipes/admin`, {
+    headers: { Authorization: `Bearer ${token}` },
   })
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`)
@@ -57,7 +66,7 @@ export const updateRecipe = async (
   data: Partial<Recipe>
 ): Promise<Recipe> => {
   const response = await fetch(`${API_BASE}/recipes/${id}`, {
-    method: 'PUT',
+    method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
@@ -70,7 +79,7 @@ export const updateRecipe = async (
   return response.json()
 }
 
-export const publishRecipe = async (token: string, id: string): Promise<void> => {
+export const publishRecipe = async (token: string, id: string): Promise<Recipe> => {
   const response = await fetch(`${API_BASE}/recipes/${id}/publish`, {
     method: 'PATCH',
     headers: { Authorization: `Bearer ${token}` },
@@ -78,9 +87,10 @@ export const publishRecipe = async (token: string, id: string): Promise<void> =>
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`)
   }
+  return response.json()
 }
 
-export const unpublishRecipe = async (token: string, id: string): Promise<void> => {
+export const unpublishRecipe = async (token: string, id: string): Promise<Recipe> => {
   const response = await fetch(`${API_BASE}/recipes/${id}/unpublish`, {
     method: 'PATCH',
     headers: { Authorization: `Bearer ${token}` },
@@ -88,6 +98,7 @@ export const unpublishRecipe = async (token: string, id: string): Promise<void> 
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`)
   }
+  return response.json()
 }
 
 export const deleteRecipe = async (token: string, id: string): Promise<void> => {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -1,4 +1,4 @@
-import { createRecipe, fetchMyRecipes, fetchTags, updateRecipe } from '@api/recipes'
+import { fetchMyRecipes, fetchTags, updateRecipe } from '@api/recipes'
 import { useAuth } from '@contexts/AuthContext'
 import type { Recipe } from '@models/recipe'
 import { render, screen, waitFor, within } from '@testing-library/react'
@@ -9,7 +9,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import RecipeEditor from './RecipeEditor'
 
 vi.mock('@api/recipes', () => ({
-  createRecipe: vi.fn(),
   updateRecipe: vi.fn(),
   fetchMyRecipes: vi.fn(),
   fetchTags: vi.fn(),
@@ -88,7 +87,6 @@ describe('RecipeEditor page', () => {
       { tag: 'Thai', count: 3 },
     ])
     vi.mocked(fetchMyRecipes).mockResolvedValue([mockRecipe])
-    vi.mocked(createRecipe).mockResolvedValue(mockRecipe)
     vi.mocked(updateRecipe).mockResolvedValue(mockRecipe)
   })
 
@@ -161,8 +159,6 @@ describe('RecipeEditor page', () => {
     await waitFor(() => {
       expect(screen.getByText(/cover image is required/i)).toBeInTheDocument()
     })
-
-    expect(createRecipe).not.toHaveBeenCalled()
   })
 
   it('shows alt-text-required error when saving with a cover image but no alt text', async () => {
@@ -258,68 +254,6 @@ describe('RecipeEditor page', () => {
     })
   })
 
-  it('"Save as draft" calls createRecipe with status: "draft"', async () => {
-    const user = userEvent.setup()
-    renderEditor('/admin/recipes/new')
-
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
-    })
-
-    const titleInput = screen.getByRole('textbox', { name: /title/i })
-    const introInput = screen.getByRole('textbox', { name: /intro/i })
-    await user.type(titleInput, 'My Recipe')
-    await user.type(introInput, 'A great recipe')
-
-    const ingredientInputs = screen.getAllByRole('textbox', { name: /item/i })
-    await user.type(ingredientInputs[0], 'Flour')
-
-    const stepTextareas = screen.getAllByRole('textbox', { name: /step.*text/i })
-    await user.type(stepTextareas[0], 'Mix it all')
-
-    await fillValidCoverImage(user)
-
-    await user.click(screen.getByRole('button', { name: /save as draft/i }))
-
-    await waitFor(() => {
-      expect(createRecipe).toHaveBeenCalledWith(
-        'token-123',
-        expect.objectContaining({ status: 'draft' })
-      )
-    })
-  })
-
-  it('"Publish" calls createRecipe with status: "published"', async () => {
-    const user = userEvent.setup()
-    renderEditor('/admin/recipes/new')
-
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
-    })
-
-    const titleInput = screen.getByRole('textbox', { name: /title/i })
-    const introInput = screen.getByRole('textbox', { name: /intro/i })
-    await user.type(titleInput, 'My Recipe')
-    await user.type(introInput, 'A great recipe')
-
-    const ingredientInputs = screen.getAllByRole('textbox', { name: /item/i })
-    await user.type(ingredientInputs[0], 'Flour')
-
-    const stepTextareas = screen.getAllByRole('textbox', { name: /step.*text/i })
-    await user.type(stepTextareas[0], 'Mix it all')
-
-    await fillValidCoverImage(user)
-
-    await user.click(screen.getByRole('button', { name: /publish/i }))
-
-    await waitFor(() => {
-      expect(createRecipe).toHaveBeenCalledWith(
-        'token-123',
-        expect.objectContaining({ status: 'published' })
-      )
-    })
-  })
-
   it('"Save changes" (edit mode) calls updateRecipe preserving current status', async () => {
     const user = userEvent.setup()
     renderEditor('/admin/recipes/rec-001/edit')
@@ -339,58 +273,16 @@ describe('RecipeEditor page', () => {
     })
   })
 
-  it('shows success toast after save', async () => {
-    const user = userEvent.setup()
-    renderEditor('/admin/recipes/new')
-
-    await waitFor(() => {
-      expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
-    })
-
-    const titleInput = screen.getByRole('textbox', { name: /title/i })
-    const introInput = screen.getByRole('textbox', { name: /intro/i })
-    await user.type(titleInput, 'My Recipe')
-    await user.type(introInput, 'A great recipe')
-
-    const ingredientInputs = screen.getAllByRole('textbox', { name: /item/i })
-    await user.type(ingredientInputs[0], 'Flour')
-
-    const stepTextareas = screen.getAllByRole('textbox', { name: /step.*text/i })
-    await user.type(stepTextareas[0], 'Mix it all')
-
-    await fillValidCoverImage(user)
-
-    await user.click(screen.getByRole('button', { name: /save as draft/i }))
-
-    await waitFor(() => {
-      expect(screen.getByText(/recipe saved/i)).toBeInTheDocument()
-    })
-    expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
-  })
-
   it('shows error toast on API failure', async () => {
-    vi.mocked(createRecipe).mockRejectedValue(new Error('500 Internal Server Error'))
+    vi.mocked(updateRecipe).mockRejectedValue(new Error('500 Internal Server Error'))
     const user = userEvent.setup()
-    renderEditor('/admin/recipes/new')
+    renderEditor('/admin/recipes/rec-001/edit')
 
     await waitFor(() => {
-      expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
+      expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
     })
 
-    const titleInput = screen.getByRole('textbox', { name: /title/i })
-    const introInput = screen.getByRole('textbox', { name: /intro/i })
-    await user.type(titleInput, 'My Recipe')
-    await user.type(introInput, 'A great recipe')
-
-    const ingredientInputs = screen.getAllByRole('textbox', { name: /item/i })
-    await user.type(ingredientInputs[0], 'Flour')
-
-    const stepTextareas = screen.getAllByRole('textbox', { name: /step.*text/i })
-    await user.type(stepTextareas[0], 'Mix it all')
-
-    await fillValidCoverImage(user)
-
-    await user.click(screen.getByRole('button', { name: /save as draft/i }))
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
 
     await waitFor(() => {
       expect(screen.getByText(/error/i)).toBeInTheDocument()
@@ -461,33 +353,6 @@ describe('RecipeEditor page', () => {
       window.dispatchEvent(event)
 
       expect(event.defaultPrevented).toBe(true)
-    })
-
-    it('does not prevent beforeunload after a successful save (form becomes pristine)', async () => {
-      const user = userEvent.setup()
-      renderEditor('/admin/recipes/new')
-
-      await waitFor(() => {
-        expect(screen.getByRole('textbox', { name: /title/i })).toBeInTheDocument()
-      })
-
-      await user.type(screen.getByRole('textbox', { name: /title/i }), 'My Recipe')
-      await user.type(screen.getByRole('textbox', { name: /intro/i }), 'A great recipe')
-      await user.type(screen.getAllByRole('textbox', { name: /item/i })[0], 'Flour')
-      await user.type(screen.getAllByRole('textbox', { name: /step.*text/i })[0], 'Mix it all')
-
-      await fillValidCoverImage(user)
-
-      await user.click(screen.getByRole('button', { name: /save as draft/i }))
-
-      await waitFor(() => {
-        expect(createRecipe).toHaveBeenCalled()
-      })
-
-      const event = new Event('beforeunload', { cancelable: true })
-      window.dispatchEvent(event)
-
-      expect(event.defaultPrevented).toBe(false)
     })
 
     it('blocks React Router navigation and shows a confirmation dialogue when the form is dirty', async () => {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -1,5 +1,5 @@
 import { isSessionError } from '@api/auth'
-import { createRecipe, fetchMyRecipes, fetchTags, updateRecipe } from '@api/recipes'
+import { fetchMyRecipes, fetchTags, updateRecipe } from '@api/recipes'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
 import ImageUpload from '@components/ImageUpload'
@@ -36,7 +36,7 @@ interface FormState {
   steps: Step[]
   coverImageKey: string
   coverImageAlt: string
-  status: string
+  status: Recipe['status']
   dirty: boolean
 }
 
@@ -185,7 +185,7 @@ const RecipeEditor: FC = () => {
     }
   }, [])
 
-  const handleSubmit = async (targetStatus: string) => {
+  const handleSubmit = async (targetStatus: Recipe['status']) => {
     const validationErrors = validate()
     setErrors(validationErrors)
 
@@ -213,7 +213,8 @@ const RecipeEditor: FC = () => {
       if (isEditMode && id) {
         await updateRecipe(token, id, data)
       } else {
-        await createRecipe(token, data)
+        // TODO(#153): create-on-mount flow replaces this branch — draft-on-mount + autosave + publish button.
+        throw new Error('not implemented — pending #153')
       }
 
       dispatch({ type: 'MARK_PRISTINE' })

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -41,5 +41,6 @@ export interface Recipe extends RecipeIndex {
   authorId: string
   authorName: string
   updatedAt: string
-  status: string
+  status: 'draft' | 'published'
+  ttl?: number
 }


### PR DESCRIPTION
Closes #147

## What changed

**API client (`src/api/recipes.ts`)**
- Added `createDraft(token)` → `POST /recipes/drafts`, returns `{ id, slug }`.
- Added `fetchAllRecipes(token)` → `GET /recipes/admin`, returns plain `Recipe[]`.
- Removed `createRecipe` — every call site updated.

**Types (`src/types/recipe.ts`)**
- Narrowed `Recipe.status` from `string` to `'draft' | 'published'`.
- Added optional `ttl?: number`.

**Out-of-scope fixes bundled in (pre-approved as gap fixes against the new backend):**
- `updateRecipe` method `PUT → PATCH` — the backend removed `PUT /recipes/{id}` in the infra milestone; leaving it as PUT would 404 and break autosave in #148/#153.
- `publishRecipe` / `unpublishRecipe` now return `Promise<Recipe>` — the backend returns the updated recipe body; the editor (#153) will consume it instead of refetching.
- `fetchAllRecipes` returns plain `Recipe[]` (not `{ recipes: Recipe[] }`) because that's what the deployed backend returns; the PRD's wrapped shape is drift.

**Known stop-gap:** the `RecipeEditor.tsx` create-path submit now throws `'not implemented — pending #153'` with a TODO. The whole submit flow is rewritten in #153 (draft-on-mount + autosave + publish button). Clicking "Save as draft" / "Publish" on `/admin/recipes/new` will surface an error toast until #153 lands — the 4 tests that exercised the old createRecipe path were deleted as obsolete.

## Why
Per `docs/prds/draft-recipes.md`, creation now flows through `POST /recipes/drafts → PATCH → publish`. The infra side (already on main in `akli-infrastructure` v1.6.0) removed `POST /recipes` and `PUT /recipes/{id}` entirely; the frontend API client must match.

## How to verify
- `pnpm test` — 493/493 pass.
- `pnpm lint` — exits 0 (5 pre-existing `react-refresh/only-export-components` warnings unrelated).
- Unit tests in `src/api/recipes.test.ts` cover `createDraft` + `fetchAllRecipes` happy + 401 paths, the `updateRecipe` PATCH assertion, and a regression guard asserting `createRecipe` is not exported.
- Type-level assertions in the test file confirm `Recipe.status` is narrowed (`@ts-expect-error` on `'archived'`).

## Decisions made
- Matched the deployed backend's response shape (plain `Recipe[]`) over the PRD's wrapped shape — reality trumps spec.
- Kept the PUT→PATCH and publish/unpublish return-value fixes in this PR rather than splitting them out — both are 1–2 line corrections blocking subsequent issues in the same milestone.
- Left the RecipeEditor create-path stop-gap as an explicit throw with a TODO rather than silently no-oping — makes the pending work obvious at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)