### PR TITLE
Thread processedAt through ImageUpload and StepList

### DIFF
--- a/src/components/ImageUpload/ImageUpload.test.tsx
+++ b/src/components/ImageUpload/ImageUpload.test.tsx
@@ -213,10 +213,7 @@ describe('ImageUpload', () => {
         />
       )
 
-      // The ProcessingPlaceholder renders its caption text.
       expect(screen.getByText(/processing image/i)).toBeInTheDocument()
-
-      // The processed <img> should NOT be in the document — we're still processing.
       expect(screen.queryByRole('img')).not.toBeInTheDocument()
     })
 
@@ -235,8 +232,6 @@ describe('ImageUpload', () => {
       const image = screen.getByRole('img')
       expect(image).toBeInTheDocument()
       expect(image).toHaveAttribute('alt', 'A tasty dish')
-
-      // Processing placeholder is not shown once processedAt is set.
       expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
     })
 
@@ -265,7 +260,6 @@ describe('ImageUpload', () => {
         expect(preview).toHaveAttribute('src', 'blob:http://localhost/fake-preview')
       })
 
-      // Processing placeholder must not render when a blob preview is active.
       expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
     })
   })

--- a/src/components/ImageUpload/ImageUpload.test.tsx
+++ b/src/components/ImageUpload/ImageUpload.test.tsx
@@ -201,4 +201,72 @@ describe('ImageUpload', () => {
     // becomes optional again, TypeScript will fail this file's compilation.
     expect(true).toBe(true)
   })
