### PR TITLE
Refactor meta.ts to use recipeImageUrl + fix double-prefix (#184)

### DIFF
--- a/src/meta.test.ts
+++ b/src/meta.test.ts
@@ -361,7 +361,7 @@ describe('getMetaTags', () => {
       id: 'r1',
       title: 'Spaghetti Bolognese',
       slug: 'spaghetti-bolognese',
-      coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+      coverImage: { key: 'recipes/spaghetti-bolognese/cover', alt: 'A bowl of spaghetti bolognese' },
       tags: ['Italian', 'Pasta'],
       prepTime: 15,
       cookTime: 45,
@@ -404,11 +404,9 @@ describe('getMetaTags', () => {
       expect(meta.og.description.length).toBeLessThanOrEqual(160)
     })
 
-    it('returns og:image with cover medium URL', () => {
+    it('returns og:image as the absolute images.akli.dev URL for the cover medium variant', () => {
       const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
-      expect(meta.og.image).toBeDefined()
-      expect(meta.og.image).toContain('spaghetti-cover')
-      expect(meta.og.image).toContain('-medium')
+      expect(meta.og.image).toBe('https://images.akli.dev/recipes/spaghetti-bolognese/cover-medium.webp')
     })
 
     it('returns og:type as article', () => {
@@ -431,11 +429,9 @@ describe('getMetaTags', () => {
       expect(meta.twitter.description).toBe('A classic Italian pasta dish with rich meat sauce.')
     })
 
-    it('returns twitter:image with cover medium URL', () => {
+    it('returns twitter:image as the absolute images.akli.dev URL for the cover medium variant', () => {
       const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
-      expect(meta.twitter.image).toBeDefined()
-      expect(meta.twitter.image).toContain('spaghetti-cover')
-      expect(meta.twitter.image).toContain('-medium')
+      expect(meta.twitter.image).toBe('https://images.akli.dev/recipes/spaghetti-bolognese/cover-medium.webp')
     })
   })
 })

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -20,6 +20,7 @@ export interface MetaTags {
 
 import type { RecipeData } from './contexts/RecipeDataContext'
 import * as postsModule from './pages/Blog/posts/index'
+import { recipeImageUrl } from './types/recipe'
 
 const BASE_URL = 'https://akli.dev'
 
@@ -87,7 +88,9 @@ const buildMetaTags = (
   ogType: string = 'website',
   image?: string,
 ): MetaTags => {
-  const fullImage = image ? `${BASE_URL}${image}` : undefined
+  const fullImage = image
+    ? (image.startsWith('http') ? image : `${BASE_URL}${image}`)
+    : undefined
   return {
     title,
     description,
@@ -140,14 +143,13 @@ export const getMetaTags = (path: string, data?: RecipeData): MetaTags => {
     const description = recipe.intro.length > 160
       ? recipe.intro.slice(0, 157) + '...'
       : recipe.intro
-    const coverMediumPath = `/images/${recipe.coverImage.key}-medium.webp`
     return buildMetaTags(
       `${recipe.title} | Akli Aissat`,
       description,
       canonical,
       undefined,
       'article',
-      coverMediumPath,
+      recipeImageUrl(recipe.coverImage.key, 'medium'),
     )
   }
 


### PR DESCRIPTION
Closes #184

## What changed
- `src/meta.ts:144-150` — recipe cover URL is now built via `recipeImageUrl(recipe.coverImage.key, 'medium')` instead of an inline `\`/images/${recipe.coverImage.key}-medium.webp\`` template. Single source of truth for recipe image URLs.
- `src/meta.ts:91-93` — `buildMetaTags` `fullImage` computation gains a `startsWith('http')` guard so absolute URLs (from `recipeImageUrl`, returning `https://images.akli.dev/...`) pass through verbatim while relative paths (from blog post `image` fields) continue to get the `BASE_URL` prefix.
- `src/meta.test.ts` — recipe fixture's `coverImage.key` upgrades from `'spaghetti-cover'` to the production-shaped `'recipes/spaghetti-bolognese/cover'`. The two test cases that previously asserted via `toContain('spaghetti-cover') + toContain('-medium')` now assert the full absolute URL — `'https://images.akli.dev/recipes/spaghetti-bolognese/cover-medium.webp'` — as a regression guard for the double-prefix bug.

## Why
After #183 flipped `RECIPE_IMAGE_BASE` to `https://images.akli.dev`, the `recipeImageUrl` helper now returns absolute URLs. `src/meta.ts` was bypassing the helper and building a relative URL inline, which only worked because `buildMetaTags` unconditionally prefixed `BASE_URL`. Naively switching to `recipeImageUrl(...)` without the `buildMetaTags` fix would produce a malformed `https://akli.devhttps://images.akli.dev/...`. The two changes are coupled — surfaced explicitly in the PRD's "Technical Considerations".

## How to verify
- `pnpm test` — 602/602 pass.
- `pnpm lint` — clean.
- `pnpm exec tsc --noEmit` — no new TS errors.
- After merge: an OG share card for any recipe page renders the absolute `https://images.akli.dev/recipes/<id>/<file>-medium.webp` URL (visible via `<meta property="og:image">` in `view-source:`).

## Decisions made
- **Conditional `BASE_URL` prefix via `startsWith('http')`** rather than always-absolute or always-relative input. Blog posts pass relative paths (`/images/blog/<slug>.jpg`) to keep MDX terse; recipes use the helper which produces absolute URLs. The conditional handles both cleanly.
- **Full-URL assertions** in tests are explicitly per the PRD — substring assertions would silently pass even if the double-prefix bug came back.
- **Blog tests untouched** — the existing `https://akli.dev/images/blog/...` assertions at `src/meta.test.ts:309, 315` already use the absolute form and still pass.

## AC coverage
- ✅ `src/meta.ts:143` no longer constructs the URL inline; uses `recipeImageUrl(...)` instead.
- ✅ `src/meta.ts` imports `recipeImageUrl` from `./types/recipe`.
- ✅ `buildMetaTags` `fullImage` uses `image.startsWith('http')` guard.
- ✅ `src/meta.test.ts` recipe fixture key upgraded to production shape.
- ✅ `og.image` and `twitter.image` recipe-branch tests assert the full absolute URL.
- ✅ Blog-branch tests still pass.