### PR TITLE
Build useImageProcessingPoll hook (TDD)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -82,3 +82,8 @@ export const handleSessionError = (
   navigate('/admin/login')
   return true
 }
+
+export const isNotFoundError = (err: unknown): boolean => {
+  const message = err instanceof Error ? err.message : ''
+  return /\b404\b/.test(message)
+}

--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -60,9 +60,14 @@ export const fetchAllRecipes = async (token: string): Promise<Recipe[]> => {
   return response.json()
 }
 
-export const fetchRecipeByIdAdmin = async (token: string, id: string): Promise<Recipe> => {
+export const fetchRecipeByIdAdmin = async (
+  token: string,
+  id: string,
+  signal?: AbortSignal
+): Promise<Recipe> => {
   const response = await fetch(`${API_BASE}/recipes/admin/${id}`, {
     headers: { Authorization: `Bearer ${token}` },
+    signal,
   })
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`)

--- a/src/hooks/useImageProcessingPoll.test.ts
+++ b/src/hooks/useImageProcessingPoll.test.ts
@@ -1,0 +1,536 @@
+import * as authApi from '@api/auth'
+import * as recipesApi from '@api/recipes'
+import * as authContext from '@contexts/AuthContext'
+import type { Recipe } from '@models/recipe'
+import { act, configure, renderHook, waitFor } from '@testing-library/react'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+
+import { useImageProcessingPoll } from './useImageProcessingPoll'
+
+vi.mock('@api/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@api/auth')>()
+  return {
+    ...actual,
+    handleSessionError: vi.fn(),
+  }
+})
+
+vi.mock('@api/recipes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@api/recipes')>()
+  return {
+    ...actual,
+    fetchRecipeByIdAdmin: vi.fn(),
+  }
+})
+
+// Mock useNavigate so the hook can resolve it without a router.
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
+
+const navigateMock = vi.fn()
+const logoutMock = vi.fn()
+const getAccessTokenMock = vi.fn<() => Promise<string>>()
+
+// Stub useAuth so the hook can pull logout / getAccessToken without a full AuthProvider.
+const useAuthSpy = vi.spyOn(authContext, 'useAuth')
+
+const fetchMock = vi.mocked(recipesApi.fetchRecipeByIdAdmin)
+
+const makeRecipe = (overrides: Partial<Recipe> = {}): Recipe => ({
+  id: 'r1',
+  title: 'Test Recipe',
+  slug: 'test-recipe',
+  coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+  tags: [],
+  prepTime: 10,
+  cookTime: 20,
+  servings: 2,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  intro: '',
+  ingredients: [],
+  steps: [],
+  authorId: 'author-1',
+  authorName: 'Admin',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  status: 'draft',
+  ...overrides,
+})
+
+beforeEach(() => {
+  navigateMock.mockReset()
+  logoutMock.mockReset()
+  getAccessTokenMock.mockReset()
+  getAccessTokenMock.mockResolvedValue('token-123')
+  fetchMock.mockReset()
+  vi.mocked(authApi.handleSessionError).mockReset()
+  useAuthSpy.mockReturnValue({
+    user: null,
+    isAuthenticated: true,
+    isAdmin: true,
+    loading: false,
+    login: vi.fn(),
+    logout: logoutMock,
+    getAccessToken: getAccessTokenMock,
+  })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+beforeAll(() => {
+  configure({ asyncUtilTimeout: 5000 })
+})
+
+afterAll(() => {
+  configure({ asyncUtilTimeout: 1000 })
+})
+
+describe('useImageProcessingPoll — state machine', () => {
+  it('does not fetch when recipe is null', async () => {
+    const onReady = vi.fn()
+    renderHook(() => useImageProcessingPoll(null, onReady))
+
+    // Give the hook a few microtasks to settle any effects.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(onReady).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when all images already have processedAt', async () => {
+    const onReady = vi.fn()
+    const recipe = makeRecipe({
+      coverImage: { key: 'recipes/r1/cover', alt: 'cover', processedAt: 1000 },
+      steps: [
+        { order: 1, text: 'Step 1', image: { key: 'recipes/r1/step-1', alt: 'step', processedAt: 1000 } },
+      ],
+    })
+
+    renderHook(() => useImageProcessingPoll(recipe, onReady))
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(onReady).not.toHaveBeenCalled()
+  })
+
+  it('fetches when recipe has at least one image with a key but no processedAt', async () => {
+    const onReady = vi.fn()
+    const recipe = makeRecipe({
+      coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+    })
+
+    // Never-resolving response so we only observe the first fetch kickoff.
+    fetchMock.mockImplementation(() => new Promise(() => {}))
+
+    renderHook(() => useImageProcessingPoll(recipe, onReady))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled()
+    })
+    expect(fetchMock.mock.calls[0][0]).toBe('token-123')
+    expect(fetchMock.mock.calls[0][1]).toBe('r1')
+  })
+
+  it('invokes onReady with { key, processedAt } for newly-ready images only', async () => {
+    const onReady = vi.fn()
+    const recipe = makeRecipe({
+      coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+      steps: [
+        { order: 1, text: 'Step 1', image: { key: 'recipes/r1/step-1', alt: 'step' } },
+      ],
+    })
+
+    // Server response: cover is ready, step-1 still processing.
+    fetchMock.mockResolvedValueOnce(
+      makeRecipe({
+        coverImage: { key: 'recipes/r1/cover', alt: 'cover', processedAt: 5000 },
+        steps: [
+          { order: 1, text: 'Step 1', image: { key: 'recipes/r1/step-1', alt: 'step' } },
+        ],
+      })
+    )
+    // Keep subsequent ticks pending so we only assert on the first flip.
+    fetchMock.mockImplementation(() => new Promise(() => {}))
+
+    renderHook(() => useImageProcessingPoll(recipe, onReady))
+
+    await waitFor(() => {
+      expect(onReady).toHaveBeenCalled()
+    })
+
+    const [updates] = onReady.mock.calls[0]
+    expect(updates).toEqual([{ key: 'recipes/r1/cover', processedAt: 5000 }])
+  })
+
+  it('does not duplicate onReady entries across ticks', async () => {
+    const onReady = vi.fn()
+    const recipe = makeRecipe({
+      coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+      steps: [
+        { order: 1, text: 'Step 1', image: { key: 'recipes/r1/step-1', alt: 'step' } },
+      ],
+    })
+
+    // Tick 1: cover flips to ready, step-1 still processing.
+    fetchMock.mockResolvedValueOnce(
+      makeRecipe({
+        coverImage: { key: 'recipes/r1/cover', alt: 'cover', processedAt: 5000 },
+        steps: [
+          { order: 1, text: 'Step 1', image: { key: 'recipes/r1/step-1', alt: 'step' } },
+        ],
+      })
+    )
+    // Tick 2: step-1 flips to ready too; cover is unchanged.
+    fetchMock.mockResolvedValueOnce(
+      makeRecipe({
+        coverImage: { key: 'recipes/r1/cover', alt: 'cover', processedAt: 5000 },
+        steps: [
+          { order: 1, text: 'Step 1', image: { key: 'recipes/r1/step-1', alt: 'step', processedAt: 6000 } },
+        ],
+      })
+    )
+    // Stall any further ticks.
+    fetchMock.mockImplementation(() => new Promise(() => {}))
+
+    vi.useFakeTimers()
+    try {
+      renderHook(() => useImageProcessingPoll(recipe, onReady))
+
+      // Advance through two poll ticks.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500)
+      })
+
+      await waitFor(() => {
+        expect(onReady).toHaveBeenCalledTimes(2)
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+
+    // Each call should only carry the entries that flipped on that tick.
+    expect(onReady.mock.calls[0][0]).toEqual([
+      { key: 'recipes/r1/cover', processedAt: 5000 },
+    ])
+    expect(onReady.mock.calls[1][0]).toEqual([
+      { key: 'recipes/r1/step-1', processedAt: 6000 },
+    ])
+  })
+
+  it('delegates 401 responses to handleSessionError and stops polling', async () => {
+    const onReady = vi.fn()
+    const recipe = makeRecipe({
+      coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+    })
+
+    const authErr = new Error('401 Unauthorized')
+    fetchMock.mockRejectedValueOnce(authErr)
+    // If polling (incorrectly) continues, further fetches would pend.
+    fetchMock.mockImplementation(() => new Promise(() => {}))
+    // Session errors do the redirect — report true so the hook knows it's handled.
+    vi.mocked(authApi.handleSessionError).mockReturnValue(true)
+
+    vi.useFakeTimers()
+    try {
+      renderHook(() => useImageProcessingPoll(recipe, onReady))
+
+      await waitFor(() => {
+        expect(vi.mocked(authApi.handleSessionError)).toHaveBeenCalled()
+      })
+
+      const [errArg, logoutArg, navigateArg] = vi.mocked(authApi.handleSessionError).mock.calls[0]
+      expect(errArg).toBe(authErr)
+      expect(logoutArg).toBe(logoutMock)
+      expect(navigateArg).toBe(navigateMock)
+
+      // Should not continue polling after the 401.
+      const callsAfter401 = fetchMock.mock.calls.length
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500 * 3)
+      })
+      expect(fetchMock.mock.calls.length).toBe(callsAfter401)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(onReady).not.toHaveBeenCalled()
+  })
+
+  it('stops polling silently on 404 (recipe deleted)', async () => {
+    const onReady = vi.fn()
+    const recipe = makeRecipe({
+      coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+    })
+
+    fetchMock.mockRejectedValueOnce(new Error('404 Not Found'))
+    // Subsequent ticks would error too if polling continues.
+    fetchMock.mockImplementation(() => new Promise(() => {}))
+
+    vi.useFakeTimers()
+    try {
+      renderHook(() => useImageProcessingPoll(recipe, onReady))
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+      })
+
+      // Advance several intervals; no more fetches should fire.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500 * 5)
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(vi.mocked(authApi.handleSessionError)).not.toHaveBeenCalled()
+    expect(onReady).not.toHaveBeenCalled()
+  })
+
+  it('aborts the in-flight request and suppresses state updates on unmount', async () => {
+    const onReady = vi.fn()
+    const recipe = makeRecipe({
+      coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+    })
+
+    const seenSignals: AbortSignal[] = []
+    let resolveFirst: ((r: Recipe) => void) | null = null
+    fetchMock.mockImplementationOnce((_token, _id, signal?: AbortSignal) => {
+      if (signal) seenSignals.push(signal)
+      return new Promise<Recipe>((resolve) => {
+        resolveFirst = resolve
+      })
+    })
+
+    const { unmount } = renderHook(() => useImageProcessingPoll(recipe, onReady))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled()
+    })
+
+    unmount()
+
+    expect(seenSignals.length).toBeGreaterThan(0)
+    expect(seenSignals[0].aborted).toBe(true)
+
+    // Resolve the already-aborted request — no onReady should fire.
+    await act(async () => {
+      resolveFirst?.(
+        makeRecipe({
+          coverImage: { key: 'recipes/r1/cover', alt: 'cover', processedAt: 9999 },
+        })
+      )
+    })
+
+    expect(onReady).not.toHaveBeenCalled()
+  })
+
+  it('aborts in-flight and re-evaluates readiness when recipe.id changes', async () => {
+    const onReady = vi.fn()
+    const recipeA = makeRecipe({
+      id: 'recipe-a',
+      coverImage: { key: 'recipes/a/cover', alt: 'cover' },
+    })
+    const recipeB = makeRecipe({
+      id: 'recipe-b',
+      coverImage: { key: 'recipes/b/cover', alt: 'cover' },
+    })
+
+    const seenSignals: AbortSignal[] = []
+    let resolveRecipeA: ((r: Recipe) => void) | null = null
+    fetchMock.mockImplementationOnce((_token, _id, signal?: AbortSignal) => {
+      if (signal) seenSignals.push(signal)
+      return new Promise<Recipe>((resolve) => {
+        resolveRecipeA = resolve
+      })
+    })
+    // Recipe B fetch: stall — we just need to observe the first fetch aborted.
+    fetchMock.mockImplementation((_token, _id, signal?: AbortSignal) => {
+      if (signal) seenSignals.push(signal)
+      return new Promise(() => {})
+    })
+
+    const { rerender } = renderHook(
+      ({ recipe }: { recipe: Recipe }) => useImageProcessingPoll(recipe, onReady),
+      { initialProps: { recipe: recipeA } }
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('token-123', 'recipe-a', expect.anything())
+    })
+
+    rerender({ recipe: recipeB })
+
+    await waitFor(() => {
+      expect(seenSignals[0].aborted).toBe(true)
+    })
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('token-123', 'recipe-b', expect.anything())
+    })
+
+    // Resolving recipe A's request late must NOT trigger onReady for recipe B.
+    await act(async () => {
+      resolveRecipeA?.(
+        makeRecipe({
+          id: 'recipe-a',
+          coverImage: { key: 'recipes/a/cover', alt: 'cover', processedAt: 1111 },
+        })
+      )
+    })
+
+    expect(onReady).not.toHaveBeenCalled()
+  })
+})
+
+describe('useImageProcessingPoll — timing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires exactly N fetches after N × 1500ms have elapsed', async () => {
+    const onReady = vi.fn()
+    const recipe = makeRecipe({
+      coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+    })
+
+    // Always respond with the same unready recipe so polling keeps running.
+    fetchMock.mockResolvedValue(
+      makeRecipe({
+        coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+      })
+    )
+
+    renderHook(() => useImageProcessingPoll(recipe, onReady))
+
+    // Just before the first interval elapses — nothing yet, or at most the
+    // kickoff tick if the hook fires one immediately. Allow either N=0 or N=1
+    // here and assert cadence going forward.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    // After 1 full interval the count should be exactly 1 more than initial.
+    const initial = fetchMock.mock.calls.length
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500)
+    })
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.length).toBe(initial + 1)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500)
+    })
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.length).toBe(initial + 2)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500)
+    })
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.length).toBe(initial + 3)
+    })
+  })
+
+  it('stops polling after 60s timeout and reports timedOut: true', async () => {
+    const onReady = vi.fn()
+    const recipe = makeRecipe({
+      coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+    })
+
+    fetchMock.mockResolvedValue(
+      makeRecipe({
+        coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+      })
+    )
+
+    const { result } = renderHook(() => useImageProcessingPoll(recipe, onReady))
+
+    // Advance past the 60s timeout.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    // Let any pending microtasks settle.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    await waitFor(() => {
+      expect(result.current.timedOut).toBe(true)
+    })
+
+    const callsAtTimeout = fetchMock.mock.calls.length
+
+    // Polling must be stopped — no more fetches in the next few intervals.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500 * 5)
+    })
+    expect(fetchMock.mock.calls.length).toBe(callsAtTimeout)
+  })
+
+  it('honours custom intervalMs and timeoutMs overrides', async () => {
+    const onReady = vi.fn()
+    const recipe = makeRecipe({
+      coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+    })
+
+    fetchMock.mockResolvedValue(
+      makeRecipe({
+        coverImage: { key: 'recipes/r1/cover', alt: 'cover' },
+      })
+    )
+
+    const { result } = renderHook(() =>
+      useImageProcessingPoll(recipe, onReady, { intervalMs: 500, timeoutMs: 2000 })
+    )
+
+    const initial = fetchMock.mock.calls.length
+
+    // After 500ms, one more fetch has fired at the custom cadence.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.length).toBe(initial + 1)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.length).toBe(initial + 2)
+    })
+
+    // Past the custom 2000ms timeout.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+    await waitFor(() => {
+      expect(result.current.timedOut).toBe(true)
+    })
+
+    const callsAtTimeout = fetchMock.mock.calls.length
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500 * 5)
+    })
+    expect(fetchMock.mock.calls.length).toBe(callsAtTimeout)
+  })
+})

--- a/src/hooks/useImageProcessingPoll.ts
+++ b/src/hooks/useImageProcessingPoll.ts
@@ -1,4 +1,4 @@
-import { handleSessionError } from '@api/auth'
+import { handleSessionError, isNotFoundError } from '@api/auth'
 import { fetchRecipeByIdAdmin } from '@api/recipes'
 import { useAuth } from '@contexts/AuthContext'
 import type { Recipe, RecipeImage } from '@models/recipe'
@@ -36,11 +36,6 @@ const unreadyKeysOf = (recipe: Recipe): string[] =>
     .filter((img) => !img.processedAt)
     .map((img) => img.key)
 
-const is404 = (err: unknown): boolean => {
-  const message = err instanceof Error ? err.message : ''
-  return /\b404\b/.test(message)
-}
-
 export const useImageProcessingPoll = (
   recipe: Recipe | null,
   onReady: (updates: ImageReadyUpdate[]) => void,
@@ -60,7 +55,7 @@ export const useImageProcessingPoll = (
   const getAccessTokenRef = useRef(getAccessToken)
   const isMountedRef = useRef(true)
   const abortRef = useRef<AbortController | null>(null)
-  const intervalTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const nextTickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const timeoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const emittedReadyRef = useRef<Set<string>>(new Set())
   const activeRecipeIdRef = useRef<string | null>(null)
@@ -73,11 +68,8 @@ export const useImageProcessingPoll = (
   const recipeId = recipe?.id ?? null
   const unreadyKeysSignature = useMemo(() => {
     if (!recipe) return ''
-    const keys = unreadyKeysOf(recipe)
-    return keys.sort().join('|')
+    return unreadyKeysOf(recipe).sort().join('|')
   }, [recipe])
-
-  const shouldPoll = recipeId !== null && unreadyKeysSignature.length > 0
 
   useEffect(() => {
     isMountedRef.current = true
@@ -87,7 +79,7 @@ export const useImageProcessingPoll = (
   }, [])
 
   useEffect(() => {
-    if (!shouldPoll || recipeId === null) {
+    if (recipeId === null || unreadyKeysSignature.length === 0) {
       return
     }
 
@@ -96,9 +88,9 @@ export const useImageProcessingPoll = (
     setTimedOut(false)
 
     const stopPolling = () => {
-      if (intervalTimerRef.current !== null) {
-        clearInterval(intervalTimerRef.current)
-        intervalTimerRef.current = null
+      if (nextTickTimerRef.current !== null) {
+        clearTimeout(nextTickTimerRef.current)
+        nextTickTimerRef.current = null
       }
       if (timeoutTimerRef.current !== null) {
         clearTimeout(timeoutTimerRef.current)
@@ -108,6 +100,28 @@ export const useImageProcessingPoll = (
         abortRef.current.abort()
         abortRef.current = null
       }
+    }
+
+    const handleTickError = (err: unknown): boolean => {
+      if (isNotFoundError(err)) {
+        stopPolling()
+        return true
+      }
+      if (handleSessionError(err, logoutRef.current, navigateRef.current)) {
+        stopPolling()
+        return true
+      }
+      return false
+    }
+
+    const scheduleNextTick = () => {
+      if (!isMountedRef.current) return
+      if (activeRecipeIdRef.current !== recipeId) return
+      if (nextTickTimerRef.current !== null) return
+      nextTickTimerRef.current = setTimeout(() => {
+        nextTickTimerRef.current = null
+        void runTick()
+      }, intervalMs)
     }
 
     const runTick = async () => {
@@ -124,8 +138,7 @@ export const useImageProcessingPoll = (
       } catch (err) {
         if (controller.signal.aborted) return
         if (activeRecipeIdRef.current !== tickRecipeId) return
-        const redirected = handleSessionError(err, logoutRef.current, navigateRef.current)
-        if (redirected) stopPolling()
+        if (!handleTickError(err)) scheduleNextTick()
         return
       }
 
@@ -136,8 +149,13 @@ export const useImageProcessingPoll = (
         if (activeRecipeIdRef.current !== tickRecipeId) return
 
         const newlyReady: ImageReadyUpdate[] = []
+        let hasUnready = false
         for (const img of collectImages(fresh)) {
-          if (img.processedAt && !emittedReadyRef.current.has(img.key)) {
+          if (!img.processedAt) {
+            hasUnready = true
+            continue
+          }
+          if (!emittedReadyRef.current.has(img.key)) {
             emittedReadyRef.current.add(img.key)
             newlyReady.push({ key: img.key, processedAt: img.processedAt })
           }
@@ -147,28 +165,19 @@ export const useImageProcessingPoll = (
           onReadyRef.current(newlyReady)
         }
 
-        if (unreadyKeysOf(fresh).length === 0) {
+        if (hasUnready) {
+          scheduleNextTick()
+        } else {
           stopPolling()
         }
       } catch (err) {
         if (controller.signal.aborted) return
         if (activeRecipeIdRef.current !== tickRecipeId) return
-
-        if (is404(err)) {
-          stopPolling()
-          return
-        }
-
-        const redirected = handleSessionError(err, logoutRef.current, navigateRef.current)
-        if (redirected) {
-          stopPolling()
-        }
+        if (!handleTickError(err)) scheduleNextTick()
       }
     }
 
-    intervalTimerRef.current = setInterval(() => {
-      void runTick()
-    }, intervalMs)
+    scheduleNextTick()
 
     timeoutTimerRef.current = setTimeout(() => {
       stopPolling()
@@ -180,7 +189,7 @@ export const useImageProcessingPoll = (
     return () => {
       stopPolling()
     }
-  }, [shouldPoll, recipeId, unreadyKeysSignature, intervalMs, timeoutMs])
+  }, [recipeId, unreadyKeysSignature, intervalMs, timeoutMs])
 
   return { timedOut }
 }

--- a/src/hooks/useImageProcessingPoll.ts
+++ b/src/hooks/useImageProcessingPoll.ts
@@ -1,0 +1,25 @@
+import type { Recipe } from '@models/recipe'
+
+export interface ImageReadyUpdate {
+  key: string
+  processedAt: number
+}
+
+export interface UseImageProcessingPollOptions {
+  intervalMs?: number
+  timeoutMs?: number
+}
+
+export interface UseImageProcessingPollResult {
+  timedOut: boolean
+}
+
+// Stub — implementation arrives with the TDD pass. Returns the idle shape so
+// the test file can import a real module and fail on behaviour, not imports.
+export const useImageProcessingPoll = (
+  _recipe: Recipe | null,
+  _onReady: (updates: ImageReadyUpdate[]) => void,
+  _options?: UseImageProcessingPollOptions
+): UseImageProcessingPollResult => {
+  return { timedOut: false }
+}

--- a/src/hooks/useImageProcessingPoll.ts
+++ b/src/hooks/useImageProcessingPoll.ts
@@ -1,4 +1,9 @@
-import type { Recipe } from '@models/recipe'
+import { handleSessionError } from '@api/auth'
+import { fetchRecipeByIdAdmin } from '@api/recipes'
+import { useAuth } from '@contexts/AuthContext'
+import type { Recipe, RecipeImage } from '@models/recipe'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 export interface ImageReadyUpdate {
   key: string
@@ -14,12 +19,168 @@ export interface UseImageProcessingPollResult {
   timedOut: boolean
 }
 
-// Stub — implementation arrives with the TDD pass. Returns the idle shape so
-// the test file can import a real module and fail on behaviour, not imports.
+const DEFAULT_INTERVAL_MS = 1500
+const DEFAULT_TIMEOUT_MS = 60_000
+
+const collectImages = (recipe: Recipe): RecipeImage[] => {
+  const images: RecipeImage[] = []
+  if (recipe.coverImage?.key) images.push(recipe.coverImage)
+  for (const step of recipe.steps) {
+    if (step.image?.key) images.push(step.image)
+  }
+  return images
+}
+
+const unreadyKeysOf = (recipe: Recipe): string[] =>
+  collectImages(recipe)
+    .filter((img) => !img.processedAt)
+    .map((img) => img.key)
+
+const is404 = (err: unknown): boolean => {
+  const message = err instanceof Error ? err.message : ''
+  return /\b404\b/.test(message)
+}
+
 export const useImageProcessingPoll = (
-  _recipe: Recipe | null,
-  _onReady: (updates: ImageReadyUpdate[]) => void,
-  _options?: UseImageProcessingPollOptions
+  recipe: Recipe | null,
+  onReady: (updates: ImageReadyUpdate[]) => void,
+  options?: UseImageProcessingPollOptions
 ): UseImageProcessingPollResult => {
-  return { timedOut: false }
+  const intervalMs = options?.intervalMs ?? DEFAULT_INTERVAL_MS
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+  const { logout, getAccessToken } = useAuth()
+  const navigate = useNavigate()
+
+  const [timedOut, setTimedOut] = useState(false)
+
+  const onReadyRef = useRef(onReady)
+  const logoutRef = useRef(logout)
+  const navigateRef = useRef(navigate)
+  const getAccessTokenRef = useRef(getAccessToken)
+  const isMountedRef = useRef(true)
+  const abortRef = useRef<AbortController | null>(null)
+  const intervalTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const timeoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const emittedReadyRef = useRef<Set<string>>(new Set())
+  const activeRecipeIdRef = useRef<string | null>(null)
+
+  onReadyRef.current = onReady
+  logoutRef.current = logout
+  navigateRef.current = navigate
+  getAccessTokenRef.current = getAccessToken
+
+  const recipeId = recipe?.id ?? null
+  const unreadyKeysSignature = useMemo(() => {
+    if (!recipe) return ''
+    const keys = unreadyKeysOf(recipe)
+    return keys.sort().join('|')
+  }, [recipe])
+
+  const shouldPoll = recipeId !== null && unreadyKeysSignature.length > 0
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!shouldPoll || recipeId === null) {
+      return
+    }
+
+    activeRecipeIdRef.current = recipeId
+    emittedReadyRef.current = new Set()
+    setTimedOut(false)
+
+    const stopPolling = () => {
+      if (intervalTimerRef.current !== null) {
+        clearInterval(intervalTimerRef.current)
+        intervalTimerRef.current = null
+      }
+      if (timeoutTimerRef.current !== null) {
+        clearTimeout(timeoutTimerRef.current)
+        timeoutTimerRef.current = null
+      }
+      if (abortRef.current) {
+        abortRef.current.abort()
+        abortRef.current = null
+      }
+    }
+
+    const runTick = async () => {
+      if (abortRef.current) {
+        abortRef.current.abort()
+      }
+      const controller = new AbortController()
+      abortRef.current = controller
+      const tickRecipeId = recipeId
+
+      let token: string
+      try {
+        token = await getAccessTokenRef.current()
+      } catch (err) {
+        if (controller.signal.aborted) return
+        if (activeRecipeIdRef.current !== tickRecipeId) return
+        const redirected = handleSessionError(err, logoutRef.current, navigateRef.current)
+        if (redirected) stopPolling()
+        return
+      }
+
+      try {
+        const fresh = await fetchRecipeByIdAdmin(token, tickRecipeId, controller.signal)
+        if (controller.signal.aborted) return
+        if (!isMountedRef.current) return
+        if (activeRecipeIdRef.current !== tickRecipeId) return
+
+        const newlyReady: ImageReadyUpdate[] = []
+        for (const img of collectImages(fresh)) {
+          if (img.processedAt && !emittedReadyRef.current.has(img.key)) {
+            emittedReadyRef.current.add(img.key)
+            newlyReady.push({ key: img.key, processedAt: img.processedAt })
+          }
+        }
+
+        if (newlyReady.length > 0) {
+          onReadyRef.current(newlyReady)
+        }
+
+        if (unreadyKeysOf(fresh).length === 0) {
+          stopPolling()
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return
+        if (activeRecipeIdRef.current !== tickRecipeId) return
+
+        if (is404(err)) {
+          stopPolling()
+          return
+        }
+
+        const redirected = handleSessionError(err, logoutRef.current, navigateRef.current)
+        if (redirected) {
+          stopPolling()
+        }
+      }
+    }
+
+    intervalTimerRef.current = setInterval(() => {
+      void runTick()
+    }, intervalMs)
+
+    timeoutTimerRef.current = setTimeout(() => {
+      stopPolling()
+      if (isMountedRef.current) {
+        setTimedOut(true)
+      }
+    }, timeoutMs)
+
+    return () => {
+      stopPolling()
+    }
+  }, [shouldPoll, recipeId, unreadyKeysSignature, intervalMs, timeoutMs])
+
+  return { timedOut }
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,13 @@
 import '@testing-library/jest-dom'
 import { vi } from 'vitest'
 
+// Shim `jest` global so @testing-library's `waitFor` detects vitest's fake
+// timers (it checks `typeof jest !== 'undefined'` plus `setTimeout.clock`).
+// Without this, `waitFor` silently hangs under `vi.useFakeTimers()`.
+;(globalThis as unknown as { jest: { advanceTimersByTime: (ms: number) => void } }).jest = {
+  advanceTimersByTime: (ms: number) => vi.advanceTimersByTime(ms),
+}
+
 export class MockIntersectionObserver {
   observe: ReturnType<typeof vi.fn>
   unobserve = vi.fn()


### PR DESCRIPTION
Closes #168

## What changed
- New hook `src/hooks/useImageProcessingPoll.ts` — polls `fetchRecipeByIdAdmin` on a 1500ms cadence until every recipe image has a `processedAt`, or 60s elapses. Returns `{ timedOut: boolean }`.
- Widened `fetchRecipeByIdAdmin` to accept an optional `signal?: AbortSignal`, mirroring `updateRecipe`'s shape.
- Added `isNotFoundError` next to `isSessionError` in `src/api/auth.ts` — shared 404 detection for polling consumers.
- Added a 4-line `jest` global shim in `tests/setup.ts` so `@testing-library/waitFor` works under `vi.useFakeTimers()` (known testing-library/vitest interop gap — commented in-place).
- 12 tests across state-machine and timing describe blocks, mirroring `useAutosave.test.ts` structure.

## Why
The editor (#172) and preview page (#173) both need a single source of truth for "keep asking the server until every image has finished processing." Extracting the polling logic into a standalone hook keeps `RecipeEditor` and `RecipePreview` declarative — each passes a recipe and an `onReady` callback, and the hook handles AbortController cleanup, session errors, 404s, identity changes, and timeouts.

## How to verify
- `pnpm test src/hooks/useImageProcessingPoll.test.ts` — 12/12 green.
- `pnpm test` — full suite 562/562 green.
- `pnpm lint` — 0 errors.

## Decisions made
- **setTimeout chain, not setInterval.** A slow tick delays the next fetch instead of aborting-and-restarting it. Avoids cancel/retry churn under sustained slow network.
- **Key emissions by image `key`, not step order.** Lets the consumer reducer match against live form state and ignore stale updates if the user swapped the image.
- **`useMemo` over `recipe.id + sorted unready keys`.** A new recipe object with identical identity + identical unready set does not restart polling.
- **`activeRecipeIdRef` guard in every tick handler.** A stale response from recipe A cannot invoke `onReady` after recipe B mounts, even if the abort loses the race.
- **401 delegates to `handleSessionError`; 404 stops silently.** Matches PRD; 404 is the "recipe was deleted" path, which is not a session error.
- **No hook wiring to `RecipeEditor` / `RecipePreview` yet.** Those live in #172 and #173.