### PR TITLE
Tighten ImageUpload recipeId prop to required string

### DIFF
--- a/src/components/ImageUpload/ImageUpload.test.tsx
+++ b/src/components/ImageUpload/ImageUpload.test.tsx
@@ -33,7 +33,7 @@ describe('ImageUpload', () => {
   })
 
   it('renders an upload area', () => {
-    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} />)
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     expect(
       screen.getByRole('button', { name: /upload/i }) || screen.getByText(/upload/i)
@@ -41,7 +41,7 @@ describe('ImageUpload', () => {
   })
 
   it('rejects files over 10MB', async () => {
-    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} />)
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     const file = new File(['x'], 'large.png', { type: 'image/png' })
     Object.defineProperty(file, 'size', { value: 11 * 1024 * 1024 })
@@ -58,7 +58,7 @@ describe('ImageUpload', () => {
   })
 
   it('rejects non-image MIME types', async () => {
-    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} />)
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     const file = new File(['x'], 'doc.pdf', { type: 'application/pdf' })
 
@@ -77,7 +77,7 @@ describe('ImageUpload', () => {
     mockGetUploadUrl.mockResolvedValue({ uploadUrl: 'https://s3.example.com/upload', key: 'img/123.jpg' })
     vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }))
 
-    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} />)
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     const file = new File(['x'], 'photo.png', { type: 'image/png' })
     Object.defineProperty(file, 'size', { value: 1024 })
@@ -97,7 +97,7 @@ describe('ImageUpload', () => {
     mockGetUploadUrl.mockResolvedValue({ uploadUrl: 'https://s3.example.com/upload', key: 'img/123.jpg' })
     vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }))
 
-    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} />)
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     const file = new File(['x'], 'photo.png', { type: 'image/png' })
     Object.defineProperty(file, 'size', { value: 1024 })
@@ -117,7 +117,7 @@ describe('ImageUpload', () => {
   it('shows error with retry on upload failure', async () => {
     mockGetUploadUrl.mockRejectedValue(new Error('Network error'))
 
-    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} />)
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     const file = new File(['x'], 'photo.png', { type: 'image/png' })
     Object.defineProperty(file, 'size', { value: 1024 })
@@ -134,7 +134,7 @@ describe('ImageUpload', () => {
   })
 
   it('has "Replace" button when currentKey is set', () => {
-    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} currentKey="img/existing.jpg" />)
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} recipeId="test-recipe-id" currentKey="img/existing.jpg" />)
 
     expect(screen.getByRole('button', { name: /replace/i })).toBeInTheDocument()
   })
