### PR TITLE
Manual QA and refinements

### DIFF
--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -47,6 +47,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
             <input
               type="text"
               aria-label={`Ingredient ${index + 1} quantity`}
+              placeholder="Qty"
               value={ingredient.quantity}
               onChange={(e) => handleFieldChange(index, 'quantity', e.target.value)}
               className={[styles.input, styles.quantityInput].join(' ')}
@@ -57,6 +58,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
             <input
               type="text"
               aria-label={`Ingredient ${index + 1} unit`}
+              placeholder="Unit"
               value={ingredient.unit}
               onChange={(e) => handleFieldChange(index, 'unit', e.target.value)}
               className={[styles.input, styles.unitInput].join(' ')}
@@ -67,6 +69,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
             <input
               type="text"
               aria-label={`Ingredient ${index + 1} item`}
+              placeholder="Ingredient"
               value={ingredient.item}
               onChange={(e) => handleFieldChange(index, 'item', e.target.value)}
               className={[styles.input, styles.itemInput].join(' ')}

--- a/src/components/StepList/StepList.module.css
+++ b/src/components/StepList/StepList.module.css
@@ -69,7 +69,7 @@
   font-size: var(--font-size-base);
   font-family: var(--font-sans);
   resize: vertical;
-  min-height: 4rem;
+  min-height: 8rem;
 }
 
 .textarea:focus-visible {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -101,13 +101,6 @@
   font-size: var(--font-size-sm);
 }
 
