### PR TITLE
Build ProcessingPlaceholder component

### DIFF
--- a/src/components/ProcessingPlaceholder/ProcessingPlaceholder.module.css
+++ b/src/components/ProcessingPlaceholder/ProcessingPlaceholder.module.css
@@ -1,0 +1,55 @@
+.root {
+  margin: 0;
+}
+
+.inner {
+  position: relative;
+  overflow: hidden;
+  background-color: var(--color-bg-subtle);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+}
+
+/* ── Pulsing overlay ─────────────────────────────────────── */
+.overlay {
+  position: absolute;
+  inset: 0;
+  background-color: var(--color-bg-subtle);
+  opacity: 0.4;
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+
+  50% {
+    opacity: 0.8;
+  }
+}
+
+/* ── Reduced-motion fallbacks ────────────────────────────── */
+/* Class-based path — set by the TSX when matchMedia reports reduce. */
+.root.reducedMotion .overlay {
+  animation: none;
+  opacity: 0.6;
+}
+
+/* Media-query path — covers cases where JS hasn't applied the class yet. */
+@media (prefers-reduced-motion: reduce) {
+  .overlay {
+    animation: none;
+    opacity: 0.6;
+  }
+}
+
+/* ── Caption ─────────────────────────────────────────────── */
+.caption {
+  padding: var(--space-3) 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  text-align: center;
+  font-style: italic;
+}

--- a/src/components/ProcessingPlaceholder/ProcessingPlaceholder.test.tsx
+++ b/src/components/ProcessingPlaceholder/ProcessingPlaceholder.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ProcessingPlaceholder from './ProcessingPlaceholder'
+import styles from './ProcessingPlaceholder.module.css'
+
+/**
+ * Swap `window.matchMedia` with a mock whose `matches` tracks whatever
+ * `(prefers-reduced-motion: reduce)` is asked about. Anything else returns false.
+ */
+const stubMatchMedia = (prefersReducedMotion: boolean): void => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches:
+        query === '(prefers-reduced-motion: reduce)'
+          ? prefersReducedMotion
+          : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  )
+}
+
+describe('ProcessingPlaceholder', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders the default "Processing image…" caption', () => {
+    stubMatchMedia(false)
+
+    render(<ProcessingPlaceholder />)
+
+    expect(screen.getByText(/processing image/i)).toBeInTheDocument()
+  })
+
+  it('renders the overridden caption and hides the default', () => {
+    stubMatchMedia(false)
+
+    render(<ProcessingPlaceholder caption="Resizing cover…" />)
+
+    expect(screen.getByText('Resizing cover…')).toBeInTheDocument()
+    expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
+  })
+
+  it('does not carry aria-live on its root or any descendant', () => {
+    stubMatchMedia(false)
+
+    const { container } = render(<ProcessingPlaceholder />)
+
+    const root = container.firstElementChild
+    expect(root).not.toBeNull()
+    expect(root).not.toHaveAttribute('aria-live')
+
+    // Announcements are routed via a page-level region (see PRD) —
+    // no descendant of the placeholder should carry aria-live either.
+    const descendantsWithAriaLive = container.querySelectorAll('[aria-live]')
+    expect(descendantsWithAriaLive).toHaveLength(0)
+  })
+
+  it('forwards the className prop to its outer element', () => {
+    stubMatchMedia(false)
+
+    const { container } = render(<ProcessingPlaceholder className="foo" />)
+
+    const root = container.firstElementChild
+    expect(root).toHaveClass('foo')
+  })
+
+  it('applies the aspectRatio prop via inline style', () => {
+    stubMatchMedia(false)
+
+    const { container } = render(
+      <ProcessingPlaceholder aspectRatio="16/9" />,
+    )
+
+    const root = container.firstElementChild as HTMLElement | null
+    expect(root).not.toBeNull()
+    expect(root).toHaveStyle({ aspectRatio: '16/9' })
+  })
+
+  it('does not apply the reduced-motion class when prefers-reduced-motion is not set', () => {
+    stubMatchMedia(false)
+
+    const { container } = render(<ProcessingPlaceholder />)
+
+    const root = container.firstElementChild
+    expect(root).not.toHaveClass(styles.reducedMotion)
+  })
+
+  it('applies the reduced-motion class when prefers-reduced-motion: reduce matches', () => {
+    stubMatchMedia(true)
+
+    const { container } = render(<ProcessingPlaceholder />)
+
+    const root = container.firstElementChild
+    expect(root).toHaveClass(styles.reducedMotion)
+  })
+})

--- a/src/components/ProcessingPlaceholder/ProcessingPlaceholder.test.tsx
+++ b/src/components/ProcessingPlaceholder/ProcessingPlaceholder.test.tsx
@@ -72,16 +72,16 @@ describe('ProcessingPlaceholder', () => {
     expect(root).toHaveClass('foo')
   })
 
