### PR TITLE
Build AutosaveStatus component

### DIFF
--- a/src/components/AutosaveStatus/AutosaveStatus.module.css
+++ b/src/components/AutosaveStatus/AutosaveStatus.module.css
@@ -33,8 +33,11 @@
   background-color: var(--color-error);
 }
 
-.iconIdle {
-  background-color: var(--color-text-muted);
+.liveRegion {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-2);
 }
 
 .text {
@@ -43,8 +46,8 @@
 }
 
 .relativeTime {
-  /* Inherits from .text; separate class kept so the TSX can target the
-     aria-live="off" wrapper without extra visual treatment. */
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 
 .retryButton {

--- a/src/components/AutosaveStatus/AutosaveStatus.module.css
+++ b/src/components/AutosaveStatus/AutosaveStatus.module.css
@@ -1,5 +1,3 @@
-/* AutosaveStatus component styles */
-
 .container {
   display: inline-flex;
   flex-direction: row;

--- a/src/components/AutosaveStatus/AutosaveStatus.module.css
+++ b/src/components/AutosaveStatus/AutosaveStatus.module.css
@@ -1,0 +1,86 @@
+/* AutosaveStatus component styles */
+
+.container {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  color: var(--color-text);
+}
+
+.icon {
+  display: inline-block;
+  flex-shrink: 0;
+  inline-size: 0.5rem;
+  block-size: 0.5rem;
+  border-radius: var(--radius-none);
+  background-color: var(--color-text-muted);
+}
+
+.iconSaving {
+  background-color: var(--color-text-muted);
+  animation: autosaveStatusPulse 1.2s ease-in-out infinite;
+}
+
+.iconSaved {
+  background-color: var(--color-success);
+}
+
+.iconError {
+  background-color: var(--color-error);
+}
+
+.iconIdle {
+  background-color: var(--color-text-muted);
+}
+
+.text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
+.relativeTime {
+  /* Inherits from .text; separate class kept so the TSX can target the
+     aria-live="off" wrapper without extra visual treatment. */
+}
+
+.retryButton {
+  padding: 0;
+  font: inherit;
+  color: var(--color-primary);
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-none);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.retryButton:hover {
+  color: var(--color-primary-hover);
+}
+
+.retryButton:focus-visible {
+  outline: var(--border-width) solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+@keyframes autosaveStatusPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .iconSaving {
+    animation: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/components/AutosaveStatus/AutosaveStatus.test.tsx
+++ b/src/components/AutosaveStatus/AutosaveStatus.test.tsx
@@ -1,0 +1,221 @@
+import AutosaveStatus from '@components/AutosaveStatus'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+
+const FIXED_NOW = new Date('2026-04-19T12:00:00.000Z')
+
+describe('AutosaveStatus', () => {
+  const noop = (): void => {}
+
+  describe('idle state', () => {
+    it('renders no visible text in idle state', () => {
+      const { container } = render(
+        <AutosaveStatus status="idle" lastSavedAt={null} onRetry={noop} />
+      )
+
+      expect(container.textContent ?? '').toBe('')
+    })
+  })
+
+  describe('saving state', () => {
+    it('renders the "Saving…" text', () => {
+      render(<AutosaveStatus status="saving" lastSavedAt={null} onRetry={noop} />)
+
+      expect(screen.getByText(/saving…/i)).toBeInTheDocument()
+    })
+
+    it('renders an icon marker alongside the text', () => {
+      const { container } = render(
+        <AutosaveStatus status="saving" lastSavedAt={null} onRetry={noop} />
+      )
+
+      const icon = container.querySelector('[aria-hidden="true"]')
+
+      expect(icon).not.toBeNull()
+    })
+  })
+
+  describe('saved state — relative time', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(FIXED_NOW)
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('renders "Saved · just now" when saved less than a minute ago', () => {
+      const lastSavedAt = new Date(FIXED_NOW.getTime() - 10 * 1000)
+
+      render(
+        <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
+      )
+
+      expect(screen.getByText(/saved · just now/i)).toBeInTheDocument()
+    })
+
+    it('renders "Saved · 2m ago" when saved 2 minutes ago', () => {
+      const lastSavedAt = new Date(FIXED_NOW.getTime() - 2 * 60 * 1000)
+
+      render(
+        <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
+      )
+
+      expect(screen.getByText(/saved · 2m ago/i)).toBeInTheDocument()
+    })
+
+    it('renders "Saved · 1h ago" when saved ~65 minutes ago', () => {
+      const lastSavedAt = new Date(FIXED_NOW.getTime() - 65 * 60 * 1000)
+
+      render(
+        <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
+      )
+
+      expect(screen.getByText(/saved · 1h ago/i)).toBeInTheDocument()
+    })
+
+    it('renders "Saved · 3d ago" when saved ~72 hours ago', () => {
+      const lastSavedAt = new Date(FIXED_NOW.getTime() - 72 * 60 * 60 * 1000)
+
+      render(
+        <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
+      )
+
+      expect(screen.getByText(/saved · 3d ago/i)).toBeInTheDocument()
+    })
+
+    it('renders an icon marker alongside the text', () => {
+      const lastSavedAt = new Date(FIXED_NOW.getTime() - 10 * 1000)
+
+      const { container } = render(
+        <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
+      )
+
+      const icon = container.querySelector('[aria-hidden="true"]')
+
+      expect(icon).not.toBeNull()
+    })
+  })
+
+  describe('error state', () => {
+    it('renders "Failed to save" text', () => {
+      render(<AutosaveStatus status="error" lastSavedAt={null} onRetry={noop} />)
+
+      expect(screen.getByText(/failed to save/i)).toBeInTheDocument()
+    })
+
+    it('renders a Retry button with accessible name', () => {
+      render(<AutosaveStatus status="error" lastSavedAt={null} onRetry={noop} />)
+
+      const button = screen.getByRole('button', { name: /retry/i })
+
+      expect(button).toBeInTheDocument()
+    })
+
+    it('invokes onRetry when the Retry button is clicked', () => {
+      const onRetry = vi.fn()
+
+      render(<AutosaveStatus status="error" lastSavedAt={null} onRetry={onRetry} />)
+
+      const button = screen.getByRole('button', { name: /retry/i })
+
+      fireEvent.click(button)
+
+      expect(onRetry).toHaveBeenCalledTimes(1)
+      expect(onRetry).toHaveBeenCalledWith()
+    })
+
+    it('renders an icon marker alongside the text', () => {
+      const { container } = render(
+        <AutosaveStatus status="error" lastSavedAt={null} onRetry={noop} />
+      )
+
+      const icon = container.querySelector('[aria-hidden="true"]')
+
+      expect(icon).not.toBeNull()
+    })
+  })
+
+  describe('ARIA live region', () => {
+    it('uses role="status" and aria-live="polite" on the saving state', () => {
+      render(<AutosaveStatus status="saving" lastSavedAt={null} onRetry={noop} />)
+
+      const region = screen.getByRole('status')
+
+      expect(region).toHaveAttribute('aria-live', 'polite')
+    })
+
+    it('uses role="status" and aria-live="polite" on the saved state', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(FIXED_NOW)
+      const lastSavedAt = new Date(FIXED_NOW.getTime() - 10 * 1000)
+
+      render(
+        <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
+      )
+
+      const region = screen.getByRole('status')
+
+      expect(region).toHaveAttribute('aria-live', 'polite')
+
+      vi.useRealTimers()
+    })
+
+    it('uses role="status" and aria-live="polite" on the idle state', () => {
+      render(<AutosaveStatus status="idle" lastSavedAt={null} onRetry={noop} />)
+
+      const region = screen.getByRole('status')
+
+      expect(region).toHaveAttribute('aria-live', 'polite')
+    })
+
+    it('uses aria-live="assertive" on the error state', () => {
+      render(<AutosaveStatus status="error" lastSavedAt={null} onRetry={noop} />)
+
+      const region = screen.getByRole('status')
+
+      expect(region).toHaveAttribute('aria-live', 'assertive')
+    })
+  })
+
+  describe('relative-time tick updates', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(FIXED_NOW)
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('updates the relative-time text from "just now" to "1m ago" after 60s', () => {
+      const lastSavedAt = new Date(FIXED_NOW.getTime() - 10 * 1000)
+
+      render(
+        <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
+      )
+
+      expect(screen.getByText(/saved · just now/i)).toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(60 * 1000)
+      })
+
+      expect(screen.getByText(/saved · 1m ago/i)).toBeInTheDocument()
+    })
+
+    it('wraps the relative-time text in a node whose aria-live is absent or "off" so ticks are not announced', () => {
+      const lastSavedAt = new Date(FIXED_NOW.getTime() - 10 * 1000)
+
+      render(
+        <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
+      )
+
+      const relativeTimeNode = screen.getByText(/just now/i)
+      const ariaLive = relativeTimeNode.getAttribute('aria-live')
+
+      // Acceptable: absent, or explicitly "off"
+      expect(ariaLive === null || ariaLive === 'off').toBe(true)
+    })
+  })
+})

