### PR TITLE
Build useAutosave hook with debounce, abort, and visibility flush

### DIFF
--- a/src/hooks/useAutosave.test.ts
+++ b/src/hooks/useAutosave.test.ts
@@ -1,14 +1,11 @@
 import * as authApi from '@api/auth'
 import * as authContext from '@contexts/AuthContext'
-import { act, renderHook, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, configure, renderHook, waitFor } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 
 import { useAutosave } from './useAutosave'
 
-// Mock handleSessionError so we can spy on it; keep the other exports intact
-// because AuthContext (re-exported under this alias above) pulls them in at
-// module init time for the hook's consumers.
 vi.mock('@api/auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@api/auth')>()
   return {
@@ -58,6 +55,14 @@ afterEach(() => {
 })
 
 describe('useAutosave — state machine', () => {
+  beforeAll(() => {
+    configure({ asyncUtilTimeout: 5000 })
+  })
+
+  afterAll(() => {
+    configure({ asyncUtilTimeout: 1000 })
+  })
+
   it('status is idle on first render', () => {
     const saveFn = vi.fn().mockResolvedValue(undefined)
     const { result } = renderHook(() =>
@@ -323,21 +328,22 @@ describe('useAutosave — debounce timing + lifecycle', () => {
     })
     expect(saveFn).not.toHaveBeenCalled()
 
-    Object.defineProperty(document, 'visibilityState', {
-      value: 'hidden',
-      configurable: true,
-    })
-    await act(async () => {
-      document.dispatchEvent(new Event('visibilitychange'))
-    })
+    try {
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'hidden',
+        configurable: true,
+      })
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
 
-    expect(saveFn).toHaveBeenCalledTimes(1)
-
-    // Restore so later tests are unaffected.
-    Object.defineProperty(document, 'visibilityState', {
-      value: 'visible',
-      configurable: true,
-    })
+      expect(saveFn).toHaveBeenCalledTimes(1)
+    } finally {
+      Object.defineProperty(document, 'visibilityState', {
+        value: 'visible',
+        configurable: true,
+      })
+    }
   })
 
   it('flushes the pending save on unmount', async () => {
@@ -363,6 +369,14 @@ describe('useAutosave — debounce timing + lifecycle', () => {
 })
 
 describe('useAutosave — 401 handling', () => {
+  beforeAll(() => {
+    configure({ asyncUtilTimeout: 5000 })
+  })
+
+  afterAll(() => {
+    configure({ asyncUtilTimeout: 1000 })
+  })
+
   it('invokes handleSessionError with (err, logout, navigate) when saveFn rejects with a 401', async () => {
     const authErr = new Error('401 Unauthorized')
     const saveFn = vi.fn().mockRejectedValue(authErr)

--- a/src/hooks/useAutosave.test.ts
+++ b/src/hooks/useAutosave.test.ts
@@ -1,0 +1,386 @@
+import * as authApi from '@api/auth'
+import * as authContext from '@contexts/AuthContext'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+
+import { useAutosave } from './useAutosave'
+
+// Mock handleSessionError so we can spy on it; keep the other exports intact
+// because AuthContext (re-exported under this alias above) pulls them in at
+// module init time for the hook's consumers.
+vi.mock('@api/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@api/auth')>()
+  return {
+    ...actual,
+    handleSessionError: vi.fn(),
+  }
+})
+
+// Mock useNavigate so the hook can resolve it without a router.
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
+
+const navigateMock = vi.fn()
+const logoutMock = vi.fn()
+
+// Stub useAuth so the hook can pull logout without a full AuthProvider.
+const useAuthSpy = vi.spyOn(authContext, 'useAuth')
+
+type Draft = {
+  dirty: boolean
+  title: string
+  body?: string
+}
+
+beforeEach(() => {
+  navigateMock.mockReset()
+  logoutMock.mockReset()
+  vi.mocked(authApi.handleSessionError).mockReset()
+  useAuthSpy.mockReturnValue({
+    user: null,
+    isAuthenticated: true,
+    isAdmin: true,
+    loading: false,
+    login: vi.fn(),
+    logout: logoutMock,
+    getAccessToken: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useAutosave — state machine', () => {
+  it('status is idle on first render', () => {
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() =>
+      useAutosave<Draft>({ dirty: false, title: '' }, saveFn)
+    )
+
+    expect(result.current.status).toBe('idle')
+    expect(result.current.lastSavedAt).toBeNull()
+  })
+
+  it('transitions idle → saving → saved after a dirty change and sets lastSavedAt', async () => {
+    let resolveSave!: () => void
+    const saveFn = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve
+        })
+    )
+
+    const initial: Draft = { dirty: false, title: '' }
+    const { result, rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: initial } }
+    )
+
+    expect(result.current.status).toBe('idle')
+
+    rerender({ state: { dirty: true, title: 'Hello' } })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('saving')
+    })
+
+    await act(async () => {
+      resolveSave()
+    })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('saved')
+    })
+    expect(result.current.lastSavedAt).toBeInstanceOf(Date)
+  })
+
+  it('transitions to error when saveFn rejects with a non-session error and does not update lastSavedAt', async () => {
+    const saveFn = vi.fn().mockRejectedValue(new Error('Network down'))
+
+    const { result, rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: '' } as Draft } }
+    )
+
+    rerender({ state: { dirty: true, title: 'Hello' } as Draft })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error')
+    })
+    expect(result.current.lastSavedAt).toBeNull()
+  })
+
+  it('retry re-invokes saveFn and transitions saving → saved on success', async () => {
+    const saveFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Network down'))
+      .mockResolvedValueOnce(undefined)
+
+    const { result, rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: '' } as Draft } }
+    )
+
+    rerender({ state: { dirty: true, title: 'Hello' } as Draft })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('error')
+    })
+
+    act(() => {
+      result.current.retry()
+    })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('saved')
+    })
+    expect(saveFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts an in-flight save when a newer fire starts (previous AbortSignal is aborted)', async () => {
+    const calls: Array<{ state: Draft; signal: AbortSignal; resolve: () => void }> = []
+    const saveFn = vi.fn((state: Draft, signal: AbortSignal) => {
+      return new Promise<void>((resolve) => {
+        calls.push({ state, signal, resolve })
+      })
+    })
+
+    const { result, rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: '' } as Draft } }
+    )
+
+    rerender({ state: { dirty: true, title: 'First' } as Draft })
+
+    await waitFor(() => {
+      expect(calls.length).toBe(1)
+    })
+
+    // A newer dirty change while the first is still in flight.
+    rerender({ state: { dirty: true, title: 'Second' } as Draft })
+
+    await waitFor(() => {
+      expect(calls.length).toBe(2)
+    })
+
+    // The first signal should now be aborted.
+    expect(calls[0].signal.aborted).toBe(true)
+    expect(calls[1].signal.aborted).toBe(false)
+
+    // Resolve both in reverse order; only the latest result updates lastSavedAt.
+    await act(async () => {
+      calls[0].resolve()
+      calls[1].resolve()
+    })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('saved')
+    })
+    expect(result.current.lastSavedAt).toBeInstanceOf(Date)
+  })
+
+  it('skips saveFn when dirty is false', () => {
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: 'A' } as Draft } }
+    )
+
+    rerender({ state: { dirty: false, title: 'B' } as Draft })
+    rerender({ state: { dirty: false, title: 'C' } as Draft })
+
+    expect(saveFn).not.toHaveBeenCalled()
+  })
+
+  it('skips saveFn when state is dirty but matches the last-saved snapshot', async () => {
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+
+    const snapshot: Draft = { dirty: true, title: 'Hello', body: 'World' }
+    const { result, rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: 'Hello', body: 'World' } as Draft } }
+    )
+
+    // First dirty fire — saves.
+    rerender({ state: snapshot })
+    await waitFor(() => {
+      expect(result.current.status).toBe('saved')
+    })
+    expect(saveFn).toHaveBeenCalledTimes(1)
+
+    // Dispatch the same values again as "dirty". Nothing changed against
+    // the last-saved snapshot, so the hook should skip.
+    rerender({ state: { dirty: true, title: 'Hello', body: 'World' } as Draft })
+
+    // Give the hook a turn to react without triggering a fresh save.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(saveFn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useAutosave — debounce timing + lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not call saveFn at t=1999ms but does at t=2000ms after a dirty change', async () => {
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: '' } as Draft } }
+    )
+
+    rerender({ state: { dirty: true, title: 'Hello' } as Draft })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1999)
+    })
+    expect(saveFn).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(saveFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapses multiple dirty changes within the debounce window into a single trailing call', async () => {
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: '' } as Draft } }
+    )
+
+    rerender({ state: { dirty: true, title: 'One' } as Draft })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    rerender({ state: { dirty: true, title: 'Two' } as Draft })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    rerender({ state: { dirty: true, title: 'Three' } as Draft })
+
+    // Advance to 2s after the last change.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+
+    expect(saveFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires with the latest state snapshot (stale-closure guard)', async () => {
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: '' } as Draft } }
+    )
+
+    rerender({ state: { dirty: true, title: 'Early' } as Draft })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    rerender({ state: { dirty: true, title: 'Latest' } as Draft })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+
+    expect(saveFn).toHaveBeenCalledTimes(1)
+    const [payload] = saveFn.mock.calls[0]
+    expect(payload.title).toBe('Latest')
+  })
+
+  it('flushes the pending save immediately on visibilitychange → hidden', async () => {
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: '' } as Draft } }
+    )
+
+    rerender({ state: { dirty: true, title: 'Hello' } as Draft })
+
+    // Debounce has not elapsed yet.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(saveFn).not.toHaveBeenCalled()
+
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(saveFn).toHaveBeenCalledTimes(1)
+
+    // Restore so later tests are unaffected.
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    })
+  })
+
+  it('flushes the pending save on unmount', async () => {
+    const saveFn = vi.fn().mockResolvedValue(undefined)
+
+    const { rerender, unmount } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: '' } as Draft } }
+    )
+
+    rerender({ state: { dirty: true, title: 'Hello' } as Draft })
+
+    // Unmount before the debounce fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(saveFn).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(saveFn).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useAutosave — 401 handling', () => {
+  it('invokes handleSessionError with (err, logout, navigate) when saveFn rejects with a 401', async () => {
+    const authErr = new Error('401 Unauthorized')
+    const saveFn = vi.fn().mockRejectedValue(authErr)
+
+    const { rerender } = renderHook(
+      ({ state }: { state: Draft }) => useAutosave<Draft>(state, saveFn),
+      { initialProps: { state: { dirty: false, title: '' } as Draft } }
+    )
+
+    rerender({ state: { dirty: true, title: 'Hello' } as Draft })
+
+    await waitFor(() => {
+      expect(vi.mocked(authApi.handleSessionError)).toHaveBeenCalled()
+    })
+
+    const [errArg, logoutArg, navigateArg] = vi.mocked(authApi.handleSessionError).mock.calls[0]
+    expect(errArg).toBe(authErr)
+    expect(logoutArg).toBe(logoutMock)
+    expect(navigateArg).toBe(navigateMock)
+  })
+})

