### PR TITLE
Wire RecipeEditor to polling, reducer, and publish guard

### DIFF
--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -119,3 +119,16 @@
   color: var(--color-text);
   box-shadow: var(--shadow-sm);
 }
+
+.timeoutBanner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+  padding: var(--space-4);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-none);
+  background: var(--color-warning, var(--color-surface));
+  color: var(--color-text);
+  box-shadow: var(--shadow-sm);
+}

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -18,7 +18,7 @@ import type { Recipe } from '@models/recipe'
 import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent, { type UserEvent } from '@testing-library/user-event'
 import { createMemoryRouter, Link, RouterProvider } from 'react-router-dom'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 
 import RecipeEditor from './RecipeEditor'
 
@@ -50,8 +50,8 @@ interface AutosaveMockControls {
   triggerSuccess: () => Promise<void>
   reset: () => void
   hookResult: UseAutosaveResult
-  retryMock: ReturnType<typeof vi.fn>
-  flushMock: ReturnType<typeof vi.fn>
+  retryMock: Mock<() => void>
+  flushMock: Mock<() => Promise<void>>
   callCount: number
 }
 

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -10,8 +10,12 @@ import {
 } from '@api/recipes'
 import { useAuth } from '@contexts/AuthContext'
 import { useAutosave, type AutosaveStatus, type UseAutosaveResult } from '@hooks/useAutosave'
+import type {
+  ImageReadyUpdate,
+  UseImageProcessingPollResult,
+} from '@hooks/useImageProcessingPoll'
 import type { Recipe } from '@models/recipe'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent, { type UserEvent } from '@testing-library/user-event'
 import { createMemoryRouter, Link, RouterProvider } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -96,6 +100,65 @@ vi.mock('@hooks/useAutosave', async (importOriginal) => {
   }
 })
 
