### PR TITLE
Epic: Images CDN — Phase 1 (Frontend Cutover)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "personal-website",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/api/recipes.test.ts
+++ b/src/api/recipes.test.ts
@@ -16,7 +16,7 @@ const mockRecipeIndex: RecipeIndex = {
   id: 'r1',
   title: 'Spaghetti Bolognese',
   slug: 'spaghetti-bolognese',
-  coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+  coverImage: { key: 'recipes/spaghetti-bolognese/cover', alt: 'A bowl of spaghetti bolognese' },
   tags: ['Italian', 'Pasta'],
   prepTime: 15,
   cookTime: 45,
@@ -52,7 +52,7 @@ const _statusOk2: Recipe['status'] = 'published'
 const _statusBad: Recipe['status'] = 'archived'
 const _recipeWithTtl: Recipe = { ...mockRecipe, ttl: 123 }
 const _coverWithProcessedAt: Recipe['coverImage'] = {
-  key: 'spaghetti-cover',
+  key: 'recipes/spaghetti-bolognese/cover',
   alt: 'A bowl of spaghetti bolognese',
   processedAt: 1714000000,
 }

--- a/src/components/RecipeDetailView/RecipeDetailView.module.css
+++ b/src/components/RecipeDetailView/RecipeDetailView.module.css
@@ -8,17 +8,6 @@
   margin-block-end: var(--space-10);
 }
 
