### PR TITLE
QA refinements: dev S3 proxy + ImageUpload preview sizing (closes #174)

### DIFF
--- a/src/api/recipes.ts
+++ b/src/api/recipes.ts
@@ -128,6 +128,14 @@ export const deleteRecipe = async (token: string, id: string): Promise<void> => 
   }
 }
 
+// Dev-only: route the S3 PUT through the vite proxy so the browser sees a
+// same-origin request. The prod bucket's CORS only allows https://akli.dev.
+const applyDevS3Proxy = (uploadUrl: string): string => {
+  const bucketHost = import.meta.env.VITE_S3_BUCKET_HOST
+  if (!import.meta.env.DEV || !bucketHost) return uploadUrl
+  return uploadUrl.replace(`https://${bucketHost}`, '/s3-upload')
+}
+
 export const getUploadUrl = async (
   token: string,
   params: { recipeId: string; imageType: string; stepOrder?: number }
@@ -143,5 +151,6 @@ export const getUploadUrl = async (
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`)
   }
-  return response.json()
+  const { uploadUrl, key }: { uploadUrl: string; key: string } = await response.json()
+  return { uploadUrl: applyDevS3Proxy(uploadUrl), key }
 }

--- a/src/components/ImageUpload/ImageUpload.module.css
+++ b/src/components/ImageUpload/ImageUpload.module.css
@@ -18,8 +18,6 @@
 }
 
 .preview {
-  max-width: 200px;
-  max-height: 200px;
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-none);
   object-fit: cover;

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -98,6 +98,8 @@ const ImageUpload: FC<ImageUploadProps> = ({
           src={preview}
           alt="Upload preview"
           className={styles.preview}
+          aspectRatio="1 / 1"
+          maxWidth="200px"
           lazy={false}
         />
       )
@@ -110,10 +112,12 @@ const ImageUpload: FC<ImageUploadProps> = ({
           src={recipeImageUrl(currentKey, 'medium')}
           alt={currentAlt ?? 'Current image'}
           className={styles.preview}
+          aspectRatio="1 / 1"
+          maxWidth="200px"
         />
       )
     }
-    return <ProcessingPlaceholder />
+    return <ProcessingPlaceholder aspectRatio="1 / 1" />
   }
 
   return (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import react from '@vitejs/plugin-react'
 import rehypeMermaid from 'rehype-mermaid'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
+import { loadEnv } from 'vite'
 import { imagetools } from 'vite-imagetools'
 import { defineConfig } from 'vitest/config'
 import remarkReadingTime from './plugins/remark-reading-time'
@@ -29,7 +30,9 @@ const getBlogRoutes = (): Array<{ route: string; priority: number; changefreq: '
   }
 }
 
-export default defineConfig(({ isSsrBuild }) => ({
+export default defineConfig(({ isSsrBuild, mode }) => {
+  const env = loadEnv(mode, dirname(fileURLToPath(import.meta.url)), '')
+  return {
   plugins: [
     react(),
     mdx({
@@ -108,6 +111,13 @@ export default defineConfig(({ isSsrBuild }) => ({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },
+      ...(env.VITE_S3_BUCKET_HOST && {
+        '/s3-upload': {
+          target: `https://${env.VITE_S3_BUCKET_HOST}`,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/s3-upload/, ''),
+        },
+      }),
     },
   },
   ssr: {
@@ -133,4 +143,5 @@ export default defineConfig(({ isSsrBuild }) => ({
       reporter: ['text', 'json', 'html'],
     },
   },
-}))
+  }
+})


### PR DESCRIPTION
## Summary
- Adds a Vite dev proxy that routes localhost S3 uploads through the dev server so presigned PUTs work without hitting the bucket's CORS rules locally. Prod uploads are unaffected.
- Reserves preview space in `ImageUpload` so the error overlay renders readably instead of collapsing onto a zero-height container.

Closes #174.

## Test plan
- [x] `pnpm test` passes
- [x] `pnpm lint` passes
- [x] Local: `pnpm dev`, upload a recipe cover image, confirm the upload PUT goes through the Vite dev proxy with no CORS error in the console
- [x] Local: force an image-load error and confirm the error overlay renders at a readable size

🤖 Generated with [Claude Code](https://claude.com/claude-code)