+// Spy on useImageProcessingPoll so tests can:
+// - capture the onReady callback and invoke it to simulate a ready image
+// - toggle `timedOut` to assert the timeout banner
+// The real hook talks to the network and to auth/navigation — a mock is the
+// only boundary that keeps the editor tests pure DOM + reducer assertions.
+interface PollMockControls {
+  lastArgs: {
+    recipe: Recipe | null
+    onReady: ((updates: ImageReadyUpdate[]) => void) | null
+  }
+  callCount: number
+  setTimedOut: (next: boolean) => void
+  triggerReady: (updates: ImageReadyUpdate[]) => void
+  reset: () => void
+}
+
+const pollControls: PollMockControls = {
+  lastArgs: { recipe: null, onReady: null },
+  callCount: 0,
+  setTimedOut: () => {},
+  triggerReady: () => {},
+  reset: () => {},
+}
+
+vi.mock('@hooks/useImageProcessingPoll', async () => {
+  const { useState, useRef } = await import('react')
+
+  const useImageProcessingPollMock = (
+    recipe: Recipe | null,
+    onReady: (updates: ImageReadyUpdate[]) => void
+  ): UseImageProcessingPollResult => {
+    pollControls.callCount += 1
+    pollControls.lastArgs = { recipe, onReady }
+
+    const [timedOut, setTimedOut] = useState(false)
+    const setTimedOutRef = useRef(setTimedOut)
+    setTimedOutRef.current = setTimedOut
+    const onReadyRef = useRef(onReady)
+    onReadyRef.current = onReady
+
+    pollControls.setTimedOut = (next: boolean) => {
+      act(() => {
+        setTimedOutRef.current(next)
+      })
+    }
+    pollControls.triggerReady = (updates: ImageReadyUpdate[]) => {
+      act(() => {
+        onReadyRef.current(updates)
+      })
+    }
+
+    return { timedOut }
+  }
+
+  return {
+    useImageProcessingPoll: useImageProcessingPollMock,
+  }
+})
+
 // ImageUpload is replaced with a stub so we can assert on the prop passed
 // (and trigger onUpload without a real file input).
 interface ImageUploadStubProps {
@@ -124,6 +187,12 @@ vi.mock('@components/ImageUpload', () => ({
 const fillValidCoverImage = async (user: UserEvent) => {
   await user.click(screen.getByRole('button', { name: /simulate upload cover image/i }))
   await user.type(screen.getByLabelText(/cover image alt text/i), 'Cover alt text')
+  // Simulate the image processing poll detecting the uploaded cover as ready.
+  // Without this, the publish gate would consider the cover image "still
+  // processing" (key set, processedAt absent) and Publish stays disabled.
+  pollControls.triggerReady([
+    { key: 'recipes/test/cover-stub', processedAt: 1_700_000_000_000 },
+  ])
 }
 
 const fillAllRequired = async (user: UserEvent) => {
@@ -138,7 +207,14 @@ const draftRecipe: Recipe = {
   id: 'rec-001',
   title: 'Spaghetti Bolognese',
   slug: 'spaghetti-bolognese',
-  coverImage: { key: 'recipes/rec-001/cover', alt: 'Spaghetti bolognese' },
+  coverImage: {
+    key: 'recipes/rec-001/cover',
+    alt: 'Spaghetti bolognese',
+    // Readiness is defaulted to "already processed" for the shared fixture so
+    // existing tests continue to exercise the ready-branch of the publish
+    // gate. Tests that need the unready branch override coverImage explicitly.
+    processedAt: 1_700_000_000_000,
+  },
   tags: ['Italian', 'Pasta'],
   prepTime: 15,
   cookTime: 45,
@@ -180,6 +256,10 @@ describe('RecipeEditor page', () => {
       retry: autosaveControls.retryMock,
       flush: autosaveControls.flushMock,
     }
+    pollControls.lastArgs = { recipe: null, onReady: null }
+    pollControls.callCount = 0
+    pollControls.setTimedOut = () => {}
+    pollControls.triggerReady = () => {}
 
     vi.mocked(useAuth).mockReturnValue({
       getAccessToken: vi.fn().mockResolvedValue('token-123'),
@@ -899,6 +979,237 @@ describe('RecipeEditor page', () => {
       })
 
       expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+    })
+  })
+
+  describe('image processing readiness', () => {
+    // A recipe whose cover image has been uploaded (key present) but not yet
+    // processed by the resizer Lambda (processedAt absent). All other fields
+    // are valid so only the readiness gate keeps Publish disabled.
+    const recipeWithUnreadyCover: Recipe = {
+      ...draftRecipe,
+      coverImage: { key: 'recipes/rec-001/cover', alt: 'Spaghetti bolognese' },
+    }
+
+    // A recipe where the cover is ready but a step image is still processing.
+    const recipeWithUnreadyStepImage: Recipe = {
+      ...draftRecipe,
+      steps: [
+        {
+          order: 1,
+          text: 'Boil pasta',
+          image: { key: 'recipes/rec-001/step-1', alt: 'Boiling pasta' },
+        },
+      ],
+    }
+
+    // A recipe where every image is ready — cover and step.
+    const recipeFullyReady: Recipe = {
+      ...draftRecipe,
+      steps: [
+        {
+          order: 1,
+          text: 'Boil pasta',
+          image: {
+            key: 'recipes/rec-001/step-1',
+            alt: 'Boiling pasta',
+            processedAt: 1_700_000_000_000,
+          },
+        },
+      ],
+    }
+
+    it('disables Publish when the cover image has a key but no processedAt (AC 6, 7)', async () => {
+      vi.mocked(fetchMyRecipes).mockResolvedValue([recipeWithUnreadyCover])
+      vi.mocked(fetchAllRecipes).mockResolvedValue([recipeWithUnreadyCover])
+
+      renderEditor('/admin/recipes/rec-001/edit')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+      })
+
+      const publishButton = screen.getByRole('button', { name: /^publish$/i })
+      expect(publishButton).toBeDisabled()
+
+      const describedBy = publishButton.getAttribute('aria-describedby')
+      expect(describedBy).toBeTruthy()
+      const missingList = document.getElementById(describedBy as string)
+      expect(missingList).not.toBeNull()
+      expect(missingList?.textContent ?? '').toMatch(/cover image still processing/i)
+    })
+
+    it('disables Publish when a step image has a key but no processedAt (AC 6, 7)', async () => {
+      vi.mocked(fetchMyRecipes).mockResolvedValue([recipeWithUnreadyStepImage])
+      vi.mocked(fetchAllRecipes).mockResolvedValue([recipeWithUnreadyStepImage])
+
+      renderEditor('/admin/recipes/rec-001/edit')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+      })
+
+      const publishButton = screen.getByRole('button', { name: /^publish$/i })
+      expect(publishButton).toBeDisabled()
+
+      const describedBy = publishButton.getAttribute('aria-describedby')
+      const missingList = document.getElementById(describedBy as string)
+      expect(missingList?.textContent ?? '').toMatch(/step 1 image still processing/i)
+    })
+
+    it('enables Publish once every image on the loaded recipe has processedAt (AC 1, 3)', async () => {
+      // Recipe loaded with cover + step image both carrying processedAt.
+      // If recipeToFormState does not hydrate processedAt, the gate will
+      // misidentify the images as unready and Publish will stay disabled.
+      vi.mocked(fetchMyRecipes).mockResolvedValue([recipeFullyReady])
+      vi.mocked(fetchAllRecipes).mockResolvedValue([recipeFullyReady])
+
+      renderEditor('/admin/recipes/rec-001/edit')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+      })
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /^publish$/i })).not.toBeDisabled()
+      })
+    })
+
+    it('flips the publish gate when onReady reports the matching key is ready (AC 4, 1, 5)', async () => {
+      vi.mocked(fetchMyRecipes).mockResolvedValue([recipeWithUnreadyCover])
+      vi.mocked(fetchAllRecipes).mockResolvedValue([recipeWithUnreadyCover])
+
+      renderEditor('/admin/recipes/rec-001/edit')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+      })
+
+      const publishButton = screen.getByRole('button', { name: /^publish$/i })
+      expect(publishButton).toBeDisabled()
+
+      // Simulate the poll hook finding the cover image is ready.
+      pollControls.triggerReady([
+        { key: 'recipes/rec-001/cover', processedAt: 1_700_000_500_000 },
+      ])
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /^publish$/i })).not.toBeDisabled()
+      })
+
+      // The missing-fields list should no longer mention the cover image.
+      const describedBy = screen
+        .getByRole('button', { name: /^publish$/i })
+        .getAttribute('aria-describedby')
+      if (describedBy) {
+        const missingList = document.getElementById(describedBy)
+        expect(missingList?.textContent ?? '').not.toMatch(/cover image still processing/i)
+      }
+
+      // The editor should have announced "Image ready" via the page-level
+      // aria-live="polite" region.
+      await waitFor(() => {
+        const statusRegions = screen.getAllByRole('status')
+        const match = statusRegions.find(
+          (region) =>
+            region.getAttribute('aria-live') === 'polite' &&
+            /image ready/i.test(region.textContent ?? '')
+        )
+        expect(match).toBeDefined()
+      })
+    })
+
+    it('ignores IMAGE_STATUS_UPDATE entries whose keys do not match any image on the form (AC 1)', async () => {
+      vi.mocked(fetchMyRecipes).mockResolvedValue([recipeWithUnreadyCover])
+      vi.mocked(fetchAllRecipes).mockResolvedValue([recipeWithUnreadyCover])
+
+      renderEditor('/admin/recipes/rec-001/edit')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+      })
+
+      expect(screen.getByRole('button', { name: /^publish$/i })).toBeDisabled()
+
+      // Readiness update for a key that does not exist on the form.
+      pollControls.triggerReady([
+        { key: 'recipes/rec-001/some-other-key', processedAt: 1_700_000_500_000 },
+      ])
+
+      // A micro-task flush to let any reducer dispatch settle.
+      await Promise.resolve()
+
+      // Cover image still has no processedAt → Publish must remain disabled,
+      // and the missing-fields list must still include the cover reason.
+      const publishButton = screen.getByRole('button', { name: /^publish$/i })
+      expect(publishButton).toBeDisabled()
+      const describedBy = publishButton.getAttribute('aria-describedby')
+      const missingList = document.getElementById(describedBy as string)
+      expect(missingList?.textContent ?? '').toMatch(/cover image still processing/i)
+    })
+
+    it('does not mark the form dirty on IMAGE_STATUS_UPDATE (AC 2)', async () => {
+      vi.mocked(fetchMyRecipes).mockResolvedValue([recipeWithUnreadyCover])
+      vi.mocked(fetchAllRecipes).mockResolvedValue([recipeWithUnreadyCover])
+
+      renderEditor('/admin/recipes/rec-001/edit')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+      })
+
+      // After the recipe has loaded, the form is pristine.
+      await waitFor(() => {
+        expect(autosaveControls.lastArgs.state?.dirty).toBe(false)
+      })
+
+      // Fire a readiness update.
+      pollControls.triggerReady([
+        { key: 'recipes/rec-001/cover', processedAt: 1_700_000_500_000 },
+      ])
+
+      // The most recent autosave snapshot must still have dirty === false —
+      // otherwise useAutosave's dirty-gate would fire a PATCH for a
+      // server-originated readiness change, which is wrong.
+      await waitFor(() => {
+        expect(autosaveControls.lastArgs.state?.dirty).toBe(false)
+      })
+    })
+
+    it('renders the timeout banner when the poll hook reports timedOut: true (AC 8)', async () => {
+      vi.mocked(fetchMyRecipes).mockResolvedValue([recipeWithUnreadyCover])
+      vi.mocked(fetchAllRecipes).mockResolvedValue([recipeWithUnreadyCover])
+
+      renderEditor('/admin/recipes/rec-001/edit')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+      })
+
+      // Banner must not be present yet.
+      expect(
+        screen.queryByText(/processing is taking longer than expected/i)
+      ).not.toBeInTheDocument()
+
+      // Flip the hook into the timed-out state.
+      pollControls.setTimedOut(true)
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /processing is taking longer than expected — try refreshing the page\./i
+          )
+        ).toBeInTheDocument()
+      })
+
+      // The banner must be exposed via role="status" + aria-live="polite".
+      const statusRegions = screen.getAllByRole('status')
+      const banner = statusRegions.find(
+        (region) =>
+          region.getAttribute('aria-live') === 'polite' &&
+          /processing is taking longer than expected/i.test(region.textContent ?? '')
+      )
+      expect(banner).toBeDefined()
     })
   })
 })

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -106,29 +106,25 @@ const applyImageStatusUpdates = (
   state: FormState,
   updates: { key: string; processedAt: number }[]
 ): FormState => {
-  let coverImageProcessedAt = state.coverImageProcessedAt
-  let steps = state.steps
-  let stepsChanged = false
+  const byKey = new Map(updates.filter((u) => u.key).map((u) => [u.key, u.processedAt]))
+  if (byKey.size === 0) return state
 
-  for (const { key, processedAt } of updates) {
-    if (key && key === state.coverImageKey) {
-      coverImageProcessedAt = processedAt
-    }
-    const nextSteps = steps.map((step) => {
-      if (step.image?.key && step.image.key === key) {
-        stepsChanged = true
-        return { ...step, image: { ...step.image, processedAt } }
-      }
-      return step
-    })
-    steps = nextSteps
-  }
+  const coverUpdate = byKey.get(state.coverImageKey)
+  const coverImageProcessedAt = coverUpdate ?? state.coverImageProcessedAt
+
+  let stepsChanged = false
+  const steps = state.steps.map((step) => {
+    const stepUpdate = step.image?.key ? byKey.get(step.image.key) : undefined
+    if (stepUpdate === undefined) return step
+    stepsChanged = true
+    return { ...step, image: { ...step.image!, processedAt: stepUpdate } }
+  })
 
   if (coverImageProcessedAt === state.coverImageProcessedAt && !stepsChanged) {
     return state
   }
 
-  return { ...state, coverImageProcessedAt, steps }
+  return { ...state, coverImageProcessedAt, steps: stepsChanged ? steps : state.steps }
 }
 
 const formReducer = (state: FormState, action: FormAction): FormState => {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -21,8 +21,9 @@ import TagInput from '@components/TagInput'
 import Toast from '@components/Toast'
 import { useAuth } from '@contexts/AuthContext'
 import { useAutosave } from '@hooks/useAutosave'
+import { useImageProcessingPoll } from '@hooks/useImageProcessingPoll'
 import type { Ingredient, Recipe, Step, Tag } from '@models/recipe'
-import { useCallback, useEffect, useReducer, useRef, useState, type FC } from 'react'
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type FC } from 'react'
 import { useBlocker, useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import styles from './RecipeEditor.module.css'
@@ -42,17 +43,22 @@ interface FormState {
   steps: Step[]
   coverImageKey: string
   coverImageAlt: string
+  coverImageProcessedAt?: number
   mode: EditorMode
   dirty: boolean
 }
 
-type SettableField = Exclude<keyof FormState, 'dirty' | 'mode' | 'id' | 'slug'>
+type SettableField = Exclude<
+  keyof FormState,
+  'dirty' | 'mode' | 'id' | 'slug' | 'coverImageProcessedAt'
+>
 
 type FormAction =
   | { type: 'SET_FIELD'; field: SettableField; value: FormState[SettableField] }
   | { type: 'LOAD_RECIPE'; recipe: Recipe }
   | { type: 'MARK_PRISTINE' }
   | { type: 'SET_MODE'; mode: EditorMode }
+  | { type: 'IMAGE_STATUS_UPDATE'; updates: { key: string; processedAt: number }[] }
 
 const MISSING_FIELDS_ID = 'publish-missing-fields'
 
@@ -69,6 +75,7 @@ const initialFormState: FormState = {
   steps: [{ order: 1, text: '' }],
   coverImageKey: '',
   coverImageAlt: '',
+  coverImageProcessedAt: undefined,
   mode: 'draft',
   dirty: false,
 }
@@ -89,9 +96,39 @@ const recipeToFormState = (recipe: Recipe): FormState => {
     steps: steps.length > 0 ? steps : [{ order: 1, text: '' }],
     coverImageKey: recipe.coverImage?.key ?? '',
     coverImageAlt: recipe.coverImage?.alt ?? '',
+    coverImageProcessedAt: recipe.coverImage?.processedAt,
     mode: recipe.status,
     dirty: false,
   }
+}
+
+const applyImageStatusUpdates = (
+  state: FormState,
+  updates: { key: string; processedAt: number }[]
+): FormState => {
+  let coverImageProcessedAt = state.coverImageProcessedAt
+  let steps = state.steps
+  let stepsChanged = false
+
+  for (const { key, processedAt } of updates) {
+    if (key && key === state.coverImageKey) {
+      coverImageProcessedAt = processedAt
+    }
+    const nextSteps = steps.map((step) => {
+      if (step.image?.key && step.image.key === key) {
+        stepsChanged = true
+        return { ...step, image: { ...step.image, processedAt } }
+      }
+      return step
+    })
+    steps = nextSteps
+  }
+
+  if (coverImageProcessedAt === state.coverImageProcessedAt && !stepsChanged) {
+    return state
+  }
+
+  return { ...state, coverImageProcessedAt, steps }
 }
 
 const formReducer = (state: FormState, action: FormAction): FormState => {
@@ -104,6 +141,8 @@ const formReducer = (state: FormState, action: FormAction): FormState => {
       return { ...state, dirty: false }
     case 'SET_MODE':
       return { ...state, mode: action.mode }
+    case 'IMAGE_STATUS_UPDATE':
+      return applyImageStatusUpdates(state, action.updates)
   }
 }
 
