### PR TITLE
Update RecipeList: fetchAllRecipes, StatusBadge, sort by updatedAt

### DIFF
--- a/src/pages/admin/RecipeList/RecipeList.test.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.test.tsx
@@ -1,14 +1,14 @@
-import { deleteRecipe, fetchMyRecipes, publishRecipe, unpublishRecipe } from '@api/recipes'
+import { deleteRecipe, fetchAllRecipes, publishRecipe, unpublishRecipe } from '@api/recipes'
 import { useAuth } from '@contexts/AuthContext'
 import type { Recipe } from '@models/recipe'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import RecipeList from './RecipeList'
 
 vi.mock('@api/recipes', () => ({
-  fetchMyRecipes: vi.fn(),
+  fetchAllRecipes: vi.fn(),
   publishRecipe: vi.fn(),
   unpublishRecipe: vi.fn(),
   deleteRecipe: vi.fn(),
@@ -84,7 +84,7 @@ describe('Admin RecipeList page', () => {
       login: vi.fn(),
       logout: vi.fn(),
     })
-    vi.mocked(fetchMyRecipes).mockResolvedValue([mockDraftRecipe, mockPublishedRecipe])
+    vi.mocked(fetchAllRecipes).mockResolvedValue([mockDraftRecipe, mockPublishedRecipe])
     vi.mocked(publishRecipe).mockResolvedValue(undefined)
     vi.mocked(unpublishRecipe).mockResolvedValue(undefined)
     vi.mocked(deleteRecipe).mockResolvedValue(undefined)
@@ -196,7 +196,7 @@ describe('Admin RecipeList page', () => {
   })
 
   it('shows empty state when no recipes exist', async () => {
-    vi.mocked(fetchMyRecipes).mockResolvedValue([])
+    vi.mocked(fetchAllRecipes).mockResolvedValue([])
     renderRecipeList()
 
     await waitFor(() => {
@@ -207,14 +207,14 @@ describe('Admin RecipeList page', () => {
   })
 
   it('shows loading indicator while fetching', () => {
-    vi.mocked(fetchMyRecipes).mockReturnValue(new Promise(() => {}))
+    vi.mocked(fetchAllRecipes).mockReturnValue(new Promise(() => {}))
     renderRecipeList()
 
     expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
   })
 
   it('shows error state with retry button when fetch fails', async () => {
-    vi.mocked(fetchMyRecipes).mockRejectedValue(new Error('500 Internal Server Error'))
+    vi.mocked(fetchAllRecipes).mockRejectedValue(new Error('500 Internal Server Error'))
     renderRecipeList()
 
     await waitFor(() => {
@@ -232,5 +232,69 @@ describe('Admin RecipeList page', () => {
     const statuses = await screen.findAllByRole('status')
     const accessDeniedStatus = statuses.find((el) => /access denied/i.test(el.textContent ?? ''))
     expect(accessDeniedStatus).toBeDefined()
+  })
+
+  it('calls fetchAllRecipes (not fetchMyRecipes) to load both draft and published recipes', async () => {
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(fetchAllRecipes).toHaveBeenCalledWith('token-123')
+    })
+  })
+
+  it('renders rows sorted by updatedAt descending regardless of input order', async () => {
+    const oldest: Recipe = {
+      ...mockDraftRecipe,
+      id: 'rec-oldest',
+      title: 'Oldest',
+      updatedAt: '2026-01-01T00:00:00Z',
+      status: 'published',
+    }
+    const newest: Recipe = {
+      ...mockDraftRecipe,
+      id: 'rec-newest',
+      title: 'Newest',
+      updatedAt: '2026-04-19T00:00:00Z',
+      status: 'draft',
+    }
+    const middle: Recipe = {
+      ...mockDraftRecipe,
+      id: 'rec-middle',
+      title: 'Middle',
+      updatedAt: '2026-02-15T00:00:00Z',
+      status: 'published',
+    }
+
+    vi.mocked(fetchAllRecipes).mockResolvedValue([oldest, newest, middle])
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByText('Newest')).toBeInTheDocument()
+    })
+
+    const rows = screen.getAllByRole('row').slice(1) // skip header row
+    const titles = rows.map((row) => within(row).getAllByRole('cell')[0].textContent)
+
+    expect(titles).toEqual(['Newest', 'Middle', 'Oldest'])
+  })
+
+  it('renders a StatusBadge with matching data-status for each row in a mixed draft/published list', async () => {
+    renderRecipeList()
+
+    await waitFor(() => {
+      expect(screen.getByText('Spaghetti Bolognese')).toBeInTheDocument()
+    })
+
+    const draftRow = screen.getByText('Spaghetti Bolognese').closest('tr')
+    const publishedRow = screen.getByText('Thai Green Curry').closest('tr')
+
+    expect(draftRow).not.toBeNull()
+    expect(publishedRow).not.toBeNull()
+
+    const draftBadge = within(draftRow as HTMLElement).getByText(/draft/i)
+    const publishedBadge = within(publishedRow as HTMLElement).getByText(/^published$/i)
+
+    expect(draftBadge).toHaveAttribute('data-status', 'draft')
+    expect(publishedBadge).toHaveAttribute('data-status', 'published')
   })
 })

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -9,7 +9,7 @@ import Toast, { type ToastState } from '@components/Toast'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
 import type { Recipe } from '@models/recipe'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import styles from './RecipeList.module.css'
@@ -23,6 +23,11 @@ const RecipeList = () => {
   const [error, setError] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<Recipe | null>(null)
   const [toast, setToast] = useState<ToastState | null>(null)
+
+  const sortedRecipes = useMemo(
+    () => [...recipes].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
+    [recipes],
+  )
 
   useEffect(() => {
     const state = location.state as { accessDenied?: boolean } | null
@@ -108,10 +113,6 @@ const RecipeList = () => {
         </>
       )
     }
-
-    const sortedRecipes = [...recipes].sort(
-      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-    )
 
     return (
       <>

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -1,5 +1,5 @@
 import { handleSessionError } from '@api/auth'
-import { deleteRecipe, fetchMyRecipes, publishRecipe, unpublishRecipe } from '@api/recipes'
+import { deleteRecipe, fetchAllRecipes, publishRecipe, unpublishRecipe } from '@api/recipes'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
 import Link from '@components/Link'
@@ -38,7 +38,7 @@ const RecipeList = () => {
     setError(false)
     try {
       const token = await getAccessToken()
-      const data = await fetchMyRecipes(token)
+      const data = await fetchAllRecipes(token)
       setRecipes(data)
     } catch (err) {
       if (!handleSessionError(err, logout, navigate)) {
@@ -109,6 +109,10 @@ const RecipeList = () => {
       )
     }
 
+    const sortedRecipes = [...recipes].sort(
+      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    )
+
     return (
       <>
         <div className={styles.header}>
@@ -130,7 +134,7 @@ const RecipeList = () => {
               </tr>
             </thead>
             <tbody>
-              {recipes.map((recipe) => (
+              {sortedRecipes.map((recipe) => (
                 <tr key={recipe.id}>
                   <td>{recipe.title}</td>
                   <td>


### PR DESCRIPTION
Closes #151

## What changed
- Swapped data source: `fetchMyRecipes` → `fetchAllRecipes` in `RecipeList.tsx`. The admin list now shows both drafts and published recipes in a single pool.
- Added client-side sort by `updatedAt` desc via `useMemo` keyed on `recipes`, so actively-edited drafts bubble to the top and sibling state (delete dialog, toast, loading/error) doesn't trigger a re-sort.
- StatusBadge usage was already landed in #150 — this PR verifies the test for the mixed-status render path.
- 401 handling via `handleSessionError(err, logout, navigate)` unchanged.

## Why
Per the PRD's admin list spec: admins need drafts and published side-by-side to resume in-progress work, and freshest-edited first matches the natural workflow.

## How to verify
- `pnpm test` — 532/532 pass (+3 new tests covering `fetchAllRecipes` invocation, `updatedAt` desc sort with shuffled input, and mixed-status StatusBadge rendering).
- `pnpm lint` — exit 0.

## Decisions made
- **`useMemo`** for the sort rather than inline `[...recipes].sort(...)` in the render body — the component has several sibling states (delete dialog, toast) whose changes would otherwise re-sort unnecessarily. Flagged by the /simplify efficiency review.
- **AC "Search still filters across both statuses"** — `RecipeList` has no search UI in the current implementation; the AC is satisfied vacuously and no change was made. The PRD's "Search filters across both statuses unchanged" reads as "don't regress search behaviour", which holds.
- `fetchMyRecipes` is kept elsewhere (editor + preview pages) per the PRD's explicit scope limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)