@@ -142,7 +142,7 @@ describe('ImageUpload', () => {
   it('clicking the Upload button opens the file picker', async () => {
     const clickSpy = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
 
-    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} />)
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     const user = userEvent.setup()
     await user.click(screen.getByRole('button', { name: /upload/i }))
@@ -154,7 +154,7 @@ describe('ImageUpload', () => {
     const clickSpy = vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
 
     render(
-      <ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} currentKey="img/existing.jpg" />
+      <ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} recipeId="test-recipe-id" currentKey="img/existing.jpg" />
     )
 
     const user = userEvent.setup()
@@ -166,7 +166,7 @@ describe('ImageUpload', () => {
   it('clicking Retry after a failed upload re-attempts the upload', async () => {
     mockGetUploadUrl.mockRejectedValueOnce(new Error('Network error'))
 
-    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} />)
+    render(<ImageUpload onUpload={mockOnUpload} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     const file = new File(['x'], 'photo.png', { type: 'image/png' })
     Object.defineProperty(file, 'size', { value: 1024 })
@@ -192,5 +192,13 @@ describe('ImageUpload', () => {
       expect(mockGetUploadUrl).toHaveBeenCalledTimes(2)
     })
     expect(mockOnUpload).toHaveBeenCalledWith('img/123.jpg')
+  })
+
+  it('requires recipeId prop (compile-time check)', () => {
+    // @ts-expect-error — recipeId is required
+    render(<ImageUpload onUpload={vi.fn()} getToken={vi.fn()} />)
+    // The `@ts-expect-error` above is the real assertion — if recipeId ever
+    // becomes optional again, TypeScript will fail this file's compilation.
+    expect(true).toBe(true)
   })
 })

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -9,7 +9,7 @@ export interface ImageUploadProps {
   onUpload: (key: string) => void
   currentKey?: string
   getToken: () => Promise<string>
-  id?: string
+  recipeId: string
   imageType?: 'cover' | 'step'
   stepOrder?: number
 }
@@ -20,7 +20,7 @@ const ImageUpload: FC<ImageUploadProps> = ({
   onUpload,
   currentKey,
   getToken,
-  id,
+  recipeId,
   imageType = 'cover',
   stepOrder,
 }) => {
@@ -59,7 +59,7 @@ const ImageUpload: FC<ImageUploadProps> = ({
     try {
       const token = await getToken()
       const { uploadUrl, key } = await getUploadUrl(token, {
-        recipeId: id ?? '',
+        recipeId,
         imageType,
         ...(imageType === 'step' && stepOrder !== undefined ? { stepOrder } : {}),
       })

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -16,7 +16,7 @@ describe('StepList', () => {
 
   it('renders step rows with text textarea', () => {
     const onChange = vi.fn()
-    render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+    render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     const textareas = screen.getAllByRole('textbox', { name: /^step \d+ text$/i })
     expect(textareas).toHaveLength(2)
@@ -26,7 +26,7 @@ describe('StepList', () => {
 
   it('step numbers auto-update', () => {
     const onChange = vi.fn()
-    render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+    render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     expect(screen.getByText('1')).toBeInTheDocument()
     expect(screen.getByText('2')).toBeInTheDocument()
@@ -35,7 +35,7 @@ describe('StepList', () => {
   it('"Add step" button adds new row', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+    render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     const addButton = screen.getByRole('button', { name: /add step/i })
     await user.click(addButton)
@@ -49,7 +49,7 @@ describe('StepList', () => {
   it('remove button removes a row (minimum 1 enforced)', () => {
     const onChange = vi.fn()
     render(
-      <StepList steps={[makeStep(1, 'Only step')]} onChange={onChange} getToken={mockGetToken} />
+      <StepList steps={[makeStep(1, 'Only step')]} onChange={onChange} getToken={mockGetToken} recipeId="test-recipe-id" />
     )
 
     const removeButton = screen.getByRole('button', { name: /remove/i })
@@ -59,7 +59,7 @@ describe('StepList', () => {
   it('move up/down reorder and renumber steps', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
-    render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+    render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
     const moveDownButtons = screen.getAllByRole('button', { name: /move down/i })
     await user.click(moveDownButtons[0])
@@ -74,7 +74,7 @@ describe('StepList', () => {
     const user = userEvent.setup()
     const Wrapper = () => {
       const [steps, setSteps] = useState<Step[]>(twoSteps)
-      return <StepList steps={steps} onChange={setSteps} getToken={mockGetToken} />
+      return <StepList steps={steps} onChange={setSteps} getToken={mockGetToken} recipeId="test-recipe-id" />
     }
     render(<Wrapper />)
 
@@ -88,7 +88,7 @@ describe('StepList', () => {
   describe('per-step image upload (when getToken is provided)', () => {
     it('renders an image upload control and an alt-text input per step', () => {
       const onChange = vi.fn()
-      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
       const uploadButtons = screen.getAllByRole('button', { name: /^upload$/i })
       expect(uploadButtons).toHaveLength(2)
@@ -99,7 +99,7 @@ describe('StepList', () => {
 
     it('does not render the image upload control when getToken is not provided', () => {
       const onChange = vi.fn()
-      render(<StepList steps={twoSteps} onChange={onChange} />)
+      render(<StepList steps={twoSteps} onChange={onChange} recipeId="test-recipe-id" />)
 
       expect(screen.queryByRole('button', { name: /^upload$/i })).not.toBeInTheDocument()
       expect(screen.queryByLabelText('Step 1 image alt text')).not.toBeInTheDocument()
@@ -113,6 +113,7 @@ describe('StepList', () => {
           steps={[makeStep(1, 'Preheat oven')]}
           onChange={onChange}
           getToken={mockGetToken}
+          recipeId="test-recipe-id"
         />
       )
 
@@ -131,7 +132,7 @@ describe('StepList', () => {
     // the 44x44px minimum in StepList.module.css.
     it('move up buttons carry the action-button class (44x44px min)', () => {
       const onChange = vi.fn()
-      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
       const moveUpButtons = screen.getAllByRole('button', { name: /move up/i })
       moveUpButtons.forEach((button) => {
@@ -141,7 +142,7 @@ describe('StepList', () => {
 
     it('move down buttons carry the action-button class (44x44px min)', () => {
       const onChange = vi.fn()
-      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
       const moveDownButtons = screen.getAllByRole('button', { name: /move down/i })
       moveDownButtons.forEach((button) => {
@@ -151,7 +152,7 @@ describe('StepList', () => {
 
     it('remove buttons carry the action-button class (44x44px min)', () => {
       const onChange = vi.fn()
-      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} />)
+      render(<StepList steps={twoSteps} onChange={onChange} getToken={mockGetToken} recipeId="test-recipe-id" />)
 
       const removeButtons = screen.getAllByRole('button', { name: /remove step/i })
       removeButtons.forEach((button) => {

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -9,7 +9,7 @@ import styles from './StepList.module.css'
 export interface StepListProps {
   steps: Step[]
   onChange: (steps: Step[]) => void
-  recipeId?: string
+  recipeId: string
   getToken?: () => Promise<string>
   onAnnounce?: (message: string) => void
 }
@@ -71,7 +71,7 @@ const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken, onAn
             {getToken && (
               <div className={styles.imageBlock}>
                 <ImageUpload
-                  id={recipeId}
+                  recipeId={recipeId}
                   imageType="step"
                   stepOrder={index + 1}
                   currentKey={step.image?.key}

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -100,8 +100,7 @@ vi.mock('@hooks/useAutosave', async (importOriginal) => {
 // (and trigger onUpload without a real file input).
 interface ImageUploadStubProps {
   onUpload: (key: string) => void
-  recipeId?: string
-  id?: string
+  recipeId: string
   imageType?: 'cover' | 'step'
 }
 
@@ -109,13 +108,11 @@ vi.mock('@components/ImageUpload', () => ({
   default: ({
     onUpload,
     recipeId,
-    id,
     imageType = 'cover',
   }: ImageUploadStubProps) => {
-    const passedId = recipeId ?? id ?? ''
     return (
       <div>
-        <span data-testid={`image-upload-recipe-id-${imageType}`}>{passedId}</span>
+        <span data-testid={`image-upload-recipe-id-${imageType}`}>{recipeId}</span>
         <button type="button" onClick={() => onUpload(`recipes/test/${imageType}-stub`)}>
           Simulate upload {imageType} image
         </button>

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -428,12 +428,14 @@ const RecipeEditor: FC = () => {
 
         <div className={styles.section}>
           <div className={styles.field}>
-            <ImageUpload
-              onUpload={setCoverImageKey}
-              currentKey={form.coverImageKey || undefined}
-              getToken={getAccessToken}
-              id={recipeId}
-            />
+            {recipeId && (
+              <ImageUpload
+                onUpload={setCoverImageKey}
+                currentKey={form.coverImageKey || undefined}
+                getToken={getAccessToken}
+                recipeId={recipeId}
+              />
+            )}
           </div>
 
           <div className={styles.field}>
@@ -505,13 +507,15 @@ const RecipeEditor: FC = () => {
         </div>
 
         <div className={styles.section}>
-          <StepList
-            steps={form.steps}
-            onChange={setSteps}
-            recipeId={recipeId}
-            getToken={getAccessToken}
-            onAnnounce={announce}
-          />
+          {recipeId && (
+            <StepList
+              steps={form.steps}
+              onChange={setSteps}
+              recipeId={recipeId}
+              getToken={getAccessToken}
+              onAnnounce={announce}
+            />
+          )}
         </div>
 
         <div className={styles.actions}>


### PR DESCRIPTION
Closes #152

## What changed
- `ImageUpload.tsx` — `id?: string` → `recipeId: string` (renamed + required). Removed the `id ?? ''` fallback that was the original bug motivating the whole milestone (empty string as recipeId meant image uploads silently failed for new recipes).
- `StepList.tsx` — `recipeId?: string` → `recipeId: string` (required). Single consumer (`RecipeEditor`) already passes a defined value.
- `RecipeEditor.tsx` — wrapped both `<ImageUpload>` and `<StepList>` renders in `{recipeId && (...)}`. The computed `recipeId = form.id || routeId` is still `string | undefined` until the editor has loaded, and this guard narrows it honestly — if neither is set, the upload UI simply doesn't render (the rest of the form remains usable).
- Call sites updated from `id={recipeId}` → `recipeId={recipeId}`.
- Test renders updated across `ImageUpload.test.tsx` (10), `StepList.test.tsx` (9), and a few `RecipeEditor.test.tsx` mock helpers to pass the now-required prop.
- New `@ts-expect-error` compile-time test in `ImageUpload.test.tsx` asserts that omitting `recipeId` fails typecheck.

## Why
The draft-on-mount flow from #153 guarantees `recipeId` is populated by the time the editor renders its upload UI — the old optional-prop signature advertised a contract the component couldn't fulfil (an empty string upload path). Closing the loop at the type level ensures the bug can't recur.

## How to verify
- `pnpm test` — 547/547 (+1 new ts-expect-error compile-time test).
- `pnpm lint` — exit 0.
- `grep "id ?? ''" src` — no hits.
- `grep "recipeId=" src/pages/admin/RecipeEditor src/components/StepList src/components/ImageUpload` — every call site uses the new prop name.

## Decisions made
- **Option A (conditional render) over non-null assertion**: a `recipeId={recipeId!}` would have been shorter, but the `{recipeId && ...}` guard is honest — no recipeId means no upload UI, which matches user expectation (the form itself still renders).
- **Rename to `recipeId`** rather than keeping `id`: matches the PRD phrasing and the issue AC verbatim. The name `id` was ambiguous (HTML `id`? recipe id?); `recipeId` is unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)