@@ -128,6 +167,14 @@ const computeMissingFields = (form: FormState): string[] => {
   if (!form.coverImageAlt.trim()) missing.push('Cover image alt text')
   if (!form.ingredients.some((ing) => ing.item.trim())) missing.push('At least one ingredient')
   if (!form.steps.some((s) => s.text.trim())) missing.push('At least one step')
+  if (form.coverImageKey && !form.coverImageProcessedAt) {
+    missing.push('Cover image still processing')
+  }
+  form.steps.forEach((step, index) => {
+    if (step.image?.key && !step.image.processedAt) {
+      missing.push(`Step ${index + 1} image still processing`)
+    }
+  })
   return missing
 }
 
@@ -279,6 +326,48 @@ const RecipeEditor: FC = () => {
     }
   }, [autosaveStatus, lastSavedAt])
 
+  const announce = useCallback((message: string) => {
+    setAnnouncement((prev) => ({ message, toggle: !prev.toggle }))
+  }, [])
+
+  // `useImageProcessingPoll` only reads `id`, `coverImage`, and `steps` off the
+  // recipe it receives. Memoising over those fields keeps polling stable across
+  // unrelated form edits (title, ingredients, etc.) — which would otherwise
+  // rebuild the object on every keystroke and churn the hook's effect.
+  const loadedRecipe = useMemo<Recipe | null>(() => {
+    if (!form.id) return null
+    return {
+      id: form.id,
+      slug: form.slug,
+      title: form.title,
+      intro: form.intro,
+      prepTime: form.prepTime,
+      cookTime: form.cookTime,
+      servings: form.servings,
+      tags: form.tags,
+      ingredients: form.ingredients,
+      steps: form.steps,
+      coverImage: form.coverImageKey
+        ? {
+            key: form.coverImageKey,
+            alt: form.coverImageAlt,
+            processedAt: form.coverImageProcessedAt,
+          }
+        : { key: '', alt: '' },
+      authorId: '',
+      authorName: '',
+      createdAt: '',
+      updatedAt: '',
+      status: form.mode,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form.id, form.coverImageKey, form.coverImageAlt, form.coverImageProcessedAt, form.steps])
+
+  const { timedOut } = useImageProcessingPoll(loadedRecipe, (updates) => {
+    dispatch({ type: 'IMAGE_STATUS_UPDATE', updates })
+    announce('Image ready')
+  })
+
   const missingFields = computeMissingFields(form)
   const canPublish = missingFields.length === 0
 
@@ -355,10 +444,6 @@ const RecipeEditor: FC = () => {
     setToast(null)
   }, [])
 
