### PR TITLE
chore: lowercase "recipes" in homepage CTA heading

### DIFF
--- a/src/components/RecipesCta/RecipesCta.tsx
+++ b/src/components/RecipesCta/RecipesCta.tsx
@@ -42,7 +42,7 @@ const RecipesCta: FC = () => {
     <section className={styles.section} aria-labelledby="recipes-section-title">
       <div className={styles.inner}>
         <Typography variant="heading2" id="recipes-section-title" className={styles.heading}>
-          Favourite Recipes
+          Favourite recipes
         </Typography>
         <Grid columns={3}>
           {recipes.map((recipe) => (


### PR DESCRIPTION
## What
Lowercases the word "Recipes" in the homepage "Favourite Recipes" CTA heading → "Favourite recipes".

## Why
Sentence-case heading preference.

## Notes
- Single-word copy change in `RecipesCta.tsx`. The heading test matches case-insensitively, so it stays green (6/6).
- No `.gitignore` change was needed: the local-dev `VITE_S3_BUCKET_HOST` value lives in `.env.development.local`, which is already ignored by the existing `*.local` rule — it is intentionally NOT committed (it embeds the AWS account id, and this is a public repo).