### PR TITLE
Add Dependabot (npm + GitHub Actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds `.github/dependabot.yml` to keep dependencies and GitHub Actions current.

## Config
- **npm** and **github-actions** ecosystems, root directory.
- **Weekly** schedule.
- **Minor/patch grouped** into a single PR per ecosystem (so only majors get individual, reviewable PRs) — keeps noise low.
- npm `open-pull-requests-limit: 10` for headroom on major-update PRs.

## Not covered (by design — Dependabot can't)
Dependabot does **not** update the `packageManager` (pnpm) pin or the Node version in `.nvmrc`. Those two toolchain pins stay on a manual cadence (or a future Renovate setup). Everything else — runtime/dev deps and Action versions — is now automated.

Reviewed with `/simplify` (config-only): dropped redundant `patterns: ["*"]` and `day: monday` defaults; otherwise clean.