### PR TITLE
feat(image-upload): preview the existing image when no file is selected

### DIFF
--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -1,6 +1,7 @@
 
 import { getUploadUrl } from '@api/recipes'
 import Button from '@components/Button'
+import { RECIPE_IMAGE_BASE } from '@models/recipe'
 import { useEffect, useId, useRef, useState, type ChangeEvent, type FC } from 'react'
 
 import styles from './ImageUpload.module.css'
@@ -95,7 +96,15 @@ const ImageUpload: FC<ImageUploadProps> = ({
         aria-label="Upload image"
       />
 
-      {preview && <img src={preview} alt="Upload preview" className={styles.preview} />}
+      {preview ? (
+        <img src={preview} alt="Upload preview" className={styles.preview} />
+      ) : currentKey ? (
+        <img
+          src={`${RECIPE_IMAGE_BASE}/${currentKey}-medium.webp`}
+          alt="Current image"
+          className={styles.preview}
+        />
+      ) : null}
 
       {error && (
         <div className={styles.error} role="alert">

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -1,6 +1,7 @@
 
 import { getUploadUrl } from '@api/recipes'
 import Button from '@components/Button'
+import Image from '@components/Image'
 import { recipeImageUrl } from '@models/recipe'
 import { useEffect, useId, useRef, useState, type ChangeEvent, type FC } from 'react'
 
@@ -99,9 +100,9 @@ const ImageUpload: FC<ImageUploadProps> = ({
       />
 
       {preview ? (
-        <img src={preview} alt="Upload preview" className={styles.preview} />
+        <Image src={preview} alt="Upload preview" className={styles.preview} lazy={false} />
       ) : currentKey ? (
-        <img
+        <Image
           src={recipeImageUrl(currentKey, 'medium')}
           alt={currentAlt ?? 'Current image'}
           className={styles.preview}

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -1,7 +1,7 @@
 
 import { getUploadUrl } from '@api/recipes'
 import Button from '@components/Button'
-import { RECIPE_IMAGE_BASE } from '@models/recipe'
+import { recipeImageUrl } from '@models/recipe'
 import { useEffect, useId, useRef, useState, type ChangeEvent, type FC } from 'react'
 
 import styles from './ImageUpload.module.css'
@@ -9,6 +9,7 @@ import styles from './ImageUpload.module.css'
 export interface ImageUploadProps {
   onUpload: (key: string) => void
   currentKey?: string
+  currentAlt?: string
   getToken: () => Promise<string>
   recipeId: string
   imageType?: 'cover' | 'step'
@@ -20,6 +21,7 @@ const MAX_SIZE = 10 * 1024 * 1024
 const ImageUpload: FC<ImageUploadProps> = ({
   onUpload,
   currentKey,
+  currentAlt,
   getToken,
   recipeId,
   imageType = 'cover',
@@ -100,8 +102,8 @@ const ImageUpload: FC<ImageUploadProps> = ({
         <img src={preview} alt="Upload preview" className={styles.preview} />
       ) : currentKey ? (
         <img
-          src={`${RECIPE_IMAGE_BASE}/${currentKey}-medium.webp`}
-          alt="Current image"
+          src={recipeImageUrl(currentKey, 'medium')}
+          alt={currentAlt ?? 'Current image'}
           className={styles.preview}
         />
       ) : null}

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -1,6 +1,6 @@
 import Image from '@components/Image'
 import Typography from '@components/Typography'
-import { RECIPE_IMAGE_BASE, type RecipeIndex } from '@models/recipe'
+import { recipeImageUrl, type RecipeIndex } from '@models/recipe'
 import type { FC } from 'react'
 import { Link } from 'react-router-dom'
 import styles from './RecipeCard.module.css'
@@ -14,7 +14,7 @@ export interface RecipeCardProps {
 
 
 const RecipeCard: FC<RecipeCardProps> = ({ recipe, eager = false, hideTags = false, hideMeta = false }) => {
-  const thumbnailSrc = `${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-thumb.webp`
+  const thumbnailSrc = recipeImageUrl(recipe.coverImage.key, 'thumb')
 
   return (
     <article className={styles.card}>

--- a/src/components/RecipeDetailView/RecipeDetailView.tsx
+++ b/src/components/RecipeDetailView/RecipeDetailView.tsx
@@ -2,7 +2,7 @@ import Image from '@components/Image'
 import RecipeIngredients from '@components/RecipeIngredients'
 import RecipeSteps from '@components/RecipeSteps'
 import Typography from '@components/Typography'
-import { RECIPE_IMAGE_BASE, type Recipe } from '@models/recipe'
+import { recipeImageUrl, type Recipe } from '@models/recipe'
 import type { FC } from 'react'
 import { Link } from 'react-router-dom'
 
@@ -24,8 +24,8 @@ const formatDate = (dateString: string): string => {
 const RecipeDetailView: FC<RecipeDetailViewProps> = ({ recipe }) => (
   <article className={styles.page}>
     <Image
-      src={`${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-medium.webp`}
-      srcSet={`${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-medium.webp 800w, ${RECIPE_IMAGE_BASE}/${recipe.coverImage.key}-full.webp 1200w`}
+      src={recipeImageUrl(recipe.coverImage.key, 'medium')}
+      srcSet={`${recipeImageUrl(recipe.coverImage.key, 'medium')} 800w, ${recipeImageUrl(recipe.coverImage.key, 'full')} 1200w`}
       alt={recipe.coverImage.alt}
       priority
       maxWidth="var(--max-w-site)"

--- a/src/components/RecipeSteps/RecipeSteps.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.tsx
@@ -1,6 +1,6 @@
 import Image from '@components/Image'
 import Typography from '@components/Typography'
-import { RECIPE_IMAGE_BASE, type Step } from '@models/recipe'
+import { recipeImageUrl, type Step } from '@models/recipe'
 import type { FC } from 'react'
 import styles from './RecipeSteps.module.css'
 
@@ -16,7 +16,7 @@ const RecipeSteps: FC<RecipeStepsProps> = ({ steps }) => (
         <Typography variant="body" className={styles.text}>{step.text}</Typography>
         {step.image && (
           <Image
-            src={`${RECIPE_IMAGE_BASE}/${step.image.key}-medium.webp`}
+            src={recipeImageUrl(step.image.key, 'medium')}
             alt={step.image.alt}
             className={styles.image}
           />

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -75,6 +75,7 @@ const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken, onAn
                   imageType="step"
                   stepOrder={index + 1}
                   currentKey={step.image?.key}
+                  currentAlt={step.image?.alt}
                   getToken={getToken}
                   onUpload={(key) => updateImage(index, { key })}
                 />

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -432,6 +432,7 @@ const RecipeEditor: FC = () => {
               <ImageUpload
                 onUpload={setCoverImageKey}
                 currentKey={form.coverImageKey || undefined}
+                currentAlt={form.coverImageAlt || undefined}
                 getToken={getAccessToken}
                 recipeId={recipeId}
               />

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,5 +1,10 @@
 export const RECIPE_IMAGE_BASE = 'https://akli.dev/images'
 
+export type RecipeImageVariant = 'thumb' | 'medium' | 'full'
+
+export const recipeImageUrl = (key: string, variant: RecipeImageVariant): string =>
+  `${RECIPE_IMAGE_BASE}/${key}-${variant}.webp`
+
 export interface RecipeImage {
   key: string
   alt: string


### PR DESCRIPTION
## What changed
- On the recipe editor, `ImageUpload` now renders an `<img>` preview of the existing cover/step image when it has a `currentKey` and no locally-selected file — so editors can see what's already attached before deciding to replace it.
- New `currentAlt?` prop so the preview's `alt` text reflects the recipe's actual alt (not a generic "Current image" fallback). `RecipeEditor` passes `form.coverImageAlt`; `StepList` passes `step.image?.alt`.

## /simplify pass
Extracted `recipeImageUrl(key, variant)` + `RecipeImageVariant` type into `src/types/recipe.ts`. Replaced inline template literals at the 4 call sites:
- `RecipeCard` (thumb)
- `RecipeDetailView` (medium + srcSet medium/full)
- `RecipeSteps` (medium)
- `ImageUpload` (medium — the new preview)

Keeps variant names in one place and tightens against typos.

## How to verify
- `pnpm test` — 547/547 pass.
- `pnpm lint` — exit 0.
- Open `/admin/recipes/:id/edit` on a recipe with a cover — the preview now renders above the Replace button.

## Note
Depends on the infra fix in `akli-infrastructure` PR #103 (returns the `processed/` key instead of `uploads/`). Until that merges and deploys, previews against prod will 404 for newly-uploaded images. Existing `/images/processed/...` keys work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)