-  const announce = useCallback((message: string) => {
-    setAnnouncement((prev) => ({ message, toggle: !prev.toggle }))
-  }, [])
-
   const setIngredients = useCallback((next: Ingredient[]) => setField('ingredients', next), [setField])
   const setSteps = useCallback((next: Step[]) => setField('steps', next), [setField])
   const setTags = useCallback((next: string[]) => setField('tags', next), [setField])
@@ -383,6 +468,12 @@ const RecipeEditor: FC = () => {
         <div className={styles.sessionBanner} role="alert">
           <span>Session expired — please log in again</span>
           <Link to={loginHref}>Log in again</Link>
+        </div>
+      )}
+
+      {timedOut && (
+        <div role="status" aria-live="polite" className={styles.timeoutBanner}>
+          Processing is taking longer than expected — try refreshing the page.
         </div>
       )}
 
@@ -433,6 +524,7 @@ const RecipeEditor: FC = () => {
                 onUpload={setCoverImageKey}
                 currentKey={form.coverImageKey || undefined}
                 currentAlt={form.coverImageAlt || undefined}
+                processedAt={form.coverImageProcessedAt}
                 getToken={getAccessToken}
                 recipeId={recipeId}
               />


### PR DESCRIPTION
Closes #172

## What changed
- `FormState` gains `coverImageProcessedAt?: number`; new `IMAGE_STATUS_UPDATE` action merges `{ key, processedAt }[]` by matching each key against `form.coverImageKey` and each `step.image?.key`, ignoring non-matching entries. The action does not mark the form dirty, so autosave's existing dirty-gate keeps it from firing a spurious PATCH.
- `recipeToFormState` hydrates `coverImageProcessedAt` on load; step images carry `processedAt` through unchanged.
- The editor memoises a minimal `loadedRecipe` projection and feeds it to `useImageProcessingPoll`. The hook's `onReady` callback dispatches the reducer and calls the existing `announce('Image ready')` helper once per transition.
- `computeMissingFields` adds "Cover image still processing" and per-step "Step N image still processing" reasons; the Publish button stays disabled via the existing `!canPublish` gate and the reasons surface in the existing `aria-describedby` missing-fields `<ul>`.
- A `role="status"` `aria-live="polite"` banner appears at the top of the page when the hook reports `timedOut: true`: "Processing is taking longer than expected — try refreshing the page."
- Cover `<ImageUpload>` now receives `processedAt={form.coverImageProcessedAt}` so the inline ProcessingPlaceholder appears in the editor itself (issue #170 wired this for step images already).

## Why
Part of the **Image Processing Readiness — Frontend** milestone (PRD: `docs/prds/image-processing-readiness.md`). The editor is now the single consumer that drives polling on the admin side — it watches the loaded recipe, dispatches readiness updates back into form state, and blocks publish client-side in sync with the server-side publish guard.

## How to verify
- `pnpm test` → 585/585 pass across 64 files.
- `pnpm lint` → 0 errors (5 pre-existing warnings in untouched files).
- Manual: load a draft whose cover image is mid-processing — Publish is disabled, missing-fields `<ul>` includes "Cover image still processing", placeholder renders inline, and within a few seconds the poll resolves and Publish enables. Force-throttle the network to trigger the 60s banner.

## Decisions made
- `loadedRecipe` is built as a minimal full-`Recipe` via `useMemo` over only the fields the hook actually reads (`id`, `coverImage`, `steps`). An explicit `react-hooks/exhaustive-deps` disable makes it clear that excluding unrelated form fields is intentional — a keystroke in the title shouldn't rebuild the object and churn the hook's effect.
- `applyImageStatusUpdates` uses a single `Map<key, processedAt>` pass so the `steps` array identity only changes when a step image actually matched an update (avoids spurious downstream re-renders on cover-only updates).
- `IMAGE_STATUS_UPDATE` is intentionally excluded from `SettableField` — it can never leak through `SET_FIELD`, only via the dedicated reducer branch.
- `buildPatchPayload` continues to send `coverImage: { key, alt }` — `processedAt` is server-owned per the PRD and must not leak back into a PATCH.
- `fillValidCoverImage` test helper now also fires `pollControls.triggerReady(...)` after the stub upload, modelling the realistic flow (upload → poll resolves → Publish enabled). Prevents the pre-existing Publish-enabled tests from regressing once the gate lands.