--- a/src/hooks/useAutosave.test.ts
+++ b/src/hooks/useAutosave.test.ts
@@ -54,15 +54,15 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+beforeAll(() => {
+  configure({ asyncUtilTimeout: 5000 })
+})
+
+afterAll(() => {
+  configure({ asyncUtilTimeout: 1000 })
+})
+
 describe('useAutosave — state machine', () => {
-  beforeAll(() => {
-    configure({ asyncUtilTimeout: 5000 })
-  })
-
-  afterAll(() => {
-    configure({ asyncUtilTimeout: 1000 })
-  })
-
   it('status is idle on first render', () => {
     const saveFn = vi.fn().mockResolvedValue(undefined)
     const { result } = renderHook(() =>
@@ -369,14 +369,6 @@ describe('useAutosave — debounce timing + lifecycle', () => {
 })
 
 describe('useAutosave — 401 handling', () => {
-  beforeAll(() => {
-    configure({ asyncUtilTimeout: 5000 })
-  })
-
-  afterAll(() => {
-    configure({ asyncUtilTimeout: 1000 })
-  })
-
   it('invokes handleSessionError with (err, logout, navigate) when saveFn rejects with a 401', async () => {
     const authErr = new Error('401 Unauthorized')
     const saveFn = vi.fn().mockRejectedValue(authErr)

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -1,5 +1,7 @@
-// Stub — real implementation to be added by feature agent.
-// See issue #148 / docs/prds/draft-recipes.md.
+import { handleSessionError } from '@api/auth'
+import { useAuth } from '@contexts/AuthContext'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 export interface UseAutosaveOptions {
   intervalMs?: number
@@ -11,10 +13,133 @@ export interface UseAutosaveResult {
   retry: () => void
 }
 
+const DEFAULT_INTERVAL_MS = 2000
+
+const stripDirty = <T extends { dirty: boolean }>(state: T): Omit<T, 'dirty'> => {
+  const rest = { ...state } as Partial<T>
+  delete rest.dirty
+  return rest as Omit<T, 'dirty'>
+}
+
+const isEqualSnapshot = <T extends { dirty: boolean }>(
+  a: T | null,
+  b: T
+): boolean => {
+  if (a === null) return false
+  return JSON.stringify(stripDirty(a)) === JSON.stringify(stripDirty(b))
+}
+
 export const useAutosave = <T extends { dirty: boolean }>(
-  _state: T,
-  _saveFn: (state: T, signal: AbortSignal) => Promise<void>,
-  _options?: UseAutosaveOptions
+  state: T,
+  saveFn: (state: T, signal: AbortSignal) => Promise<void>,
+  options?: UseAutosaveOptions
 ): UseAutosaveResult => {
-  throw new Error('useAutosave: not implemented')
+  const intervalMs = options?.intervalMs ?? DEFAULT_INTERVAL_MS
+
+  const { logout } = useAuth()
+  const navigate = useNavigate()
+
+  const [status, setStatus] = useState<UseAutosaveResult['status']>('idle')
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null)
+
+  const stateRef = useRef<T>(state)
+  const saveFnRef = useRef(saveFn)
+  const logoutRef = useRef(logout)
+  const navigateRef = useRef(navigate)
+  const lastSavedSnapshotRef = useRef<T | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const pendingRef = useRef(false)
+  const latestFireIdRef = useRef(0)
+
+  stateRef.current = state
+  saveFnRef.current = saveFn
+  logoutRef.current = logout
+  navigateRef.current = navigate
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  const runSave = useCallback(async (snapshot: T) => {
+    if (abortRef.current) {
+      abortRef.current.abort()
+    }
+    const controller = new AbortController()
+    abortRef.current = controller
+    const fireId = ++latestFireIdRef.current
+
+    setStatus('saving')
+
+    try {
+      await saveFnRef.current(snapshot, controller.signal)
+      if (controller.signal.aborted) return
+      if (fireId !== latestFireIdRef.current) return
+      lastSavedSnapshotRef.current = snapshot
+      setLastSavedAt(new Date())
+      setStatus('saved')
+    } catch (err) {
+      if (controller.signal.aborted) return
+      if (fireId !== latestFireIdRef.current) return
+      const redirected = handleSessionError(err, logoutRef.current, navigateRef.current)
+      if (!redirected) {
+        setStatus('error')
+      }
+    }
+  }, [])
+
+  const flushPending = useCallback(() => {
+    if (!pendingRef.current) return
+    clearTimer()
+    pendingRef.current = false
+    void runSave(stateRef.current)
+  }, [clearTimer, runSave])
+
+  useEffect(() => {
+    if (!state.dirty) return
+    if (isEqualSnapshot(lastSavedSnapshotRef.current, state)) return
+
+    clearTimer()
+    pendingRef.current = true
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      pendingRef.current = false
+      void runSave(stateRef.current)
+    }, intervalMs)
+  }, [state, intervalMs, clearTimer, runSave])
+
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        flushPending()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [flushPending])
+
+  useEffect(() => {
+    return () => {
+      if (pendingRef.current) {
+        clearTimer()
+        pendingRef.current = false
+        void saveFnRef.current(stateRef.current, new AbortController().signal)
+      } else {
+        clearTimer()
+      }
+    }
+  }, [clearTimer])
+
+  const retry = useCallback(() => {
+    clearTimer()
+    pendingRef.current = false
+    void runSave(stateRef.current)
+  }, [clearTimer, runSave])
+
+  return { status, lastSavedAt, retry }
 }

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -1,0 +1,20 @@
+// Stub — real implementation to be added by feature agent.
+// See issue #148 / docs/prds/draft-recipes.md.
+
+export interface UseAutosaveOptions {
+  intervalMs?: number
+}
+
+export interface UseAutosaveResult {
+  status: 'idle' | 'saving' | 'saved' | 'error'
+  lastSavedAt: Date | null
+  retry: () => void
+}
+
+export const useAutosave = <T extends { dirty: boolean }>(
+  _state: T,
+  _saveFn: (state: T, signal: AbortSignal) => Promise<void>,
+  _options?: UseAutosaveOptions
+): UseAutosaveResult => {
+  throw new Error('useAutosave: not implemented')
+}

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -21,6 +21,7 @@ const stripDirty = <T extends { dirty: boolean }>(state: T): Omit<T, 'dirty'> =>
   return rest as Omit<T, 'dirty'>
 }
 
+// Assumes state fields have stable key ordering — safe for the reducer's static shape
 const isEqualSnapshot = <T extends { dirty: boolean }>(
   a: T | null,
   b: T
@@ -51,6 +52,7 @@ export const useAutosave = <T extends { dirty: boolean }>(
   const abortRef = useRef<AbortController | null>(null)
   const pendingRef = useRef(false)
   const latestFireIdRef = useRef(0)
+  const isMountedRef = useRef(true)
 
   stateRef.current = state
   saveFnRef.current = saveFn
@@ -72,20 +74,22 @@ export const useAutosave = <T extends { dirty: boolean }>(
     abortRef.current = controller
     const fireId = ++latestFireIdRef.current
 
-    setStatus('saving')
+    if (isMountedRef.current) setStatus('saving')
 
     try {
       await saveFnRef.current(snapshot, controller.signal)
       if (controller.signal.aborted) return
       if (fireId !== latestFireIdRef.current) return
       lastSavedSnapshotRef.current = snapshot
-      setLastSavedAt(new Date())
-      setStatus('saved')
+      if (isMountedRef.current) {
+        setLastSavedAt(new Date())
+        setStatus('saved')
+      }
     } catch (err) {
       if (controller.signal.aborted) return
       if (fireId !== latestFireIdRef.current) return
       const redirected = handleSessionError(err, logoutRef.current, navigateRef.current)
-      if (!redirected) {
+      if (!redirected && isMountedRef.current) {
         setStatus('error')
       }
     }
@@ -125,10 +129,14 @@ export const useAutosave = <T extends { dirty: boolean }>(
 
   useEffect(() => {
     return () => {
+      isMountedRef.current = false
+      abortRef.current?.abort()
       if (pendingRef.current) {
         clearTimer()
         pendingRef.current = false
-        void saveFnRef.current(stateRef.current, new AbortController().signal)
+        // fire-and-forget: hook is unmounting, no state to update or redirect to dispatch
+        const flushController = new AbortController()
+        void saveFnRef.current(stateRef.current, flushController.signal)
       } else {
         clearTimer()
       }

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -51,7 +51,6 @@ export const useAutosave = <T extends { dirty: boolean }>(
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const abortRef = useRef<AbortController | null>(null)
   const pendingRef = useRef(false)
-  const latestFireIdRef = useRef(0)
   const isMountedRef = useRef(true)
 
   stateRef.current = state
@@ -72,14 +71,12 @@ export const useAutosave = <T extends { dirty: boolean }>(
     }
     const controller = new AbortController()
     abortRef.current = controller
-    const fireId = ++latestFireIdRef.current
 
     if (isMountedRef.current) setStatus('saving')
 
     try {
       await saveFnRef.current(snapshot, controller.signal)
       if (controller.signal.aborted) return
-      if (fireId !== latestFireIdRef.current) return
       lastSavedSnapshotRef.current = snapshot
       if (isMountedRef.current) {
         setLastSavedAt(new Date())
@@ -87,7 +84,6 @@ export const useAutosave = <T extends { dirty: boolean }>(
       }
     } catch (err) {
       if (controller.signal.aborted) return
-      if (fireId !== latestFireIdRef.current) return
       const redirected = handleSessionError(err, logoutRef.current, navigateRef.current)
       if (!redirected && isMountedRef.current) {
         setStatus('error')

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,8 @@
 import '@testing-library/jest-dom'
+import { configure } from '@testing-library/react'
 import { vi } from 'vitest'
+
+configure({ asyncUtilTimeout: 5000 })
 
 export class MockIntersectionObserver {
   observe: ReturnType<typeof vi.fn>

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,8 +1,5 @@
 import '@testing-library/jest-dom'
-import { configure } from '@testing-library/react'
 import { vi } from 'vitest'
-
-configure({ asyncUtilTimeout: 5000 })
 
 export class MockIntersectionObserver {
   observe: ReturnType<typeof vi.fn>


### PR DESCRIPTION
Closes #148

## What changed
New `useAutosave` hook at `src/hooks/useAutosave.ts` used by `RecipeEditor` in #153.

**Hook contract:**
```ts
useAutosave<T extends { dirty: boolean }>(
  state: T,
  saveFn: (state: T, signal: AbortSignal) => Promise<void>,
  options?: { intervalMs?: number }
): { status: 'idle' | 'saving' | 'saved' | 'error', lastSavedAt: Date | null, retry: () => void }
```

**Behaviour:**
- Default 2s debounce on dirty changes; multiple changes within the window collapse to one trailing call.
- New fire aborts the previous `AbortController`; late-resolving aborted saves can't clobber state (`signal.aborted` guard on both resolve and reject paths).
- Stale-closure guard via refs updated every render — the debounced callback always reads the latest state, not the snapshot at debounce start.
- `visibilitychange → hidden` flushes pending saves immediately.
- Unmount flush fires the pending save through a fresh `AbortController` (fire-and-forget) and aborts any in-flight save; `isMountedRef` guards prevent setState-on-unmount warnings.
- Skips `saveFn` when `dirty === false` or when the dirty state's diff against the last-saved snapshot is empty (JSON.stringify compare on state minus `dirty`).
- 401 from `saveFn` → `handleSessionError(err, logout, navigate)` from `@api/auth`; on successful redirect, status stays in its prior state rather than flipping to `error`.
- `retry` function re-invokes `saveFn` with the current state regardless of dirty/diff.

**Tests (13 new, 506 total):** split per PRD guidance:
- **State machine** describe (7 tests, no fake timers): transitions, retry, abort-on-update, skip-on-pristine, skip-on-empty-diff.
- **Debounce timing + lifecycle** describe (5 tests, fake timers): 2s debounce boundary, trailing collapse, stale-closure guard, visibilitychange flush, unmount flush.
- **401 handling** describe (1 test): asserts `handleSessionError` is invoked with `logout` from `useAuth()` and `navigate` from `useNavigate()`.

## Why
Foundation for autosave in the admin recipe editor (#153). Extracted as a standalone hook so the editor stays focused on reducer + presentation, while the hook owns debounce timing, abort safety, and session-expiry redirect.

## How to verify
- `pnpm test` — 506/506 pass.
- `pnpm lint` — exit 0 (5 pre-existing `react-refresh` warnings unrelated).
- Inspect `src/hooks/useAutosave.ts` for the state machine, refs, and three lifecycle effects (ref sync, visibilitychange, unmount).

## Decisions made
- **Refs over closures for `logout`/`navigate`**: keeps `runSave` stable (empty-deps `useCallback`) so the visibility listener effect doesn't re-register on every auth tick. Trade-off: slightly more refs, but the stability guarantee matters.
- **`JSON.stringify` equality**: pragmatic; assumes stable key ordering in the reducer's shape (commented at the helper). Swap for a stable serializer if a future refactor spreads props in variable order.
- **Scoped waitFor timeout**: `configure({ asyncUtilTimeout: 5000 })` in `beforeAll`/`afterAll` at the useAutosave test file scope (not globally) so the 2s real-timer debounce tests don't race the default 1s waitFor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)