### PR TITLE
ci: fix pnpm-workspace config + align CI to pnpm 10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 8 # or 9+ if you've upgraded
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/package.json
+++ b/package.json
@@ -56,18 +56,5 @@
     "vite": "^7.3.1",
     "vite-imagetools": "^10.0.0",
     "vitest": "^4.1.2"
-  },
-  "pnpm": {
-    "supportedArchitectures": {
-      "os": [
-        "current",
-        "linux"
-      ],
-      "cpu": [
-        "current",
-        "x64",
-        "arm64"
-      ]
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
-allowBuilds:
-  esbuild: true
-  sharp: true
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+supportedArchitectures:
+  os:
+    - current
+    - linux
+  cpu:
+    - current
+    - x64
+    - arm64


### PR DESCRIPTION
## Problem
The deploy workflow failed at install:
```
Run pnpm install --no-frozen-lockfile
ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION  packages field missing or empty
```
CI runs **pnpm 8**, but `pnpm-workspace.yaml` used an invalid `allowBuilds:` key with no `packages:` field, and the repo's `pnpm-lock.yaml` is already **`lockfileVersion: 9.0`** (pnpm 9+). pnpm 8 treats the file as a workspace definition and rejects it. (Same root cause as the akli-infrastructure CI fix.)

## Fix
- **`pnpm/action-setup` → v10** in the deploy job — reads the 9.0 lockfile and supports a settings-only `pnpm-workspace.yaml`.
- **`allowBuilds` → `onlyBuiltDependencies: [esbuild, sharp]`** — the correct key for approving build scripts in pnpm 10+ (esbuild via Vite, sharp via vite-imagetools).
- **Moved `supportedArchitectures`** out of the `package.json` `pnpm` field (pnpm 10+ no longer reads settings there) into `pnpm-workspace.yaml`, so linux native binaries are still resolved for the deploy target.

## Validation
Ran a **fresh** `pnpm@10 install` (matching CI exactly): exit 0, no `ERR_PNPM_IGNORED_BUILDS`, no workspace-config error, lockfile unchanged.

> Note: this repo's workflow only triggers on **push to main** (no PR CI), so this PR won't show a check — the real validation runs on merge. Also note: pnpm **11** locally is stricter and will hard-fail a *fresh* install on ignored builds; CI is pinned to pnpm 10 where it's clean. Pinning `packageManager: pnpm@10` repo-wide (and in akli-infrastructure) is a sensible follow-up if you want local + CI fully locked to one version.