+
+  describe('render branches (preview / processing / ready)', () => {
+    it('renders the processing placeholder when currentKey is set but processedAt is not', () => {
+      render(
+        <ImageUpload
+          onUpload={mockOnUpload}
+          getToken={mockGetToken}
+          recipeId="test-recipe-id"
+          currentKey="img/x.jpg"
+        />
+      )
+
+      // The ProcessingPlaceholder renders its caption text.
+      expect(screen.getByText(/processing image/i)).toBeInTheDocument()
+
+      // The processed <img> should NOT be in the document — we're still processing.
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    })
+
+    it('renders the ready image when currentKey and processedAt are both set', () => {
+      render(
+        <ImageUpload
+          onUpload={mockOnUpload}
+          getToken={mockGetToken}
+          recipeId="test-recipe-id"
+          currentKey="img/x.jpg"
+          currentAlt="A tasty dish"
+          processedAt={1234567890}
+        />
+      )
+
+      const image = screen.getByRole('img')
+      expect(image).toBeInTheDocument()
+      expect(image).toHaveAttribute('alt', 'A tasty dish')
+
+      // Processing placeholder is not shown once processedAt is set.
+      expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
+    })
+
+    it('shows the blob preview even when processedAt is set (blob preview wins)', async () => {
+      mockGetUploadUrl.mockResolvedValue({ uploadUrl: 'https://s3.example.com/upload', key: 'img/123.jpg' })
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 200 }))
+
+      render(
+        <ImageUpload
+          onUpload={mockOnUpload}
+          getToken={mockGetToken}
+          recipeId="test-recipe-id"
+          currentKey="img/existing.jpg"
+          processedAt={1234567890}
+        />
+      )
+
+      const file = new File(['x'], 'photo.png', { type: 'image/png' })
+      Object.defineProperty(file, 'size', { value: 1024 })
+
+      const input = screen.getByLabelText(/upload/i)
+      fireEvent.change(input, { target: { files: [file] } })
+
+      await waitFor(() => {
+        const preview = screen.getByRole('img')
+        expect(preview).toHaveAttribute('src', 'blob:http://localhost/fake-preview')
+      })
+
+      // Processing placeholder must not render when a blob preview is active.
+      expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -90,6 +90,32 @@ const ImageUpload: FC<ImageUploadProps> = ({
     if (lastFile) upload(lastFile)
   }
 
+  const renderPreview = () => {
+    if (preview) {
+      return (
+        <Image
+          key="preview"
+          src={preview}
+          alt="Upload preview"
+          className={styles.preview}
+          lazy={false}
+        />
+      )
+    }
+    if (!currentKey) return null
+    if (processedAt) {
+      return (
+        <Image
+          key="processed"
+          src={recipeImageUrl(currentKey, 'medium')}
+          alt={currentAlt ?? 'Current image'}
+          className={styles.preview}
+        />
+      )
+    }
+    return <ProcessingPlaceholder />
+  }
+
   return (
     <div className={styles.container}>
       <input
@@ -102,24 +128,7 @@ const ImageUpload: FC<ImageUploadProps> = ({
         aria-label="Upload image"
       />
 
-      {preview ? (
-        <Image
-          key="preview"
-          src={preview}
-          alt="Upload preview"
-          className={styles.preview}
-          lazy={false}
-        />
-      ) : currentKey && processedAt ? (
-        <Image
-          key="processed"
-          src={recipeImageUrl(currentKey, 'medium')}
-          alt={currentAlt ?? 'Current image'}
-          className={styles.preview}
-        />
-      ) : currentKey ? (
-        <ProcessingPlaceholder />
-      ) : null}
+      {renderPreview()}
 
       {error && (
         <div className={styles.error} role="alert">

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -2,6 +2,7 @@
 import { getUploadUrl } from '@api/recipes'
 import Button from '@components/Button'
 import Image from '@components/Image'
+import ProcessingPlaceholder from '@components/ProcessingPlaceholder'
 import { recipeImageUrl } from '@models/recipe'
 import { useEffect, useId, useRef, useState, type ChangeEvent, type FC } from 'react'
 
@@ -11,6 +12,7 @@ export interface ImageUploadProps {
   onUpload: (key: string) => void
   currentKey?: string
   currentAlt?: string
+  processedAt?: number
   getToken: () => Promise<string>
   recipeId: string
   imageType?: 'cover' | 'step'
@@ -23,6 +25,7 @@ const ImageUpload: FC<ImageUploadProps> = ({
   onUpload,
   currentKey,
   currentAlt,
+  processedAt,
   getToken,
   recipeId,
   imageType = 'cover',
@@ -100,13 +103,22 @@ const ImageUpload: FC<ImageUploadProps> = ({
       />
 
       {preview ? (
-        <Image src={preview} alt="Upload preview" className={styles.preview} lazy={false} />
-      ) : currentKey ? (
         <Image
+          key="preview"
+          src={preview}
+          alt="Upload preview"
+          className={styles.preview}
+          lazy={false}
+        />
+      ) : currentKey && processedAt ? (
+        <Image
+          key="processed"
           src={recipeImageUrl(currentKey, 'medium')}
           alt={currentAlt ?? 'Current image'}
           className={styles.preview}
         />
+      ) : currentKey ? (
+        <ProcessingPlaceholder />
       ) : null}
 
       {error && (

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -105,6 +105,45 @@ describe('StepList', () => {
       expect(screen.queryByLabelText('Step 1 image alt text')).not.toBeInTheDocument()
     })
 
+    it('passes processedAt through to per-step ImageUpload so the correct render branch shows', () => {
+      const onChange = vi.fn()
+      const unreadyStep: Step = {
+        order: 1,
+        text: 'Stir',
+        image: { key: 'img/step.jpg', alt: 'x' },
+      }
+      const { rerender } = render(
+        <StepList
+          steps={[unreadyStep]}
+          onChange={onChange}
+          getToken={mockGetToken}
+          recipeId="test-recipe-id"
+        />
+      )
+
+      // Unready step: processing placeholder shown, no rendered <img>.
+      expect(screen.getByText(/processing image/i)).toBeInTheDocument()
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
+
+      const readyStep: Step = {
+        order: 1,
+        text: 'Stir',
+        image: { key: 'img/step.jpg', alt: 'x', processedAt: 12345 },
+      }
+      rerender(
+        <StepList
+          steps={[readyStep]}
+          onChange={onChange}
+          getToken={mockGetToken}
+          recipeId="test-recipe-id"
+        />
+      )
+
+      // Ready step: the <img> renders, placeholder gone.
+      expect(screen.getByRole('img')).toBeInTheDocument()
+      expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
+    })
+
     it('typing in the alt-text input calls onChange with the updated step', async () => {
       const user = userEvent.setup()
       const onChange = vi.fn()

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -121,7 +121,6 @@ describe('StepList', () => {
         />
       )
 
-      // Unready step: processing placeholder shown, no rendered <img>.
       expect(screen.getByText(/processing image/i)).toBeInTheDocument()
       expect(screen.queryByRole('img')).not.toBeInTheDocument()
 
@@ -139,7 +138,6 @@ describe('StepList', () => {
         />
       )
 
-      // Ready step: the <img> renders, placeholder gone.
       expect(screen.getByRole('img')).toBeInTheDocument()
       expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
     })

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -76,6 +76,7 @@ const StepList: FC<StepListProps> = ({ steps, onChange, recipeId, getToken, onAn
                   stepOrder={index + 1}
                   currentKey={step.image?.key}
                   currentAlt={step.image?.alt}
+                  processedAt={step.image?.processedAt}
                   getToken={getToken}
                   onUpload={(key) => updateImage(index, { key })}
                 />


### PR DESCRIPTION
Closes #170

## What changed
- `ImageUpload` accepts an optional `processedAt?: number` prop. Render is split across three branches: blob preview wins if a file is picked; otherwise `currentKey && processedAt` renders the processed `<Image>`; otherwise `currentKey` alone renders `<ProcessingPlaceholder>`.
- `StepList` threads `step.image?.processedAt` through to each per-step `<ImageUpload>`, so step images honour the same branch.
- Tests cover all three branches on `ImageUpload` and the processing→ready transition on `StepList`.

## Why
Part of the **Image Processing Readiness — Frontend** milestone (PRD: `docs/prds/image-processing-readiness.md`). Prepares the upload component for the polling and readiness wiring in issue #172 — unblocks that by making the render branch honour `processedAt` on the prop contract.

## How to verify
- `pnpm test --run src/components/ImageUpload/ImageUpload.test.tsx src/components/StepList/StepList.test.tsx` → 27/27 pass.
- `pnpm test` → 573/573 across the full suite.
- `pnpm lint` → 0 errors (5 pre-existing warnings untouched).

## Decisions made
- The ready-image and blob-preview `<Image>` instances carry distinct `key` props (`"preview"` and `"processed"`). `src/components/Image/Image.tsx` initialises its internal `currentSrc` via `useState(src)` and never re-syncs on prop change, so without distinct keys React would reuse the same `<img>` DOM node across the processing → preview transition and the `src` attribute would stick to the stale processed URL. Forcing a remount is the minimal local fix; the underlying `Image` defect would benefit from a dedicated follow-up issue (separate from the readiness work).
- The three-way render is extracted into a `renderPreview()` helper with early returns rather than left as a nested ternary, from the `/simplify` pass.
- `ProcessingPlaceholder` is rendered without `aria-live`; announcements are routed through the page-level live region in `RecipeEditor` (issue #172), per PRD.