### PR TITLE
Flip RECIPE_IMAGE_BASE to images.akli.dev (#183)

### DIFF
--- a/src/types/recipe.test.ts
+++ b/src/types/recipe.test.ts
@@ -1,0 +1,52 @@
+import { RECIPE_IMAGE_BASE, recipeImageUrl, type RecipeImageVariant } from '@models/recipe'
+import { describe, it, expect } from 'vitest'
+
+describe('RECIPE_IMAGE_BASE', () => {
+  it('points at the images.akli.dev CDN host', () => {
+    expect(RECIPE_IMAGE_BASE).toBe('https://images.akli.dev')
+  })
+})
+
+describe('recipeImageUrl', () => {
+  it('builds a medium-variant URL for a simple cover key', () => {
+    expect(recipeImageUrl('recipes/abc-123/cover', 'medium')).toBe(
+      'https://images.akli.dev/recipes/abc-123/cover-medium.webp'
+    )
+  })
+
+  it.each<[RecipeImageVariant, string]>([
+    ['thumb', 'https://images.akli.dev/recipes/abc-123/cover-thumb.webp'],
+    ['medium', 'https://images.akli.dev/recipes/abc-123/cover-medium.webp'],
+    ['full', 'https://images.akli.dev/recipes/abc-123/cover-full.webp'],
+  ])('suffixes the %s variant before the .webp extension', (variant, expected) => {
+    expect(recipeImageUrl('recipes/abc-123/cover', variant)).toBe(expected)
+  })
+
+  it('preserves a UUID-shaped key segment verbatim without URL-encoding', () => {
+    expect(recipeImageUrl('recipes/9d904a59-e83f-43b8-9f40-fbdb3008974c/cover', 'medium')).toBe(
+      'https://images.akli.dev/recipes/9d904a59-e83f-43b8-9f40-fbdb3008974c/cover-medium.webp'
+    )
+  })
+
+  it('builds a step image URL with the thumb variant', () => {
+    expect(recipeImageUrl('recipes/abc/step-1', 'thumb')).toBe(
+      'https://images.akli.dev/recipes/abc/step-1-thumb.webp'
+    )
+  })
+
+  it('does not URL-encode forward slashes in nested keys', () => {
+    const url = recipeImageUrl('recipes/x/y/z', 'medium')
+    expect(url).toContain('/')
+    expect(url).not.toContain('%2F')
+  })
+
+  it('returns the base with a bare variant suffix for an empty key', () => {
+    expect(recipeImageUrl('', 'medium')).toBe('https://images.akli.dev/-medium.webp')
+  })
+
+  it('rejects variants outside the RecipeImageVariant union at compile time', () => {
+    // @ts-expect-error — 'large' is not a valid RecipeImageVariant
+    const result = recipeImageUrl('recipes/x/cover', 'large')
+    expect(typeof result).toBe('string')
+  })
+})

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,4 +1,4 @@
-export const RECIPE_IMAGE_BASE = 'https://akli.dev/images'
+export const RECIPE_IMAGE_BASE = 'https://images.akli.dev'
 
 export type RecipeImageVariant = 'thumb' | 'medium' | 'full'
 


### PR DESCRIPTION
Closes #183

## What changed
- `src/types/recipe.ts:1` — `RECIPE_IMAGE_BASE` flips from `'https://akli.dev/images'` to `'https://images.akli.dev'`. Single-line constant change. The `recipeImageUrl` helper is unchanged.
- New `src/types/recipe.test.ts` — first dedicated unit-test file for the helper. 10 tests (8 `it` blocks; one `it.each` expanding to 3) covering the constant, URL construction across all three `RecipeImageVariant` values, UUID-segment preservation, the non-encoding contract, the type-level rejection of unknown variants (`@ts-expect-error`), and the empty-key behaviour.

## Why
Frontend half of the **Images CDN — Phase 1** epic. The akli-infrastructure side (sibling PRD) deployed last week and now serves recipe-image variants from `https://images.akli.dev/recipes/<id>/<file>.webp`. Combined with the new `recipes/<id>/<type>` `key` shape coming from the API, every `recipeImageUrl` call site in the frontend (RecipeCard, RecipeSteps, RecipeDetailView, ImageUpload, plus the OG meta-tag builder once #184 lands) now produces a URL that resolves to a real image.

Before this PR: `https://akli.dev/images/processed/recipes/<id>/cover-medium.webp` → 404.
After this PR + #184: `https://images.akli.dev/recipes/<id>/cover-medium.webp` → 200.

PRD: `docs/prds/images-cdn-phase-1.md`. Sibling PRD lives at `akli-infrastructure/docs/prds/images-cdn-phase-1.md`.

## How to verify
- `pnpm test` — 602/602 pass (added 10 tests).
- `pnpm lint` — clean (5 pre-existing fast-refresh warnings, none introduced).
- `pnpm exec tsc --noEmit` — no new TS errors.
- `grep -rn 'RECIPE_IMAGE_BASE' src/` — single definition at `src/types/recipe.ts:1`; remaining matches are the test file's import + assertions, which is expected.
- After merge + deploy: refresh a published recipe page and inspect `<img>` `src` — should be `https://images.akli.dev/recipes/<id>/...`.

## AC coverage
All 11 ACs ticked — see issue body for the full list. TDD sequence followed: `245af75` test commit before `b5b59c0` implementation commit.

## Decisions made
- **Path alias `@models/recipe`** in the test file matches the existing convention at `src/api/recipes.test.ts`.
- **`@ts-expect-error` guard required a runtime `expect()` call** (single `expect(typeof result).toBe('string')`) to satisfy the project's `vitest/expect-expect` lint rule. The load-bearing assertion is the compile-time rejection of `'large'`; the runtime check is incidental.
- **Blog images at `akli.dev/images/blog/...` are unchanged** per PRD Non-Goals — that migration is reserved for the phase 2 sibling PRD.

## Out of scope (next issues in the epic)
- #184 — refactor `meta.ts` to use `recipeImageUrl` and fix the `buildMetaTags` double-prefix bug
- #185 — update test fixtures across the codebase to the new `recipes/<id>/...` key shape
- #186 — quality gates + grep regression guards
- #187 — manual QA and refinements