### PR TITLE
fix(auth): resolve hydration mismatch on admin routes

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -49,6 +49,7 @@ export const getCurrentSession = (): {
   refreshToken: string
   idToken: string
 } | null => {
+  if (typeof window === 'undefined') return null
   const accessToken = localStorage.getItem('accessToken')
   const refreshToken = localStorage.getItem('refreshToken')
   const idToken = localStorage.getItem('idToken')

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import * as authApi from '@api/auth'
 import type { AuthResult, AuthTokens, User } from '@models/auth'
-import { createContext, useCallback, useContext, useMemo, useState, type FC, type ReactNode } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type FC, type ReactNode } from 'react'
 
 export interface AuthContextValue {
   user: User | null
@@ -48,23 +48,25 @@ export const AuthContext = createContext<AuthContextValue>({
 export const useAuth = () => useContext(AuthContext)
 
 export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
-  const initSession = (): { user: User | null; isAuthenticated: boolean } => {
-    const session = authApi.getCurrentSession()
-    if (!session) {
-      return { user: null, isAuthenticated: false }
-    }
-    const user = decodeIdToken(session.idToken)
-    if (!user) {
-      authApi.logout()
-      return { user: null, isAuthenticated: false }
-    }
-    return { user, isAuthenticated: true }
-  }
+  // Start loading so server and client first render match (server can't access
+  // localStorage). A post-mount effect resolves the real session.
+  const [user, setUser] = useState<User | null>(null)
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [loading, setLoading] = useState(true)
 
-  const initial = initSession()
-  const [user, setUser] = useState<User | null>(initial.user)
-  const [isAuthenticated, setIsAuthenticated] = useState(initial.isAuthenticated)
-  const [loading] = useState(false)
+  useEffect(() => {
+    const session = authApi.getCurrentSession()
+    if (session) {
+      const decoded = decodeIdToken(session.idToken)
+      if (decoded) {
+        setUser(decoded)
+        setIsAuthenticated(true)
+      } else {
+        authApi.logout()
+      }
+    }
+    setLoading(false)
+  }, [])
 
   const isAdmin = user?.groups.includes('admin') ?? false
 

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -8,6 +8,7 @@ import {
   createStaticRouter,
   StaticRouterProvider,
 } from 'react-router-dom'
+import { AuthProvider } from './contexts/AuthContext'
 import { RecipeDataContext } from './contexts/RecipeDataContext'
 import type { RecipeData } from './contexts/RecipeDataContext'
 import { getMetaTags, escapeHtml } from './meta'
@@ -100,9 +101,11 @@ export const render = async (url: string, data?: RecipeData): Promise<string> =>
 
   return new Promise<string>((resolve, reject) => {
     const { pipe } = renderToPipeableStream(
-      <RecipeDataContext.Provider value={data ?? {}}>
-        <StaticRouterProvider router={router} context={context} />
-      </RecipeDataContext.Provider>,
+      <AuthProvider>
+        <RecipeDataContext.Provider value={data ?? {}}>
+          <StaticRouterProvider router={router} context={context} />
+        </RecipeDataContext.Provider>
+      </AuthProvider>,
       {
         onAllReady() {
           const reactStream = new PassThrough({ encoding: 'utf-8' })


### PR DESCRIPTION
## Problem
Production console on `/admin/users` (and any other `ProtectedRoute`-wrapped admin page) throws React error #418 — "Hydration failed because the initial UI does not match what was rendered on the server."

Root cause: the server didn't wrap the router in `<AuthProvider>`, so `useAuth()` inside `ProtectedRoute` fell back to the default context value on SSR. The client wrapped the router in `<AuthProvider>` (in `entry-client.tsx`), whose initial state was derived synchronously from `localStorage`. Server → "not authenticated, navigate to login". Client (logged-in user) → "authenticated, render content". Different HTML → hydration mismatch.

## Fix
Three changes:

1. **`src/entry-server.tsx`** — wrapped the `<StaticRouterProvider>` in `<AuthProvider>`, matching the client entry. Now both sides call `useAuth()` against the same provider shape.

2. **`src/contexts/AuthContext.tsx`** — initial state is now `{ user: null, isAuthenticated: false, loading: true }` on both server and client. A post-mount `useEffect` reads the session from `localStorage` and updates state. This makes the first render deterministic (both sides render `<Loading />` via `ProtectedRoute`'s `loading` branch), and the auth check happens after hydration.

3. **`src/api/auth.ts`** — `getCurrentSession` now guards with `typeof window === 'undefined'` so it returns `null` on the server instead of throwing a `ReferenceError` when the effect is ported elsewhere.

## Trade-off
Logged-in admins now see a brief `<Loading />` flash on first paint before the session resolves (one tick after hydration). This matches standard SSR-auth patterns and is far better than the hydration mismatch, which caused React to throw away the server HTML and re-render from scratch anyway — plus throwing error #418 in the console.

## How to verify
- Deploy → visit `/admin/users` while logged in → no `#418` in the console; a brief spinner before the users table renders.
- `pnpm test` — 547/547.
- `pnpm lint` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)