-  it('applies the aspectRatio prop via inline style', () => {
+  it('applies the aspectRatio prop via inline style on the inner container', () => {
     stubMatchMedia(false)
 
     const { container } = render(
       <ProcessingPlaceholder aspectRatio="16/9" />,
     )
 
-    const root = container.firstElementChild as HTMLElement | null
-    expect(root).not.toBeNull()
-    expect(root).toHaveStyle({ aspectRatio: '16/9' })
+    const inner = container.querySelector(`.${styles.inner}`) as HTMLElement | null
+    expect(inner).not.toBeNull()
+    expect(inner).toHaveStyle({ aspectRatio: '16/9' })
   })
 
   it('does not apply the reduced-motion class when prefers-reduced-motion is not set', () => {

--- a/src/components/ProcessingPlaceholder/ProcessingPlaceholder.tsx
+++ b/src/components/ProcessingPlaceholder/ProcessingPlaceholder.tsx
@@ -1,4 +1,5 @@
-import type { FC } from 'react'
+import { useEffect, useState, type FC } from 'react'
+import styles from './ProcessingPlaceholder.module.css'
 
 export interface ProcessingPlaceholderProps {
   aspectRatio?: string
@@ -6,8 +7,53 @@ export interface ProcessingPlaceholderProps {
   className?: string
 }
 
-const ProcessingPlaceholder: FC<ProcessingPlaceholderProps> = () => {
-  return <div />
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
+
+const ProcessingPlaceholder: FC<ProcessingPlaceholderProps> = ({
+  aspectRatio,
+  caption = 'Processing image…',
+  className = '',
+}) => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+
+    const mediaQueryList = window.matchMedia(REDUCED_MOTION_QUERY)
+    setPrefersReducedMotion(mediaQueryList.matches)
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches)
+    }
+
+    mediaQueryList.addEventListener('change', handleChange)
+    return () => {
+      mediaQueryList.removeEventListener('change', handleChange)
+    }
+  }, [])
+
+  const rootClassName = [
+    styles.root,
+    prefersReducedMotion ? styles.reducedMotion : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <figure
+      className={rootClassName}
+      style={{ aspectRatio: aspectRatio ?? undefined }}
+    >
+      <div
+        className={styles.inner}
+        style={{ aspectRatio: aspectRatio ?? undefined }}
+      >
+        <div className={styles.overlay} aria-hidden="true" />
+      </div>
+      <figcaption className={styles.caption}>{caption}</figcaption>
+    </figure>
+  )
 }
 
 export default ProcessingPlaceholder

--- a/src/components/ProcessingPlaceholder/ProcessingPlaceholder.tsx
+++ b/src/components/ProcessingPlaceholder/ProcessingPlaceholder.tsx
@@ -1,0 +1,13 @@
+import type { FC } from 'react'
+
+export interface ProcessingPlaceholderProps {
+  aspectRatio?: string
+  caption?: string
+  className?: string
+}
+
+const ProcessingPlaceholder: FC<ProcessingPlaceholderProps> = () => {
+  return <div />
+}
+
+export default ProcessingPlaceholder

--- a/src/components/ProcessingPlaceholder/ProcessingPlaceholder.tsx
+++ b/src/components/ProcessingPlaceholder/ProcessingPlaceholder.tsx
@@ -41,10 +41,7 @@ const ProcessingPlaceholder: FC<ProcessingPlaceholderProps> = ({
     .join(' ')
 
   return (
-    <figure
-      className={rootClassName}
-      style={{ aspectRatio: aspectRatio ?? undefined }}
-    >
+    <figure className={rootClassName}>
       <div
         className={styles.inner}
         style={{ aspectRatio: aspectRatio ?? undefined }}

--- a/src/components/ProcessingPlaceholder/index.ts
+++ b/src/components/ProcessingPlaceholder/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ProcessingPlaceholder'


### PR DESCRIPTION
Closes #169

## What changed
- New `src/components/ProcessingPlaceholder/` — `<figure>` + `<figcaption>` skeleton shown in place of an image while its processed variants are not yet available.
- Default caption "Processing image…" (U+2026), overrideable via `caption` prop. Accepts optional `aspectRatio` and `className`.
- Pulsing overlay animates `opacity` at 1.6s ease-in-out. `prefers-reduced-motion: reduce` swaps to a static muted background via a JS-driven class toggle (listens to `matchMedia` change events) with a CSS `@media` fallback for pre-hydration.
- 7 tests covering default and overridden caption, `aria-live` absence (PRD's no-chatter rule), `className` forwarding, `aspectRatio` inline style, and the reduced-motion class switch.

## Why
The editor, preview, step images, and card thumbnails all need a consistent "image is processing" treatment that tolerates missing processed variants without rendering a broken `<img>` or a 404. Factoring it out keeps `<Image>` focused on actual image rendering and gives every surface a single component to swap in.

## How to verify
- `pnpm test src/components/ProcessingPlaceholder/` — 7/7 green.
- `pnpm test` — full suite 569/569 green.
- `pnpm lint` — 0 errors.

## Decisions made
- **Sibling to `<Image>`, not a variant.** Keeps `<Image>` focused; callers pick the right component based on readiness.
- **`<figure>` + `<figcaption>` structure mirroring `<Image>`.** The figcaption sits outside the aspect-ratio'd inner container so the caption never gets squashed into the ratio box.
- **JS-driven reduced-motion class toggle, with a CSS `@media` fallback.** Belt-and-braces: tests assert the class (driven by `matchMedia`), and the media-query rule covers pre-hydration / JS-disabled.
- **No `aria-live` anywhere on the component.** The editor routes the single "Image ready" announcement through its page-level live region — per-placeholder `aria-live` would cause chatter when multiple step images process concurrently.
- **Inlined `matchMedia` listener, did not extract a `usePrefersReducedMotion` hook.** Single call site across the codebase; all other `prefers-reduced-motion` usage is CSS-only.