### PR TITLE
Fix double border + gap on recipe cover image (#187)

### DIFF
--- a/src/components/RecipeDetailView/RecipeDetailView.module.css
+++ b/src/components/RecipeDetailView/RecipeDetailView.module.css
@@ -8,17 +8,6 @@
   margin-block-end: var(--space-10);
 }
 
-.coverImage {
-  display: block;
-  width: 100%;
-  max-width: var(--max-w-site);
-  aspect-ratio: 16 / 9;
-  object-fit: cover;
-  border-radius: var(--radius-none);
-  border: var(--border-width) solid var(--color-border);
-  margin-block-end: var(--space-10);
-}
-
 .title {
   font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);

--- a/src/components/RecipeDetailView/RecipeDetailView.tsx
+++ b/src/components/RecipeDetailView/RecipeDetailView.tsx
@@ -31,7 +31,7 @@ const RecipeDetailView: FC<RecipeDetailViewProps> = ({ recipe }) => (
         alt={recipe.coverImage.alt}
         priority
         maxWidth="var(--max-w-site)"
-        className={styles.coverImage}
+        aspectRatio="16/9"
         containerClassName={styles.coverImageWrapper}
       />
     ) : (


### PR DESCRIPTION
Refinement from manual QA on #187.

## What changed
- `src/components/RecipeDetailView/RecipeDetailView.tsx` — pass `aspectRatio="16/9"` to the `Image` component; drop the `className={styles.coverImage}` prop.
- `src/components/RecipeDetailView/RecipeDetailView.module.css` — drop the `.coverImage` class entirely.

## Why
The `Image` component already paints a border on its container `<div>` and constrains aspect-ratio there. `RecipeDetailView.module.css` was applying both `border` and `aspect-ratio: 16/9` directly to the inner `<img>` via `.coverImage`, producing:

1. **Double border** — outer (from `Image`'s container) + inner (from `.coverImage` on the `<img>`).
2. **Vertical gap below the image** — the container had no `aspect-ratio` set, so it sized to its content; the `<img>` inside had its own `16/9` ratio rule that didn't fill the container's height — leaving padding before the container's bottom border.

`Image` already has the right primitives: `aspectRatio` prop on the container, `objectFit: 'cover'` default, container border, `width: 100%` on the inner `<img>`. Passing `aspectRatio="16/9"` makes the container hold the ratio (single border, no gap) and lets `.coverImage`'s duplicated rules go.

The other rules in `.coverImage` were duplicates too — already covered by the `Image` component's styling, the `maxWidth` prop, or the `.coverImageWrapper` class.

## How to verify
- Hard-refresh `/recipes/<slug>` — single neo-brutalist border, no internal gap.
- `pnpm test src/components/RecipeDetailView` — 2/2 pass.
- `pnpm lint` — clean.