--- a/src/components/AutosaveStatus/AutosaveStatus.test.tsx
+++ b/src/components/AutosaveStatus/AutosaveStatus.test.tsx
@@ -44,44 +44,56 @@ describe('AutosaveStatus', () => {
       vi.useRealTimers()
     })
 
-    it('renders "Saved · just now" when saved less than a minute ago', () => {
+    it('renders "Saved" and "· just now" when saved less than a minute ago', () => {
       const lastSavedAt = new Date(FIXED_NOW.getTime() - 10 * 1000)
 
-      render(
+      const { container } = render(
         <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
       )
 
-      expect(screen.getByText(/saved · just now/i)).toBeInTheDocument()
+      const text = (container.textContent ?? '').toLowerCase()
+
+      expect(text).toContain('saved')
+      expect(text).toContain('just now')
     })
 
-    it('renders "Saved · 2m ago" when saved 2 minutes ago', () => {
+    it('renders "Saved" and "· 2m ago" when saved 2 minutes ago', () => {
       const lastSavedAt = new Date(FIXED_NOW.getTime() - 2 * 60 * 1000)
 
-      render(
+      const { container } = render(
         <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
       )
 
-      expect(screen.getByText(/saved · 2m ago/i)).toBeInTheDocument()
+      const text = (container.textContent ?? '').toLowerCase()
+
+      expect(text).toContain('saved')
+      expect(text).toContain('2m ago')
     })
 
-    it('renders "Saved · 1h ago" when saved ~65 minutes ago', () => {
+    it('renders "Saved" and "· 1h ago" when saved ~65 minutes ago', () => {
       const lastSavedAt = new Date(FIXED_NOW.getTime() - 65 * 60 * 1000)
 
-      render(
+      const { container } = render(
         <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
       )
 
-      expect(screen.getByText(/saved · 1h ago/i)).toBeInTheDocument()
+      const text = (container.textContent ?? '').toLowerCase()
+
+      expect(text).toContain('saved')
+      expect(text).toContain('1h ago')
     })
 
-    it('renders "Saved · 3d ago" when saved ~72 hours ago', () => {
+    it('renders "Saved" and "· 3d ago" when saved ~72 hours ago', () => {
       const lastSavedAt = new Date(FIXED_NOW.getTime() - 72 * 60 * 60 * 1000)
 
-      render(
+      const { container } = render(
         <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
       )
 
-      expect(screen.getByText(/saved · 3d ago/i)).toBeInTheDocument()
+      const text = (container.textContent ?? '').toLowerCase()
+
+      expect(text).toContain('saved')
+      expect(text).toContain('3d ago')
     })
 
     it('renders an icon marker alongside the text', () => {
@@ -91,7 +103,8 @@ describe('AutosaveStatus', () => {
         <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
       )
 
-      const icon = container.querySelector('[aria-hidden="true"]')
+      const liveRegion = container.querySelector('[role="status"]')
+      const icon = liveRegion?.querySelector('[aria-hidden="true"]')
 
       expect(icon).not.toBeNull()
     })
@@ -130,7 +143,8 @@ describe('AutosaveStatus', () => {
         <AutosaveStatus status="error" lastSavedAt={null} onRetry={noop} />
       )
 
-      const icon = container.querySelector('[aria-hidden="true"]')
+      const liveRegion = container.querySelector('[role="status"]')
+      const icon = liveRegion?.querySelector('[aria-hidden="true"]')
 
       expect(icon).not.toBeNull()
     })
@@ -191,31 +205,32 @@ describe('AutosaveStatus', () => {
     it('updates the relative-time text from "just now" to "1m ago" after 60s', () => {
       const lastSavedAt = new Date(FIXED_NOW.getTime() - 10 * 1000)
 
-      render(
+      const { container } = render(
         <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
       )
 
-      expect(screen.getByText(/saved · just now/i)).toBeInTheDocument()
+      expect((container.textContent ?? '').toLowerCase()).toContain('just now')
 
       act(() => {
         vi.advanceTimersByTime(60 * 1000)
       })
 
-      expect(screen.getByText(/saved · 1m ago/i)).toBeInTheDocument()
+      expect((container.textContent ?? '').toLowerCase()).toContain('1m ago')
     })
 
-    it('wraps the relative-time text in a node whose aria-live is absent or "off" so ticks are not announced', () => {
+    it('places the relative-time outside the live region and marks it aria-hidden so screen readers skip it', () => {
       const lastSavedAt = new Date(FIXED_NOW.getTime() - 10 * 1000)
 
-      render(
+      const { container } = render(
         <AutosaveStatus status="saved" lastSavedAt={lastSavedAt} onRetry={noop} />
       )
 
+      const liveRegion = container.querySelector('[role="status"]')
       const relativeTimeNode = screen.getByText(/just now/i)
-      const ariaLive = relativeTimeNode.getAttribute('aria-live')
 
-      // Acceptable: absent, or explicitly "off"
-      expect(ariaLive === null || ariaLive === 'off').toBe(true)
+      expect(liveRegion).not.toBeNull()
+      expect(relativeTimeNode).toHaveAttribute('aria-hidden', 'true')
+      expect(liveRegion?.contains(relativeTimeNode)).toBe(false)
     })
   })
 })

--- a/src/components/AutosaveStatus/AutosaveStatus.tsx
+++ b/src/components/AutosaveStatus/AutosaveStatus.tsx
@@ -1,0 +1,13 @@
+import type { FC } from 'react'
+
+export interface AutosaveStatusProps {
+  status: 'idle' | 'saving' | 'saved' | 'error'
+  lastSavedAt: Date | null
+  onRetry: () => void
+}
+
+const AutosaveStatus: FC<AutosaveStatusProps> = () => {
+  throw new Error('AutosaveStatus: not implemented')
+}
+
+export default AutosaveStatus

--- a/src/components/AutosaveStatus/AutosaveStatus.tsx
+++ b/src/components/AutosaveStatus/AutosaveStatus.tsx
@@ -1,4 +1,4 @@
-import type { FC, JSX } from 'react'
+import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import styles from './AutosaveStatus.module.css'
 
@@ -22,6 +22,20 @@ const formatRelativeTime = (date: Date, now: Date): string => {
 const cx = (...classNames: Array<string | false | undefined>): string =>
   classNames.filter(Boolean).join(' ')
 
+const TRANSITION_TEXT: Record<AutosaveStatusProps['status'], string> = {
+  idle: '',
+  saving: 'Saving…',
+  saved: 'Saved',
+  error: 'Failed to save',
+}
+
+const ICON_CLASS: Record<AutosaveStatusProps['status'], string | undefined> = {
+  idle: undefined,
+  saving: styles.iconSaving,
+  saved: styles.iconSaved,
+  error: styles.iconError,
+}
+
 const AutosaveStatus: FC<AutosaveStatusProps> = ({ status, lastSavedAt, onRetry }) => {
   const [now, setNow] = useState<number>(() => Date.now())
 
@@ -38,41 +52,32 @@ const AutosaveStatus: FC<AutosaveStatusProps> = ({ status, lastSavedAt, onRetry 
   }, [status, lastSavedAt])
 
   const ariaLive = status === 'error' ? 'assertive' : 'polite'
-
-  const renderIcon = (stateClass: string): JSX.Element => (
-    <span aria-hidden="true" className={cx(styles.icon, stateClass)} />
-  )
+  const transitionText = TRANSITION_TEXT[status]
+  const iconClass = ICON_CLASS[status]
 
   return (
-    <span role="status" aria-live={ariaLive} className={styles.container}>
-      {status === 'saving' && (
-        <>
-          {renderIcon(styles.iconSaving)}
-          <span className={styles.text}>Saving…</span>
-        </>
-      )}
+    <span className={styles.container}>
+      <span role="status" aria-live={ariaLive} className={styles.liveRegion}>
+        {status !== 'idle' && (
+          <>
+            <span aria-hidden="true" className={cx(styles.icon, iconClass)} />
+            <span className={styles.text}>{transitionText}</span>
+          </>
+        )}
+      </span>
       {status === 'saved' && lastSavedAt !== null && (
-        <>
-          {renderIcon(styles.iconSaved)}
-          <span aria-live="off" className={cx(styles.text, styles.relativeTime)}>
-            {`Saved · ${formatRelativeTime(lastSavedAt, new Date(now))}`}
-          </span>
-        </>
+        <span aria-hidden="true" className={styles.relativeTime}>
+          {`· ${formatRelativeTime(lastSavedAt, new Date(now))}`}
+        </span>
       )}
       {status === 'error' && (
-        <>
-          {renderIcon(styles.iconError)}
-          <span className={styles.text}>
-            Failed to save ·{' '}
-            <button
-              type="button"
-              className={styles.retryButton}
-              onClick={() => { onRetry() }}
-            >
-              Retry
-            </button>
-          </span>
-        </>
+        <button
+          type="button"
+          className={styles.retryButton}
+          onClick={() => { onRetry() }}
+        >
+          Retry
+        </button>
       )}
     </span>
   )

--- a/src/components/AutosaveStatus/AutosaveStatus.tsx
+++ b/src/components/AutosaveStatus/AutosaveStatus.tsx
@@ -1,4 +1,6 @@
-import type { FC } from 'react'
+import type { FC, JSX } from 'react'
+import { useEffect, useState } from 'react'
+import styles from './AutosaveStatus.module.css'
 
 export interface AutosaveStatusProps {
   status: 'idle' | 'saving' | 'saved' | 'error'
@@ -6,8 +8,74 @@ export interface AutosaveStatusProps {
   onRetry: () => void
 }
 
-const AutosaveStatus: FC<AutosaveStatusProps> = () => {
-  throw new Error('AutosaveStatus: not implemented')
+const MINUTE_MS = 60_000
+
+const formatRelativeTime = (date: Date, now: Date): string => {
+  const diffSeconds = Math.floor((now.getTime() - date.getTime()) / 1000)
+
+  if (diffSeconds < 60) return 'just now'
+  if (diffSeconds < 3600) return `${Math.floor(diffSeconds / 60)}m ago`
+  if (diffSeconds < 86_400) return `${Math.floor(diffSeconds / 3600)}h ago`
+  return `${Math.floor(diffSeconds / 86_400)}d ago`
+}
+
+const cx = (...classNames: Array<string | false | undefined>): string =>
+  classNames.filter(Boolean).join(' ')
+
+const AutosaveStatus: FC<AutosaveStatusProps> = ({ status, lastSavedAt, onRetry }) => {
+  const [now, setNow] = useState<number>(() => Date.now())
+
+  useEffect(() => {
+    if (status !== 'saved' || lastSavedAt === null) return
+
+    const intervalId = setInterval(() => {
+      setNow(Date.now())
+    }, MINUTE_MS)
+
+    return () => {
+      clearInterval(intervalId)
+    }
+  }, [status, lastSavedAt])
+
+  const ariaLive = status === 'error' ? 'assertive' : 'polite'
+
+  const renderIcon = (stateClass: string): JSX.Element => (
+    <span aria-hidden="true" className={cx(styles.icon, stateClass)} />
+  )
+
+  return (
+    <span role="status" aria-live={ariaLive} className={styles.container}>
+      {status === 'saving' && (
+        <>
+          {renderIcon(styles.iconSaving)}
+          <span className={styles.text}>Saving…</span>
+        </>
+      )}
+      {status === 'saved' && lastSavedAt !== null && (
+        <>
+          {renderIcon(styles.iconSaved)}
+          <span aria-live="off" className={cx(styles.text, styles.relativeTime)}>
+            {`Saved · ${formatRelativeTime(lastSavedAt, new Date(now))}`}
+          </span>
+        </>
+      )}
+      {status === 'error' && (
+        <>
+          {renderIcon(styles.iconError)}
+          <span className={styles.text}>
+            Failed to save ·{' '}
+            <button
+              type="button"
+              className={styles.retryButton}
+              onClick={() => { onRetry() }}
+            >
+              Retry
+            </button>
+          </span>
+        </>
+      )}
+    </span>
+  )
 }
 
 export default AutosaveStatus

--- a/src/components/AutosaveStatus/AutosaveStatus.tsx
+++ b/src/components/AutosaveStatus/AutosaveStatus.tsx
@@ -1,9 +1,10 @@
+import type { AutosaveStatus as AutosaveStatusValue } from '@hooks/useAutosave'
 import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import styles from './AutosaveStatus.module.css'
 
 export interface AutosaveStatusProps {
-  status: 'idle' | 'saving' | 'saved' | 'error'
+  status: AutosaveStatusValue
   lastSavedAt: Date | null
   onRetry: () => void
 }
@@ -22,14 +23,14 @@ const formatRelativeTime = (date: Date, now: Date): string => {
 const cx = (...classNames: Array<string | false | undefined>): string =>
   classNames.filter(Boolean).join(' ')
 
-const TRANSITION_TEXT: Record<AutosaveStatusProps['status'], string> = {
+const TRANSITION_TEXT: Record<AutosaveStatusValue, string> = {
   idle: '',
   saving: 'Saving…',
   saved: 'Saved',
   error: 'Failed to save',
 }
 
-const ICON_CLASS: Record<AutosaveStatusProps['status'], string | undefined> = {
+const ICON_CLASS: Record<AutosaveStatusValue, string | undefined> = {
   idle: undefined,
   saving: styles.iconSaving,
   saved: styles.iconSaved,

--- a/src/components/AutosaveStatus/index.ts
+++ b/src/components/AutosaveStatus/index.ts
@@ -1,0 +1,2 @@
+export { default } from './AutosaveStatus'
+export type { AutosaveStatusProps } from './AutosaveStatus'

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -3,12 +3,14 @@ import { useAuth } from '@contexts/AuthContext'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+export type AutosaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+
 export interface UseAutosaveOptions {
   intervalMs?: number
 }
 
 export interface UseAutosaveResult {
-  status: 'idle' | 'saving' | 'saved' | 'error'
+  status: AutosaveStatus
   lastSavedAt: Date | null
   retry: () => void
 }


### PR DESCRIPTION
Closes #149

## What changed
New `AutosaveStatus` component at `src/components/AutosaveStatus/`.

**Contract:**
```ts
interface AutosaveStatusProps {
  status: AutosaveStatus  // 'idle' | 'saving' | 'saved' | 'error' — shared with useAutosave
  lastSavedAt: Date | null
  onRetry: () => void
}
```

**States:**
- `idle` — empty `role="status"` live region (renders nothing visible; the mounted region lets subsequent transitions be announced).
- `saving` — "Saving…" + pulsing icon. Icon animation replaced with static state under `prefers-reduced-motion: reduce`.
- `saved` — "Saved" inside the live region + `· {relativeTime}` as an `aria-hidden` sibling OUTSIDE the live region, so minute ticks (`just now` → `1m ago` → `2m ago`) don't re-announce. Interval only runs while `status === 'saved'`.
- `error` — "Failed to save" + Retry button (sibling of the live region, native `<button>` with link-style CSS).

**Accessibility:**
- `role="status"` + `aria-live="polite"` default; `aria-live="assertive"` on error.
- Icon spans carry `aria-hidden="true"`; text labels are never colour-only.
- Relative-time node is `aria-hidden="true"` and sits outside the live region — screen readers skip tick updates entirely.
- Retry button exposes `role="button"` + accessible name "Retry".

**Styling:**
- `--color-success` / `--color-error` tokens (auto-flip in dark mode via the `[data-theme="dark"]` cascade).
- Square 8px icon dot (neo-brutalist — no rounded corners, `--radius-none`).
- Focus ring matches `Button` convention (`2px solid var(--color-primary)`, `outline-offset: 2px`).
- Stacks vertically under 640px to avoid colliding with editor action buttons.

**Tests (18 new, 524 total):**
- Four state renders; `vi.setSystemTime` + `vi.advanceTimersByTime(60_000)` drive the relative-time tick tests (`just now`, `Nm/h/d ago`).
- ARIA live-region attributes per state; relative-time node is outside the live region and `aria-hidden`.
- Retry button invokes `onRetry` with no args.

## Why
Visible autosave feedback in the editor header (consumed by `RecipeEditor` in #153). Paired with the `useAutosave` hook from #148 — both expose the same `AutosaveStatus` union to prevent drift.

## How to verify
- `pnpm test` — 524/524 pass.
- `pnpm lint` — exit 0 (5 pre-existing `react-refresh` warnings unrelated).
- `src/components/AutosaveStatus/` — 4 files (TSX, CSS module, index, test).

## Decisions made
- **Relative-time outside the live region**: `aria-live="off"` on a descendant of `role="status"` is fragile across NVDA/VoiceOver. Moving the ticking text out of the region entirely (as `aria-hidden`) is the robust fix — discovered during review pass, addressed before merge.
- **Shared status union**: `type AutosaveStatus` is exported from `@hooks/useAutosave` and imported here under alias `AutosaveStatusValue` (to avoid the default-component name clash).
- **Bare `<button>` for Retry**: `Button` has only `primary`/`secondary` variants, neither matches the PRD's inline link-style Retry; rolled styling into `.retryButton` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)