### PR TITLE
ci: add pull_request checks workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+# Verifies pull requests (including Dependabot dependency bumps) without
+# deploying. The deploy workflow only runs on push to main, so without this
+# PRs would merge with no checks at all.
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        # version comes from the "packageManager" field in package.json
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build:prod


### PR DESCRIPTION
## Problem
The deploy workflow only triggers on `push: main`, so PRs (including Dependabot bumps) ran **no checks at all** and merged unverified.

## Fix
Add `.github/workflows/ci.yml` triggered on `pull_request` to main, running **lint + test + build:prod** (mirroring the deploy build incl. Playwright Chromium) with no AWS/deploy steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)