### PR TITLE
Switch RecipePreview to single-recipe fetch and polling

### DIFF
--- a/src/pages/admin/RecipePreview/RecipePreview.test.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.test.tsx
@@ -1,7 +1,11 @@
-import { fetchMyRecipes, publishRecipe } from '@api/recipes'
+import { fetchRecipeByIdAdmin, publishRecipe } from '@api/recipes'
 import { useAuth } from '@contexts/AuthContext'
+import type {
+  ImageReadyUpdate,
+  UseImageProcessingPollResult,
+} from '@hooks/useImageProcessingPoll'
 import type { Recipe } from '@models/recipe'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -9,7 +13,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import RecipePreview from './RecipePreview'
 
 vi.mock('@api/recipes', () => ({
-  fetchMyRecipes: vi.fn(),
+  fetchRecipeByIdAdmin: vi.fn(),
   publishRecipe: vi.fn(),
 }))
 
@@ -17,11 +21,75 @@ vi.mock('@contexts/AuthContext', () => ({
   useAuth: vi.fn(),
 }))
 
+// Spy on useImageProcessingPoll so tests can:
+// - capture the onReady callback and invoke it to simulate a ready image
+// - toggle `timedOut` if relevant
+// The real hook talks to the network and to auth/navigation — a mock is the
+// only boundary that keeps the preview tests pure DOM assertions.
+interface PollMockControls {
+  lastArgs: {
+    recipe: Recipe | null
+    onReady: ((updates: ImageReadyUpdate[]) => void) | null
+  }
+  callCount: number
+  setTimedOut: (next: boolean) => void
+  triggerReady: (updates: ImageReadyUpdate[]) => void
+}
+
+const pollControls: PollMockControls = {
+  lastArgs: { recipe: null, onReady: null },
+  callCount: 0,
+  setTimedOut: () => {},
+  triggerReady: () => {},
+}
+
+vi.mock('@hooks/useImageProcessingPoll', async () => {
+  const { useState, useRef } = await import('react')
+
+  const useImageProcessingPollMock = (
+    recipe: Recipe | null,
+    onReady: (updates: ImageReadyUpdate[]) => void
+  ): UseImageProcessingPollResult => {
+    pollControls.callCount += 1
+    pollControls.lastArgs = { recipe, onReady }
+
+    const [timedOut, setTimedOut] = useState(false)
+    const setTimedOutRef = useRef(setTimedOut)
+    setTimedOutRef.current = setTimedOut
+    const onReadyRef = useRef(onReady)
+    onReadyRef.current = onReady
+
+    pollControls.setTimedOut = (next: boolean) => {
+      act(() => {
+        setTimedOutRef.current(next)
+      })
+    }
+    pollControls.triggerReady = (updates: ImageReadyUpdate[]) => {
+      act(() => {
+        onReadyRef.current(updates)
+      })
+    }
+
+    return { timedOut }
+  }
+
+  return {
+    useImageProcessingPoll: useImageProcessingPollMock,
+  }
+})
+
 const mockDraftRecipe: Recipe = {
   id: 'rec-draft',
   title: 'Draft Lemon Tart',
   slug: 'draft-lemon-tart',
-  coverImage: { key: 'recipes/rec-draft/cover', alt: 'Lemon tart cover' },
+  coverImage: {
+    key: 'recipes/rec-draft/cover',
+    alt: 'Lemon tart cover',
+    // Default the shared fixture to "already processed" so the existing
+    // banner / publish-flow tests render the ready branch. Tests that need
+    // the unready branch override coverImage explicitly.
+    processedAt: 1_700_000_000_000,
+  },
   tags: ['Baking', 'Dessert'],
   prepTime: 20,
   cookTime: 35,
@@ -63,6 +131,11 @@ const renderPreview = (id: string) =>
 describe('RecipePreview page', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    pollControls.lastArgs = { recipe: null, onReady: null }
+    pollControls.callCount = 0
+    pollControls.setTimedOut = () => {}
+    pollControls.triggerReady = () => {}
+
     vi.mocked(useAuth).mockReturnValue({
       getAccessToken: vi.fn().mockResolvedValue('token-123'),
       isAdmin: true,
@@ -72,11 +145,8 @@ describe('RecipePreview page', () => {
       login: vi.fn(),
       logout: vi.fn(),
     })
-    vi.mocked(fetchMyRecipes).mockResolvedValue([
-      mockDraftRecipe,
-      mockPublishedRecipe,
-    ])
-    vi.mocked(publishRecipe).mockResolvedValue(undefined)
+    vi.mocked(fetchRecipeByIdAdmin).mockResolvedValue(mockDraftRecipe)
+    vi.mocked(publishRecipe).mockResolvedValue(mockPublishedRecipe)
   })
 
   // AC1 — renders the recipe using the same display components as the public
@@ -139,6 +209,7 @@ describe('RecipePreview page', () => {
   // AC3 — Published recipes show the published banner with Edit and a link
   // to the public page at /recipes/<slug>.
   it('shows the published banner with Edit and a link to the public page for a published recipe', async () => {
+    vi.mocked(fetchRecipeByIdAdmin).mockResolvedValue(mockPublishedRecipe)
     renderPreview('rec-published')
 
     await waitFor(() => {
@@ -165,6 +236,7 @@ describe('RecipePreview page', () => {
   })
 
   it('does not show a Publish button for an already-published recipe', async () => {
+    vi.mocked(fetchRecipeByIdAdmin).mockResolvedValue(mockPublishedRecipe)
     renderPreview('rec-published')
 
     await waitFor(() => {
@@ -178,18 +250,206 @@ describe('RecipePreview page', () => {
 
   // Supporting — loading state while the fetch is pending.
   it('shows a loading indicator while the recipe is being fetched', () => {
-    vi.mocked(fetchMyRecipes).mockReturnValue(new Promise(() => {}))
+    vi.mocked(fetchRecipeByIdAdmin).mockReturnValue(new Promise(() => {}))
     renderPreview('rec-draft')
 
     expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
   })
 
-  // Supporting — not-found path when the id doesn't resolve to an owned recipe.
-  it('shows a not-found message when the id does not match any owned recipe', async () => {
+  // Supporting — not-found path when the server 404s.
+  it('shows a not-found message when the server returns 404', async () => {
+    vi.mocked(fetchRecipeByIdAdmin).mockRejectedValue(
+      new Error('404 Not Found')
+    )
     renderPreview('rec-missing')
 
     await waitFor(() => {
       expect(screen.getByText(/not found/i)).toBeInTheDocument()
+    })
+  })
+
+  // ---- Issue #173 — fetch swap + polling wiring ------------------------
+
+  // AC1 — Fetches via fetchRecipeByIdAdmin(token, id) on mount.
+  describe('fetch on mount (issue #173)', () => {
+    it('calls fetchRecipeByIdAdmin(token, id) on mount', async () => {
+      renderPreview('rec-draft')
+
+      await waitFor(() => {
+        expect(fetchRecipeByIdAdmin).toHaveBeenCalledWith(
+          'token-123',
+          'rec-draft',
+          expect.anything()
+        )
+      })
+    })
+
+    it('renders the loaded recipe title once fetchRecipeByIdAdmin resolves', async () => {
+      renderPreview('rec-draft')
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { level: 1, name: 'Draft Lemon Tart' })
+        ).toBeInTheDocument()
+      })
+    })
+  })
+
+  // AC2 — Uses useImageProcessingPoll on the loaded recipe with an onReady
+  // callback that merges readiness into local state by key.
+  describe('useImageProcessingPoll wiring (issue #173)', () => {
+    it('invokes useImageProcessingPoll with the loaded recipe once fetch resolves', async () => {
+      renderPreview('rec-draft')
+
+      await waitFor(() => {
+        expect(pollControls.lastArgs.recipe).not.toBeNull()
+      })
+
+      expect(pollControls.lastArgs.recipe?.id).toBe('rec-draft')
+      expect(pollControls.lastArgs.recipe?.coverImage.key).toBe(
+        'recipes/rec-draft/cover'
+      )
+      expect(typeof pollControls.lastArgs.onReady).toBe('function')
+    })
+
+    it('renders ProcessingPlaceholder while the cover image is still processing', async () => {
+      const recipeWithUnreadyCover: Recipe = {
+        ...mockDraftRecipe,
+        coverImage: {
+          key: 'recipes/rec-draft/cover',
+          alt: 'Lemon tart cover',
+          // processedAt absent — cover is still processing.
+        },
+      }
+      vi.mocked(fetchRecipeByIdAdmin).mockResolvedValue(recipeWithUnreadyCover)
+
+      renderPreview('rec-draft')
+
+      // Wait for the page to finish loading and render the banner.
+      await waitFor(() => {
+        expect(
+          screen.getByText(/preview\s*[—-]\s*this recipe is not yet published/i)
+        ).toBeInTheDocument()
+      })
+
+      // Placeholder visible, no cover <img>.
+      expect(screen.getByText(/processing image…/i)).toBeInTheDocument()
+      expect(
+        screen.queryByRole('img', { name: /lemon tart cover/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('auto-updates the preview when onReady fires with the matching cover key (processing → ready)', async () => {
+      const recipeWithUnreadyCover: Recipe = {
+        ...mockDraftRecipe,
+        coverImage: {
+          key: 'recipes/rec-draft/cover',
+          alt: 'Lemon tart cover',
+        },
+      }
+      vi.mocked(fetchRecipeByIdAdmin).mockResolvedValue(recipeWithUnreadyCover)
+
+      renderPreview('rec-draft')
+
+      await waitFor(() => {
+        expect(screen.getByText(/processing image…/i)).toBeInTheDocument()
+      })
+
+      // Initially the cover is a placeholder.
+      expect(
+        screen.queryByRole('img', { name: /lemon tart cover/i })
+      ).not.toBeInTheDocument()
+
+      // Poll hook reports the cover is ready.
+      pollControls.triggerReady([
+        { key: 'recipes/rec-draft/cover', processedAt: 1_700_000_500_000 },
+      ])
+
+      // Placeholder gone, cover <img> now rendered.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('img', { name: /lemon tart cover/i })
+        ).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/processing image…/i)).not.toBeInTheDocument()
+    })
+
+    it('ignores readiness updates whose keys do not match any image on the recipe', async () => {
+      const recipeWithUnreadyCover: Recipe = {
+        ...mockDraftRecipe,
+        coverImage: {
+          key: 'recipes/rec-draft/cover',
+          alt: 'Lemon tart cover',
+        },
+      }
+      vi.mocked(fetchRecipeByIdAdmin).mockResolvedValue(recipeWithUnreadyCover)
+
+      renderPreview('rec-draft')
+
+      await waitFor(() => {
+        expect(screen.getByText(/processing image…/i)).toBeInTheDocument()
+      })
+
+      // Fire a readiness update for a key that does not exist on the recipe.
+      pollControls.triggerReady([
+        { key: 'recipes/rec-draft/some-other-key', processedAt: 1_700_000_500_000 },
+      ])
+
+      // Let any state updates flush.
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // Placeholder must still be visible, no cover <img>.
+      expect(screen.getByText(/processing image…/i)).toBeInTheDocument()
+      expect(
+        screen.queryByRole('img', { name: /lemon tart cover/i })
+      ).not.toBeInTheDocument()
+    })
+
+    it('auto-updates a step image placeholder when onReady fires with the step image key', async () => {
+      const recipeWithUnreadyStep: Recipe = {
+        ...mockDraftRecipe,
+        // Cover image ready so we isolate the step placeholder.
+        coverImage: {
+          key: 'recipes/rec-draft/cover',
+          alt: 'Lemon tart cover',
+          processedAt: 1_700_000_000_000,
+        },
+        steps: [
+          {
+            order: 1,
+            text: 'Rub butter into the flour',
+            image: {
+              key: 'recipes/rec-draft/step-1',
+              alt: 'Rubbed butter into flour',
+            },
+          },
+        ],
+      }
+      vi.mocked(fetchRecipeByIdAdmin).mockResolvedValue(recipeWithUnreadyStep)
+
+      renderPreview('rec-draft')
+
+      await waitFor(() => {
+        expect(screen.getByText(/processing image…/i)).toBeInTheDocument()
+      })
+
+      // Step image placeholder is visible; its <img> is not.
+      expect(
+        screen.queryByRole('img', { name: /rubbed butter into flour/i })
+      ).not.toBeInTheDocument()
+
+      // Poll hook reports the step image is ready.
+      pollControls.triggerReady([
+        { key: 'recipes/rec-draft/step-1', processedAt: 1_700_000_600_000 },
+      ])
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('img', { name: /rubbed butter into flour/i })
+        ).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/processing image…/i)).not.toBeInTheDocument()
     })
   })
 })

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -29,10 +29,11 @@ const mergeReadiness = (recipe: Recipe, updates: ImageReadyUpdate[]): Recipe => 
 
   let stepsChanged = false
   const nextSteps = recipe.steps.map((step) => {
-    const stepUpdate = step.image?.key ? byKey.get(step.image.key) : undefined
+    if (!step.image?.key) return step
+    const stepUpdate = byKey.get(step.image.key)
     if (stepUpdate === undefined) return step
     stepsChanged = true
-    return { ...step, image: { ...step.image!, processedAt: stepUpdate } }
+    return { ...step, image: { ...step.image, processedAt: stepUpdate } }
   })
 
   if (nextCover === recipe.coverImage && !stepsChanged) return recipe
@@ -56,7 +57,6 @@ const RecipePreview: FC = () => {
   useEffect(() => {
     if (!id) return
     const controller = new AbortController()
-    let cancelled = false
 
     const load = async () => {
       setLoading(true)
@@ -64,10 +64,9 @@ const RecipePreview: FC = () => {
       try {
         const token = await getAccessToken()
         const found = await fetchRecipeByIdAdmin(token, id, controller.signal)
-        if (cancelled) return
         setRecipe(found)
       } catch (err) {
-        if (cancelled) return
+        if (controller.signal.aborted) return
         if (isSessionError(err)) {
           logout()
           navigate('/admin/login')
@@ -75,14 +74,13 @@ const RecipePreview: FC = () => {
         }
         setNotFound(true)
       } finally {
-        if (!cancelled) setLoading(false)
+        if (!controller.signal.aborted) setLoading(false)
       }
     }
 
     load()
 
     return () => {
-      cancelled = true
       controller.abort()
     }
   }, [id, getAccessToken, logout, navigate])

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -1,15 +1,47 @@
 import { isSessionError } from '@api/auth'
-import { fetchMyRecipes, publishRecipe } from '@api/recipes'
+import { fetchRecipeByIdAdmin, publishRecipe } from '@api/recipes'
 import Link from '@components/Link'
 import Loading from '@components/Loading'
 import RecipeDetailView from '@components/RecipeDetailView'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
+import {
+  useImageProcessingPoll,
+  type ImageReadyUpdate,
+} from '@hooks/useImageProcessingPoll'
 import type { Recipe } from '@models/recipe'
 import { useCallback, useEffect, useState, type FC } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import styles from './RecipePreview.module.css'
+
+const mergeReadiness = (recipe: Recipe, updates: ImageReadyUpdate[]): Recipe => {
+  const byKey = new Map(
+    updates.filter((u) => u.key).map((u) => [u.key, u.processedAt])
+  )
+  if (byKey.size === 0) return recipe
+
+  const coverUpdate = byKey.get(recipe.coverImage.key)
+  const nextCover =
+    coverUpdate !== undefined
+      ? { ...recipe.coverImage, processedAt: coverUpdate }
+      : recipe.coverImage
+
+  let stepsChanged = false
+  const nextSteps = recipe.steps.map((step) => {
+    const stepUpdate = step.image?.key ? byKey.get(step.image.key) : undefined
+    if (stepUpdate === undefined) return step
+    stepsChanged = true
+    return { ...step, image: { ...step.image!, processedAt: stepUpdate } }
+  })
+
+  if (nextCover === recipe.coverImage && !stepsChanged) return recipe
+  return {
+    ...recipe,
+    coverImage: nextCover,
+    steps: stepsChanged ? nextSteps : recipe.steps,
+  }
+}
 
 const RecipePreview: FC = () => {
   const { id } = useParams<{ id: string }>()
@@ -23,6 +55,7 @@ const RecipePreview: FC = () => {
 
   useEffect(() => {
     if (!id) return
+    const controller = new AbortController()
     let cancelled = false
 
     const load = async () => {
@@ -30,14 +63,9 @@ const RecipePreview: FC = () => {
       setNotFound(false)
       try {
         const token = await getAccessToken()
-        const recipes = await fetchMyRecipes(token)
+        const found = await fetchRecipeByIdAdmin(token, id, controller.signal)
         if (cancelled) return
-        const found = recipes.find((r) => r.id === id)
-        if (!found) {
-          setNotFound(true)
-        } else {
-          setRecipe(found)
-        }
+        setRecipe(found)
       } catch (err) {
         if (cancelled) return
         if (isSessionError(err)) {
@@ -55,8 +83,13 @@ const RecipePreview: FC = () => {
 
     return () => {
       cancelled = true
+      controller.abort()
     }
   }, [id, getAccessToken, logout, navigate])
+
+  useImageProcessingPoll(recipe ?? null, (updates) => {
+    setRecipe((prev) => (prev ? mergeReadiness(prev, updates) : prev))
+  })
 
   const handlePublish = useCallback(async () => {
     if (!recipe) return


### PR DESCRIPTION
Closes #173

## What changed
- `RecipePreview` now fetches via `fetchRecipeByIdAdmin(token, id, signal)` on mount instead of the `fetchMyRecipes` list+find pattern — one round-trip, cancellable in-flight.
- `useImageProcessingPoll` is wired against the loaded recipe; its `onReady` callback runs a `mergeReadiness(recipe, updates)` helper that applies the same key-matching semantics as the editor reducer (`applyImageStatusUpdates`), so the preview auto-flips each `ProcessingPlaceholder` to the real image when the resizer catches up.
- The fetch now uses an `AbortController` that cancels the in-flight request on unmount; the separate `cancelled` flag is redundant once `controller.signal.aborted` gates the state updates.

## Why
Part of the **Image Processing Readiness — Frontend** milestone (PRD: `docs/prds/image-processing-readiness.md` → "`RecipePreview` page"). Removes the admin-list fetch that was only being used to find a single recipe, and closes the loop between the resizer writing `processedAt` and the admin preview page showing the processed image without a manual refresh.

## How to verify
- `pnpm test` → 592/592 pass across 64 files.
- `pnpm lint` → 0 errors.
- `pnpm exec tsc --noEmit` → no new TS errors in any RecipePreview file.
- Manually: upload a cover image on a draft, navigate to the preview page, confirm the skeleton renders first and auto-flips to the processed image within a few seconds.

## Decisions made
- `mergeReadiness` is intentionally **not shared** with the editor's `applyImageStatusUpdates`. Same semantics, different data shapes: the preview operates on `Recipe` (nested `coverImage.processedAt`), the editor on `FormState` (flat `coverImageKey` + `coverImageProcessedAt`). Unifying would force one side to adopt the other's shape, which would be worse than the ~30 duplicated lines. Both helpers return the same state reference when no updates match, so downstream consumers bail out on `Object.is`-equal state.
- The `onReady` callback uses the functional `setRecipe(prev => ...)` updater rather than a closed-over `recipe` reference, so a poll tick that fires across a recipe swap or pending render flush can't merge into stale state.
- `useImageProcessingPoll` is called unconditionally (before the loading-guard return) with `recipe ?? null` — the hook accepts null and no-ops, and this placement keeps hook call-order stable across renders.
- Error handling keeps the existing pattern: session errors log out + navigate, anything else sets `notFound` (the page has a single fallback UI).