### PR TITLE
Add RecipeImage.processedAt type + fetchRecipeByIdAdmin helper

### DIFF
--- a/src/api/recipes.test.ts
+++ b/src/api/recipes.test.ts
@@ -51,6 +51,11 @@ const _statusOk2: Recipe['status'] = 'published'
 // @ts-expect-error — 'archived' is not a valid status
 const _statusBad: Recipe['status'] = 'archived'
 const _recipeWithTtl: Recipe = { ...mockRecipe, ttl: 123 }
+const _coverWithProcessedAt: Recipe['coverImage'] = {
+  key: 'spaghetti-cover',
+  alt: 'A bowl of spaghetti bolognese',
+  processedAt: 1714000000,
+}
 
 beforeEach(() => {
   vi.restoreAllMocks()
@@ -297,6 +302,59 @@ describe('authenticated recipe endpoints', () => {
 
       const mod = await import('./recipes')
       await expect(mod.fetchAllRecipes('bad-token')).rejects.toThrow('401')
+    })
+  })
+
+  describe('fetchRecipeByIdAdmin', () => {
+    it('GET /recipes/admin/{id} with token and returns the Recipe', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(mockRecipe),
+        })
+      )
+
+      const mod = await import('./recipes')
+      const result = await mod.fetchRecipeByIdAdmin('token-123', 'r1')
+
+      expect(result).toEqual(mockRecipe)
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/recipes/admin/r1'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer token-123',
+          }),
+        })
+      )
+    })
+
+    it('throws with 401 on unauthorised', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+        })
+      )
+
+      const mod = await import('./recipes')
+      await expect(mod.fetchRecipeByIdAdmin('bad-token', 'r1')).rejects.toThrow('401')
+    })
+
+    it('throws with 404 when recipe is missing', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        })
+      )
+
+      const mod = await import('./recipes')
+      await expect(mod.fetchRecipeByIdAdmin('token-123', 'missing')).rejects.toThrow('404')
     })
   })
 

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -60,6 +60,10 @@ export const fetchAllRecipes = async (token: string): Promise<Recipe[]> => {
   return response.json()
 }
 
+export const fetchRecipeByIdAdmin = async (_token: string, _id: string): Promise<Recipe> => {
+  throw new Error('not implemented')
+}
+
 export const updateRecipe = async (
   token: string,
   id: string,

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -60,8 +60,14 @@ export const fetchAllRecipes = async (token: string): Promise<Recipe[]> => {
   return response.json()
 }
 
-export const fetchRecipeByIdAdmin = async (_token: string, _id: string): Promise<Recipe> => {
-  throw new Error('not implemented')
+export const fetchRecipeByIdAdmin = async (token: string, id: string): Promise<Recipe> => {
+  const response = await fetch(`${API_BASE}/recipes/admin/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+  return response.json()
 }
 
 export const updateRecipe = async (

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -8,6 +8,7 @@ export const recipeImageUrl = (key: string, variant: RecipeImageVariant): string
 export interface RecipeImage {
   key: string
   alt: string
+  processedAt?: number
 }
 
 export interface Ingredient {


### PR DESCRIPTION
Closes #167

## What changed
- Added optional `processedAt?: number` (unix ms) to the `RecipeImage` interface.
- Added `fetchRecipeByIdAdmin(token, id)` to `src/api/recipes.ts` — calls `GET /recipes/admin/{id}` with a bearer token and returns a `Recipe`; throws on non-2xx.
- Three new tests covering success, 401, and 404 paths, plus a type-level round-trip asserting the new field is accepted on `coverImage`.

## Why
Foundation for the Image Processing Readiness milestone. Every other issue in this milestone reads `processedAt` (to gate image rendering, drive polling, and block publish) or calls `fetchRecipeByIdAdmin` (editor and preview polling hook). Shipping this first unblocks the rest.

## How to verify
- `pnpm test src/api/recipes.test.ts` — the new `fetchRecipeByIdAdmin` block covers success + 401 + 404.
- `pnpm test` — full suite green (550 tests).
- `pnpm lint` — no errors.

## Decisions made
- Helper mirrors the shape of `fetchAllRecipes` / `fetchMyRecipes` exactly (same error shape, same header pattern) rather than introducing a shared `apiFetch` wrapper — pre-existing duplication is noted for a future pass, not this PR.
- Type addition is the minimum surface needed; no other interfaces touched.