-.coverImage {
-  display: block;
-  width: 100%;
-  max-width: var(--max-w-site);
-  aspect-ratio: 16 / 9;
-  object-fit: cover;
-  border-radius: var(--radius-none);
-  border: var(--border-width) solid var(--color-border);
-  margin-block-end: var(--space-10);
-}
-
 .title {
   font-size: var(--font-size-3xl);
   font-weight: var(--font-weight-bold);

--- a/src/components/RecipeDetailView/RecipeDetailView.test.tsx
+++ b/src/components/RecipeDetailView/RecipeDetailView.test.tsx
@@ -10,7 +10,7 @@ const baseRecipe: Recipe = {
   slug: 'test-recipe',
   intro: 'A delicious test recipe',
   coverImage: {
-    key: 'processed/recipes/recipe-1/cover',
+    key: 'recipes/recipe-1/cover',
     alt: 'Test cover',
     processedAt: 1_700_000_000_000,
   },
@@ -42,7 +42,7 @@ describe('RecipeDetailView', () => {
     expect(coverImg).toBeInTheDocument()
     expect(coverImg).toHaveAttribute(
       'src',
-      expect.stringContaining('processed/recipes/recipe-1/cover-medium')
+      expect.stringContaining('recipes/recipe-1/cover-medium')
     )
     expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
   })
@@ -51,7 +51,7 @@ describe('RecipeDetailView', () => {
     const processingRecipe: Recipe = {
       ...baseRecipe,
       coverImage: {
-        key: 'processed/recipes/recipe-1/cover',
+        key: 'recipes/recipe-1/cover',
         alt: 'Test cover',
       },
     }

--- a/src/components/RecipeDetailView/RecipeDetailView.tsx
+++ b/src/components/RecipeDetailView/RecipeDetailView.tsx
@@ -31,7 +31,7 @@ const RecipeDetailView: FC<RecipeDetailViewProps> = ({ recipe }) => (
         alt={recipe.coverImage.alt}
         priority
         maxWidth="var(--max-w-site)"
-        className={styles.coverImage}
+        aspectRatio="16/9"
         containerClassName={styles.coverImageWrapper}
       />
     ) : (

--- a/src/components/RecipeSteps/RecipeSteps.test.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.test.tsx
@@ -8,7 +8,7 @@ const mockSteps: Step[] = [
     order: 1,
     text: 'Mix ingredients together',
     image: {
-      key: 'processed/recipes/recipe-1/step-1',
+      key: 'recipes/recipe-1/step-1',
       alt: 'Mixing bowl',
       processedAt: 1_700_000_000_000,
     },
@@ -18,7 +18,7 @@ const mockSteps: Step[] = [
     order: 3,
     text: 'Let it cool',
     image: {
-      key: 'processed/recipes/recipe-1/step-3',
+      key: 'recipes/recipe-1/step-3',
       alt: 'Cooling rack',
       processedAt: 1_700_000_000_000,
     },
@@ -52,7 +52,7 @@ describe('RecipeSteps', () => {
     expect(mixingImg).toHaveAttribute('loading', 'lazy')
     expect(mixingImg).toHaveAttribute(
       'src',
-      expect.stringContaining('processed/recipes/recipe-1/step-1-medium')
+      expect.stringContaining('recipes/recipe-1/step-1-medium')
     )
 
     const coolingImg = screen.getByRole('img', { name: 'Cooling rack' })
@@ -71,7 +71,7 @@ describe('RecipeSteps', () => {
         order: 1,
         text: 'Mix ingredients together',
         image: {
-          key: 'processed/recipes/recipe-1/step-1',
+          key: 'recipes/recipe-1/step-1',
           alt: 'Mixing bowl',
         },
       },
@@ -89,7 +89,7 @@ describe('RecipeSteps', () => {
         order: 1,
         text: 'Mix ingredients together',
         image: {
-          key: 'processed/recipes/recipe-1/step-1',
+          key: 'recipes/recipe-1/step-1',
           alt: 'Mixing bowl',
           processedAt: 1_700_000_000_000,
         },
@@ -98,7 +98,7 @@ describe('RecipeSteps', () => {
         order: 2,
         text: 'Let it cool',
         image: {
-          key: 'processed/recipes/recipe-1/step-2',
+          key: 'recipes/recipe-1/step-2',
           alt: 'Cooling rack',
         },
       },

--- a/src/entry-server.test.tsx
+++ b/src/entry-server.test.tsx
@@ -132,7 +132,7 @@ describe('entry-server render', () => {
       id: 'r1',
       title: 'Spaghetti Bolognese',
       slug: 'spaghetti-bolognese',
-      coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+      coverImage: { key: 'recipes/spaghetti-bolognese/cover', alt: 'A bowl of spaghetti bolognese' },
       tags: ['Italian', 'Pasta'],
       prepTime: 15,
       cookTime: 45,

--- a/src/meta.test.ts
+++ b/src/meta.test.ts
@@ -361,7 +361,7 @@ describe('getMetaTags', () => {
       id: 'r1',
       title: 'Spaghetti Bolognese',
       slug: 'spaghetti-bolognese',
-      coverImage: { key: 'spaghetti-cover', alt: 'A bowl of spaghetti bolognese' },
+      coverImage: { key: 'recipes/spaghetti-bolognese/cover', alt: 'A bowl of spaghetti bolognese' },
       tags: ['Italian', 'Pasta'],
       prepTime: 15,
       cookTime: 45,
@@ -404,11 +404,9 @@ describe('getMetaTags', () => {
       expect(meta.og.description.length).toBeLessThanOrEqual(160)
     })
 
-    it('returns og:image with cover medium URL', () => {
+    it('returns og:image as the absolute images.akli.dev URL for the cover medium variant', () => {
       const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
-      expect(meta.og.image).toBeDefined()
-      expect(meta.og.image).toContain('spaghetti-cover')
-      expect(meta.og.image).toContain('-medium')
+      expect(meta.og.image).toBe('https://images.akli.dev/recipes/spaghetti-bolognese/cover-medium.webp')
     })
 
     it('returns og:type as article', () => {
@@ -431,11 +429,9 @@ describe('getMetaTags', () => {
       expect(meta.twitter.description).toBe('A classic Italian pasta dish with rich meat sauce.')
     })
 
-    it('returns twitter:image with cover medium URL', () => {
+    it('returns twitter:image as the absolute images.akli.dev URL for the cover medium variant', () => {
       const meta = getMetaTags('/recipes/spaghetti-bolognese', { recipe: mockRecipe })
-      expect(meta.twitter.image).toBeDefined()
-      expect(meta.twitter.image).toContain('spaghetti-cover')
-      expect(meta.twitter.image).toContain('-medium')
+      expect(meta.twitter.image).toBe('https://images.akli.dev/recipes/spaghetti-bolognese/cover-medium.webp')
     })
   })
 })

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -20,6 +20,7 @@ export interface MetaTags {
 
 import type { RecipeData } from './contexts/RecipeDataContext'
 import * as postsModule from './pages/Blog/posts/index'
+import { recipeImageUrl } from './types/recipe'
 
 const BASE_URL = 'https://akli.dev'
 
@@ -87,7 +88,9 @@ const buildMetaTags = (
   ogType: string = 'website',
   image?: string,
 ): MetaTags => {
-  const fullImage = image ? `${BASE_URL}${image}` : undefined
+  const fullImage = image
+    ? (image.startsWith('http') ? image : `${BASE_URL}${image}`)
+    : undefined
   return {
     title,
     description,
@@ -140,14 +143,13 @@ export const getMetaTags = (path: string, data?: RecipeData): MetaTags => {
     const description = recipe.intro.length > 160
       ? recipe.intro.slice(0, 157) + '...'
       : recipe.intro
-    const coverMediumPath = `/images/${recipe.coverImage.key}-medium.webp`
     return buildMetaTags(
       `${recipe.title} | Akli Aissat`,
       description,
       canonical,
       undefined,
       'article',
-      coverMediumPath,
+      recipeImageUrl(recipe.coverImage.key, 'medium'),
     )
   }
 

--- a/src/pages/RecipeDetail/RecipeDetail.test.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.test.tsx
@@ -16,7 +16,7 @@ const mockRecipe: Recipe = {
   slug: 'test-recipe',
   intro: 'A delicious test recipe',
   coverImage: {
-    key: 'processed/recipes/recipe-1/cover',
+    key: 'recipes/recipe-1/cover',
     alt: 'Test cover',
     processedAt: 1_700_000_000_000,
   },
@@ -29,7 +29,7 @@ const mockRecipe: Recipe = {
       order: 1,
       text: 'Mix ingredients',
       image: {
-        key: 'processed/recipes/recipe-1/step-1',
+        key: 'recipes/recipe-1/step-1',
         alt: 'Mixing',
         processedAt: 1_700_000_000_000,
       },

--- a/src/types/recipe.test.ts
+++ b/src/types/recipe.test.ts
@@ -1,0 +1,52 @@
+import { RECIPE_IMAGE_BASE, recipeImageUrl, type RecipeImageVariant } from '@models/recipe'
+import { describe, it, expect } from 'vitest'
+
+describe('RECIPE_IMAGE_BASE', () => {
+  it('points at the images.akli.dev CDN host', () => {
+    expect(RECIPE_IMAGE_BASE).toBe('https://images.akli.dev')
+  })
+})
+
+describe('recipeImageUrl', () => {
+  it('builds a medium-variant URL for a simple cover key', () => {
+    expect(recipeImageUrl('recipes/abc-123/cover', 'medium')).toBe(
+      'https://images.akli.dev/recipes/abc-123/cover-medium.webp'
+    )
+  })
+
+  it.each<[RecipeImageVariant, string]>([
+    ['thumb', 'https://images.akli.dev/recipes/abc-123/cover-thumb.webp'],
+    ['medium', 'https://images.akli.dev/recipes/abc-123/cover-medium.webp'],
+    ['full', 'https://images.akli.dev/recipes/abc-123/cover-full.webp'],
+  ])('suffixes the %s variant before the .webp extension', (variant, expected) => {
+    expect(recipeImageUrl('recipes/abc-123/cover', variant)).toBe(expected)
+  })
+
+  it('preserves a UUID-shaped key segment verbatim without URL-encoding', () => {
+    expect(recipeImageUrl('recipes/9d904a59-e83f-43b8-9f40-fbdb3008974c/cover', 'medium')).toBe(
+      'https://images.akli.dev/recipes/9d904a59-e83f-43b8-9f40-fbdb3008974c/cover-medium.webp'
+    )
+  })
+
+  it('builds a step image URL with the thumb variant', () => {
+    expect(recipeImageUrl('recipes/abc/step-1', 'thumb')).toBe(
+      'https://images.akli.dev/recipes/abc/step-1-thumb.webp'
+    )
+  })
+
+  it('does not URL-encode forward slashes in nested keys', () => {
+    const url = recipeImageUrl('recipes/x/y/z', 'medium')
+    expect(url).toContain('/')
+    expect(url).not.toContain('%2F')
+  })
+
+  it('returns the base with a bare variant suffix for an empty key', () => {
+    expect(recipeImageUrl('', 'medium')).toBe('https://images.akli.dev/-medium.webp')
+  })
+
+  it('rejects variants outside the RecipeImageVariant union at compile time', () => {
+    // @ts-expect-error — 'large' is not a valid RecipeImageVariant
+    const result = recipeImageUrl('recipes/x/cover', 'large')
+    expect(typeof result).toBe('string')
+  })
+})

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,4 +1,4 @@
-export const RECIPE_IMAGE_BASE = 'https://akli.dev/images'
+export const RECIPE_IMAGE_BASE = 'https://images.akli.dev'
 
 export type RecipeImageVariant = 'thumb' | 'medium' | 'full'
 


### PR DESCRIPTION
Cuts the frontend over to the new `https://images.akli.dev/recipes/<id>/...` URL pattern shipped by the sibling `akli-infrastructure` PRD. Recipe images now load through the new CloudFront distribution — the upload→process→serve loop is end-to-end working for the first time.

PRD: `docs/prds/images-cdn-phase-1.md`. Sibling PRD: [`akli-infrastructure/docs/prds/images-cdn-phase-1.md`](https://github.com/vandelay87/akli-infrastructure/blob/main/docs/prds/images-cdn-phase-1.md).

## Milestone summary

| # | Title | PR | Type |
|---|---|---|---|
| #183 | Flip `RECIPE_IMAGE_BASE` + add `recipeImageUrl` unit tests | #191 | feature |
| #184 | Refactor `meta.ts` to use `recipeImageUrl` + fix double-prefix | #192 | refactor |
| #185 | Update test fixtures to new `recipes/<id>/...` key shape | #193 | test |
| #186 | Quality gates + grep regression guards | (verification, no PR) | — |
| #187 | Manual QA + refinements | #194 | fix |

## What ships
- **`RECIPE_IMAGE_BASE` flips** from `'https://akli.dev/images'` to `'https://images.akli.dev'` in `src/types/recipe.ts`. Combined with the new `recipes/<id>/<type>` `key` shape coming from the API, every `recipeImageUrl` call site (RecipeCard, RecipeSteps, RecipeDetailView, ImageUpload, plus the OG meta-tag builder) now produces a URL that resolves to a real image.
- **`src/meta.ts` refactor** — the recipe-meta branch now calls `recipeImageUrl(...)` instead of building the URL inline. `buildMetaTags` gains a `startsWith('http')` guard to skip the `BASE_URL` prefix on absolute URLs, so OG tags render correctly. Blog images stay on the relative-path → BASE_URL flow per PRD Non-Goals.
- **Test fixtures swept** — five test files (`RecipeSteps`, `RecipeDetailView`, `RecipeDetail`, `recipes` API, `entry-server`) updated from old `processed/recipes/...` shape (or `'spaghetti-cover'` placeholders) to the production `recipes/<id>/...` shape.
- **Cover-image visual fix** — `RecipeDetailView` no longer applies a duplicate border + aspect-ratio to the inner `<img>`; the `Image` component's container holds both. Single border, no internal gap.
- **New `src/types/recipe.test.ts`** — first dedicated unit test for `recipeImageUrl`, pinning the URL contract and the type-level rejection of unknown variants.
- **Version bump 1.8.0 → 1.9.0** (highest type in milestone is feature → minor).

## Out-of-scope follow-ups noticed during manual QA
- **Processing toast / status indicator** — the polling that should flip the indicator from "Processing" to "Ready" was observed not updating during initial QA. This is downstream of the akli-infra hotfix #145 (the bucket policy 403 was preventing image rendering). Worth a quick re-check after this PR merges; if it persists, file a follow-up.

## How to verify (post-merge)
- Hard-refresh a published recipe — cover image renders from `images.akli.dev/recipes/<id>/cover-medium.webp` with status 200.
- View source on a recipe page — `og:image` and `twitter:image` are absolute `https://images.akli.dev/...` URLs.
- DevTools Network tab — zero requests to `akli.dev/images/processed/...`.
- Social-share preview (Slack/Twitter/Discord) renders the OG image.

## Decisions made
- **No backwards-compat shim** — the two PRDs ship in lockstep. `personal-website/main` reads URLs that only resolve once `akli-infrastructure/main` has deployed (which it has — see hotfixes #141 and #145).
- **`recipeImageUrl(key, variant)` signature preserved** — every call site gets the new URL transparently via the constant flip; no per-component code changes.
- **Blog images unchanged** — phase 2 sibling PRD migrates blog images; phase 1 is recipes-only.

## Closes
Closes #183, #184, #185, #186, #187 (and the milestone).