-.missingFields {
-  padding: var(--space-4);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-none);
-  background: var(--color-surface);
-}
-
 .missingFieldsList {
   margin: var(--space-2) 0 0;
   padding-left: var(--space-6);

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -91,8 +91,14 @@
 
 .header {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
   margin-bottom: var(--space-4);
+}
+
+.backLink {
+  font-size: var(--font-size-sm);
 }
 
 .missingFields {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -783,7 +783,7 @@ describe('RecipeEditor page', () => {
 
       const router = createMemoryRouter(
         [
-          { path: '/admin/recipes/rec-001/edit', element: <EditorWithBackLink /> },
+          { path: '/admin/recipes/:id/edit', element: <EditorWithBackLink /> },
           { path: '/admin/recipes', element: <div>Recipe list page</div> },
         ],
         { initialEntries: ['/admin/recipes/rec-001/edit'] }

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -394,6 +394,9 @@ const RecipeEditor: FC = () => {
       )}
 
       <div className={styles.header}>
+        <Link to="/admin/recipes" className={styles.backLink}>
+          ← Back to recipes
+        </Link>
         <AutosaveStatus
           status={autosaveStatus}
           lastSavedAt={lastSavedAt}

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -150,22 +150,14 @@ const draftFromCreated = (id: string, slug: string): Recipe => ({
   status: 'draft',
 })
 
-const EDIT_PATH_PATTERN = /^\/admin\/recipes\/([^/]+)\/edit\/?$/
 const NEW_PATH = '/admin/recipes/new'
 
-const deriveRouteId = (pathname: string, paramId: string | undefined): string | undefined => {
-  if (paramId) return paramId
-  const match = pathname.match(EDIT_PATH_PATTERN)
-  return match ? match[1] : undefined
-}
-
 const RecipeEditor: FC = () => {
-  const { id: paramId } = useParams<{ id: string }>()
+  const { id: routeId } = useParams<{ id: string }>()
   const { getAccessToken } = useAuth()
   const location = useLocation()
   const navigate = useNavigate()
 
-  const routeId = deriveRouteId(location.pathname, paramId)
   const isNewPath = location.pathname === NEW_PATH
 
   const [form, dispatch] = useReducer(formReducer, initialFormState)

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -10,6 +10,7 @@ import {
 } from '@api/recipes'
 import AutosaveStatus from '@components/AutosaveStatus'
 import Button from '@components/Button'
+import Callout from '@components/Callout'
 import ConfirmDialog from '@components/ConfirmDialog'
 import ImageUpload from '@components/ImageUpload'
 import IngredientList from '@components/IngredientList'
@@ -563,7 +564,7 @@ const RecipeEditor: FC = () => {
         </div>
 
         {form.mode === 'draft' && !canPublish && (
-          <div className={styles.missingFields}>
+          <Callout type="warning">
             <p id={`${MISSING_FIELDS_ID}-label`}>Add the following before publishing:</p>
             <ul
               id={MISSING_FIELDS_ID}
@@ -574,7 +575,7 @@ const RecipeEditor: FC = () => {
                 <li key={field}>{field}</li>
               ))}
             </ul>
-          </div>
+          </Callout>
         )}
       </form>
 

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -72,22 +72,26 @@ const initialFormState: FormState = {
   dirty: false,
 }
 
-const recipeToFormState = (recipe: Recipe): FormState => ({
-  id: recipe.id,
-  slug: recipe.slug,
-  title: recipe.title,
-  intro: recipe.intro,
-  prepTime: recipe.prepTime,
-  cookTime: recipe.cookTime,
-  servings: recipe.servings,
-  tags: recipe.tags,
-  ingredients: recipe.ingredients.length > 0 ? recipe.ingredients : [{ item: '', quantity: '', unit: '' }],
-  steps: recipe.steps.length > 0 ? recipe.steps : [{ order: 1, text: '' }],
-  coverImageKey: recipe.coverImage.key,
-  coverImageAlt: recipe.coverImage.alt,
-  mode: recipe.status,
-  dirty: false,
-})
+const recipeToFormState = (recipe: Recipe): FormState => {
+  const ingredients = recipe.ingredients ?? []
+  const steps = recipe.steps ?? []
+  return {
+    id: recipe.id,
+    slug: recipe.slug,
+    title: recipe.title ?? '',
+    intro: recipe.intro ?? '',
+    prepTime: recipe.prepTime,
+    cookTime: recipe.cookTime,
+    servings: recipe.servings,
+    tags: recipe.tags ?? [],
+    ingredients: ingredients.length > 0 ? ingredients : [{ item: '', quantity: '', unit: '' }],
+    steps: steps.length > 0 ? steps : [{ order: 1, text: '' }],
+    coverImageKey: recipe.coverImage?.key ?? '',
+    coverImageAlt: recipe.coverImage?.alt ?? '',
+    mode: recipe.status,
+    dirty: false,
+  }
+}
 
 const formReducer = (state: FormState, action: FormAction): FormState => {
   switch (action.type) {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -2,7 +2,7 @@ import { isSessionError } from '@api/auth'
 import {
   createDraft,
   deleteRecipe,
-  fetchAllRecipes,
+  fetchMyRecipes,
   fetchTags,
   publishRecipe,
   unpublishRecipe,
@@ -254,7 +254,7 @@ const RecipeEditor: FC = () => {
         handleError(err)
       }
       try {
-        const recipes = await fetchAllRecipes(token)
+        const recipes = await fetchMyRecipes(token)
         const recipe = recipes.find((r) => r.id === routeId)
         if (!recipe) throw new Error('Recipe not found')
         dispatch({ type: 'LOAD_RECIPE', recipe })


### PR DESCRIPTION
Closes #154

## What changed
Final Manual QA pass for the Draft Recipes — Frontend milestone. Fixes found while exercising the feature end-to-end, plus a /simplify cleanup across the whole epic.

**Bug fixes (uncovered during QA):**
- `RecipeEditor` crashed with "Cannot read properties of undefined (reading 'length')" when loading a draft. `recipeToFormState` now falls back with `?? []` / `?? { key: '', alt: '' }` / `?? ''` for every nested field that the backend may omit on a fresh draft.
- Editing a recipe and re-opening it only restored title / prep / cook / servings / tags. Root cause: the editor's load path was using `fetchAllRecipes` (which returns a lightweight list projection deliberately omitting `intro`, `ingredients`, `steps`) — reverted to `fetchMyRecipes` which returns full recipes. A new `/recipes/admin/:id` endpoint is flagged as a follow-up for the "admin edits any author's recipe" case.

**UX refinements:**
- Ingredient-row inputs now have `Qty` / `Unit` / `Ingredient` placeholders so sighted users can distinguish the three compact fields (sr-only labels remain for screen readers).
- "← Back to recipes" link in the editor header, left-aligned next to the right-aligned `AutosaveStatus`. Goes through the project's `<Link>` so `useBlocker(form.dirty)` still prompts on unsaved changes.
- Missing-fields warning under the Publish button now uses the existing `<Callout type="warning">` for a consistent visual. `aria-describedby` wiring preserved.
- StepList textarea default `min-height` raised from 4rem → 8rem for multi-sentence instructions.

**Full-epic /simplify cleanup:**
- Removed `deriveRouteId` + `EDIT_PATH_PATTERN` in `RecipeEditor.tsx` — a defensive pathname-regex fallback that existed only to prop up one test using a literal route. Fixed that test to use the proper `:id/edit` pattern; `routeId` now comes straight from `useParams<{id: string}>()`.

**/simplify findings deferred to a follow-up quality issue:**
- Extract a shared `cx(...classes)` helper — duplicated across `AutosaveStatus`, `Button`, `Link`, `ThemeToggle`.
- Extract a shared `apiFetch<T>` helper — the `fetch → check ok → throw → json` pattern repeats 17 times across `recipes.ts` / `auth.ts` / `users.ts`.
Both touch files outside this milestone, so keeping them for a dedicated cleanup issue.

## Why
Manual QA is the last milestone gate. Bugs found here are the ones that make it past unit tests; refinements here are the "looks right in a real browser" polish pass.

## How to verify
- `pnpm test` — 547/547 pass (no test regressions from the QA fixes).
- `pnpm lint` — exit 0.
- Run `pnpm dev`, exercise the checklist from the issue body (new draft, autosave transitions, publish/unpublish in place, discard, list sort, dark mode, mobile stacking). All green from my pass.

## Follow-ups (for later, not blocking merge)
- **Infra**: new `GET /recipes/admin/:id` endpoint returning full fields for admin editing of any author's recipe (unblocks the theoretical "admin edits another author's draft" case).
- **Infra**: parameterise S3 CORS origins via CDK context so local dev can PUT without baking `localhost` into production IaC.
- **Quality**: extract shared `cx` and `apiFetch` helpers (/simplify findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)