### PR TITLE
Sweep test fixtures to production recipes/<id>/... key shape (#185)

### DIFF
--- a/src/api/recipes.test.ts
+++ b/src/api/recipes.test.ts
@@ -16,7 +16,7 @@ const mockRecipeIndex: RecipeIndex = {
   id: 'r1',
   title: 'Spaghetti Bolognese',
   slug: 'spaghetti-bolognese',
-  coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+  coverImage: { key: 'recipes/spaghetti-bolognese/cover', alt: 'A bowl of spaghetti bolognese' },
   tags: ['Italian', 'Pasta'],
   prepTime: 15,
   cookTime: 45,
@@ -52,7 +52,7 @@ const _statusOk2: Recipe['status'] = 'published'
 const _statusBad: Recipe['status'] = 'archived'
 const _recipeWithTtl: Recipe = { ...mockRecipe, ttl: 123 }
 const _coverWithProcessedAt: Recipe['coverImage'] = {
-  key: 'spaghetti-cover',
+  key: 'recipes/spaghetti-bolognese/cover',
   alt: 'A bowl of spaghetti bolognese',
   processedAt: 1714000000,
 }

--- a/src/components/RecipeDetailView/RecipeDetailView.test.tsx
+++ b/src/components/RecipeDetailView/RecipeDetailView.test.tsx
@@ -10,7 +10,7 @@ const baseRecipe: Recipe = {
   slug: 'test-recipe',
   intro: 'A delicious test recipe',
   coverImage: {
-    key: 'processed/recipes/recipe-1/cover',
+    key: 'recipes/recipe-1/cover',
     alt: 'Test cover',
     processedAt: 1_700_000_000_000,
   },
@@ -42,7 +42,7 @@ describe('RecipeDetailView', () => {
     expect(coverImg).toBeInTheDocument()
     expect(coverImg).toHaveAttribute(
       'src',
-      expect.stringContaining('processed/recipes/recipe-1/cover-medium')
+      expect.stringContaining('recipes/recipe-1/cover-medium')
     )
     expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
   })
@@ -51,7 +51,7 @@ describe('RecipeDetailView', () => {
     const processingRecipe: Recipe = {
       ...baseRecipe,
       coverImage: {
-        key: 'processed/recipes/recipe-1/cover',
+        key: 'recipes/recipe-1/cover',
         alt: 'Test cover',
       },
     }

--- a/src/components/RecipeSteps/RecipeSteps.test.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.test.tsx
@@ -8,7 +8,7 @@ const mockSteps: Step[] = [
     order: 1,
     text: 'Mix ingredients together',
     image: {
-      key: 'processed/recipes/recipe-1/step-1',
+      key: 'recipes/recipe-1/step-1',
       alt: 'Mixing bowl',
       processedAt: 1_700_000_000_000,
     },
@@ -18,7 +18,7 @@ const mockSteps: Step[] = [
     order: 3,
     text: 'Let it cool',
     image: {
-      key: 'processed/recipes/recipe-1/step-3',
+      key: 'recipes/recipe-1/step-3',
       alt: 'Cooling rack',
       processedAt: 1_700_000_000_000,
     },
@@ -52,7 +52,7 @@ describe('RecipeSteps', () => {
     expect(mixingImg).toHaveAttribute('loading', 'lazy')
     expect(mixingImg).toHaveAttribute(
       'src',
-      expect.stringContaining('processed/recipes/recipe-1/step-1-medium')
+      expect.stringContaining('recipes/recipe-1/step-1-medium')
     )
 
     const coolingImg = screen.getByRole('img', { name: 'Cooling rack' })
@@ -71,7 +71,7 @@ describe('RecipeSteps', () => {
         order: 1,
         text: 'Mix ingredients together',
         image: {
-          key: 'processed/recipes/recipe-1/step-1',
+          key: 'recipes/recipe-1/step-1',
           alt: 'Mixing bowl',
         },
       },
@@ -89,7 +89,7 @@ describe('RecipeSteps', () => {
         order: 1,
         text: 'Mix ingredients together',
         image: {
-          key: 'processed/recipes/recipe-1/step-1',
+          key: 'recipes/recipe-1/step-1',
           alt: 'Mixing bowl',
           processedAt: 1_700_000_000_000,
         },
@@ -98,7 +98,7 @@ describe('RecipeSteps', () => {
         order: 2,
         text: 'Let it cool',
         image: {
-          key: 'processed/recipes/recipe-1/step-2',
+          key: 'recipes/recipe-1/step-2',
           alt: 'Cooling rack',
         },
       },

--- a/src/entry-server.test.tsx
+++ b/src/entry-server.test.tsx
@@ -132,7 +132,7 @@ describe('entry-server render', () => {
       id: 'r1',
       title: 'Spaghetti Bolognese',
       slug: 'spaghetti-bolognese',
-      coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+      coverImage: { key: 'recipes/spaghetti-bolognese/cover', alt: 'A bowl of spaghetti bolognese' },
       tags: ['Italian', 'Pasta'],
       prepTime: 15,
       cookTime: 45,

--- a/src/pages/RecipeDetail/RecipeDetail.test.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.test.tsx
@@ -16,7 +16,7 @@ const mockRecipe: Recipe = {
   slug: 'test-recipe',
   intro: 'A delicious test recipe',
   coverImage: {
-    key: 'processed/recipes/recipe-1/cover',
+    key: 'recipes/recipe-1/cover',
     alt: 'Test cover',
     processedAt: 1_700_000_000_000,
   },
@@ -29,7 +29,7 @@ const mockRecipe: Recipe = {
       order: 1,
       text: 'Mix ingredients',
       image: {
-        key: 'processed/recipes/recipe-1/step-1',
+        key: 'recipes/recipe-1/step-1',
         alt: 'Mixing',
         processedAt: 1_700_000_000_000,
       },


### PR DESCRIPTION
Closes #185

## What changed
Five test files updated from old fixture shapes to the production `recipes/<id>/...` shape that the API now returns:

| File | Change |
|---|---|
| `src/components/RecipeSteps/RecipeSteps.test.tsx` | 6 occurrences: `processed/recipes/recipe-1/...` → `recipes/recipe-1/...` (incl. the `stringContaining` URL assertion at line 55) |
| `src/components/RecipeDetailView/RecipeDetailView.test.tsx` | 3 occurrences: same pattern, includes URL `stringContaining` at line 45 |
| `src/pages/RecipeDetail/RecipeDetail.test.tsx` | 2 occurrences: cover + step keys |
| `src/api/recipes.test.ts` | 2 occurrences: `'spaghetti-cover'` → `'recipes/spaghetti-bolognese/cover'` |
| `src/entry-server.test.tsx` | 1 occurrence: same standardisation |

## Why
After #183 + #184, the frontend produces URLs from `recipeImageUrl(key, variant)` where `key` is the production shape (`recipes/<id>/<type>`). Test fixtures still carried the legacy `processed/recipes/...` shape (or unrealistic `'spaghetti-cover'` placeholders). Updating them keeps tests aligned with the shipped contract — drift in either direction now fails loudly instead of silently. PRD: `docs/prds/images-cdn-phase-1.md`.

## How to verify
- `pnpm test` — 602/602 pass.
- `pnpm lint` — clean.
- `grep -rn 'processed/recipes' src/` — 0 matches.
- `grep -rn 'spaghetti-cover\|spaghetti-step' src/` — 0 matches.

## Decisions made
- **5 files touched, not the 4 the AC listed.** The AC enumerated `RecipeSteps.test.tsx`, `RecipeDetail.test.tsx`, `recipes.test.ts`, and `entry-server.test.tsx`, but `RecipeDetailView.test.tsx` also had `processed/recipes/...` references. The canonical "grep returns 0" AC required including it — surfaced rather than silently skipped.
- **Pure fixture sweep, no assertion semantics changed** — the `stringContaining` assertions still match exactly the same intent (the URL contains the new key shape), and the alt-text / structural assertions in `RecipeDetail` were never URL-shape dependent.

## AC coverage
- ✅ `RecipeSteps.test.tsx` step keys updated (lines 11, 21, 74, 92, 101) and URL assertion (line 55) updated to `recipes/recipe-1/step-1-medium`.
- ✅ `RecipeDetail.test.tsx` cover + step keys updated; no assertion text changes needed (asserts on alt text + structural elements).
- ✅ `recipes.test.ts` `'spaghetti-cover'` upgraded to `'recipes/spaghetti-bolognese/cover'`.
- ✅ `entry-server.test.tsx` same standardisation.
- ✅ `grep -rn 'processed/recipes' src/` returns 0 matches.
- ✅ `grep -rn 'spaghetti-cover\|spaghetti-step' src/` returns 0 matches.
- ✅ All vitest runs pass (602/602).