### PR TITLE
Extract StatusBadge component from inline RecipeList markup

### DIFF
--- a/src/components/StatusBadge/StatusBadge.module.css
+++ b/src/components/StatusBadge/StatusBadge.module.css
@@ -1,0 +1,19 @@
+.badge {
+  display: inline-block;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+}
+
+.badge[data-status='published'] {
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
+  border-color: var(--color-primary);
+}
+
+.badge[data-status='draft'] {
+  background: var(--color-bg-subtle);
+  color: var(--color-text-muted);
+}

--- a/src/components/StatusBadge/StatusBadge.test.tsx
+++ b/src/components/StatusBadge/StatusBadge.test.tsx
@@ -1,0 +1,40 @@
+import StatusBadge from '@components/StatusBadge'
+import { render, screen } from '@testing-library/react'
+
+describe('StatusBadge', () => {
+  it('renders "Draft" text when status is draft', () => {
+    render(<StatusBadge status="draft" />)
+
+    expect(screen.getByText('Draft')).toBeInTheDocument()
+  })
+
+  it('renders "Published" text when status is published', () => {
+    render(<StatusBadge status="published" />)
+
+    expect(screen.getByText('Published')).toBeInTheDocument()
+  })
+
+  it('sets data-status="draft" on the element when status is draft', () => {
+    render(<StatusBadge status="draft" />)
+
+    const badge = screen.getByText('Draft').closest('[data-status]')
+
+    expect(badge).toHaveAttribute('data-status', 'draft')
+  })
+
+  it('sets data-status="published" on the element when status is published', () => {
+    render(<StatusBadge status="published" />)
+
+    const badge = screen.getByText('Published').closest('[data-status]')
+
+    expect(badge).toHaveAttribute('data-status', 'published')
+  })
+
+  it('includes a visually-hidden "Status:" prefix for screen readers', () => {
+    render(<StatusBadge status="draft" />)
+
+    const prefix = screen.getByText('Status:', { exact: false, selector: '.sr-only' })
+
+    expect(prefix).toBeInTheDocument()
+  })
+})

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -1,0 +1,19 @@
+import type { Recipe } from '@models/recipe'
+import type { FC } from 'react'
+
+import styles from './StatusBadge.module.css'
+
+export interface StatusBadgeProps {
+  status: Recipe['status']
+}
+
+const StatusBadge: FC<StatusBadgeProps> = ({ status }) => {
+  return (
+    <span className={styles.badge} data-status={status}>
+      <span className="sr-only">Status: </span>
+      {status === 'published' ? 'Published' : 'Draft'}
+    </span>
+  )
+}
+
+export default StatusBadge

--- a/src/components/StatusBadge/index.ts
+++ b/src/components/StatusBadge/index.ts
@@ -1,0 +1,2 @@
+export { default } from './StatusBadge'
+export type { StatusBadgeProps } from './StatusBadge'

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -56,26 +56,6 @@
   background: var(--color-bg);
 }
 
-.badge {
-  display: inline-block;
-  padding: var(--space-1) var(--space-2);
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-none);
-}
-
-.badge[data-status='published'] {
-  background: var(--color-bg-subtle);
-  color: var(--color-text);
-  border-color: var(--color-primary);
-}
-
-.badge[data-status='draft'] {
-  background: var(--color-bg-subtle);
-  color: var(--color-text-muted);
-}
-
 .actionsInner {
   display: flex;
   gap: var(--space-2);

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -4,6 +4,7 @@ import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
 import Link from '@components/Link'
 import Loading from '@components/Loading'
+import StatusBadge from '@components/StatusBadge'
 import Toast, { type ToastState } from '@components/Toast'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
@@ -133,9 +134,7 @@ const RecipeList = () => {
                 <tr key={recipe.id}>
                   <td>{recipe.title}</td>
                   <td>
-                    <span className={styles.badge} data-status={recipe.status}>
-                      {recipe.status === 'published' ? 'Published' : 'Draft'}
-                    </span>
+                    <StatusBadge status={recipe.status} />
                   </td>
                   <td>{recipe.tags.join(', ')}</td>
                   <td>{new Date(recipe.updatedAt).toLocaleDateString()}</td>


### PR DESCRIPTION
Closes #150

## What changed
Pure extraction — no visual or behavioural diff.

- New `<StatusBadge>` at `src/components/StatusBadge/` (TSX + CSS module + barrel + test).
- Props: `{ status: 'draft' | 'published' }` via `Recipe['status']`.
- Adds a visually-hidden "Status: " prefix (`<span className="sr-only">`) so screen readers scanning an admin table row get context beyond the badge text — matches the sr-only pattern already used in `IngredientList` and `SocialCard`.
- CSS migrated verbatim from `RecipeList.module.css` — identical selectors, same token references (`--radius-none`, `--color-*`, `--space-*`, `--border-width`), unchanged ordering.
- `RecipeList.tsx` swaps the inline `<span className={styles.badge} data-status={...}>` for `<StatusBadge status={recipe.status} />`. The 3 `.badge*` selectors removed from `RecipeList.module.css`.

## Why
Preps for #151 (`RecipeList` fetches via `fetchAllRecipes` and renders both draft + published statuses) — having the badge as a standalone component makes the list swap trivial. Also reusable anywhere the admin surface needs status context (e.g. `RecipeEditor` header in #153).

## How to verify
- `pnpm test` — 529/529 pass (+5 new StatusBadge tests).
- `pnpm lint` — exit 0.
- Visual: admin recipe list renders identically before and after (CSS verbatim, markup equivalent).
- Screen readers: badge now announces "Status: Draft" / "Status: Published" instead of just "Draft" / "Published".

## Decisions made
- `Recipe['status']` indexed type for the prop — stays in sync with the Recipe model narrowing introduced in #147.
- sr-only uses the global `.sr-only` class (defined in `src/index.css`), matching `IngredientList` and `SocialCard` convention rather than a component-scoped CSS Module rule.
- Kept the status → label mapping as an inline ternary for two cases; a `Record` lookup would be appropriate at 3+ states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)