### PR TITLE
fix(auth): fix AuthContext type error and Fast Refresh warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "personal-website",
   "private": true,
-  "version": "1.10.1",
+  "version": "1.10.2",
   "type": "module",
   "packageManager": "pnpm@11.9.0",
   "engines": {

--- a/src/contexts/AuthContext/AuthContext.test.tsx
+++ b/src/contexts/AuthContext/AuthContext.test.tsx
@@ -1,7 +1,7 @@
 import * as authApi from '@api/auth'
 import { render, screen, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { AuthProvider, useAuth } from './AuthContext'
+import { AuthProvider, useAuth } from '.'
 
 vi.mock('@api/auth', () => ({
   login: vi.fn(),

--- a/src/contexts/AuthContext/AuthProvider.tsx
+++ b/src/contexts/AuthContext/AuthProvider.tsx
@@ -1,51 +1,37 @@
 import * as authApi from '@api/auth'
 import type { AuthResult, AuthTokens, User } from '@models/auth'
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type FC, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState, type FC, type ReactNode } from 'react'
+import { AuthContext } from './context'
 
-export interface AuthContextValue {
-  user: User | null
-  isAuthenticated: boolean
-  isAdmin: boolean
-  loading: boolean
-  login: (email: string, password: string) => Promise<AuthResult>
-  logout: () => void
-  getAccessToken: () => Promise<string>
-}
-
-const decodeIdToken = (idToken: string): User => {
+const decodeJwtPayload = (token: string): Record<string, unknown> | null => {
   try {
-    const parts = idToken.split('.')
+    const parts = token.split('.')
     if (parts.length !== 3) return null
     const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
     const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
-    const payload = JSON.parse(atob(padded))
-    return {
-      email: payload.email ?? '',
-      groups: payload['cognito:groups'] ?? [],
-    }
+    return JSON.parse(atob(padded))
   } catch {
     return null
+  }
+}
+
+const decodeIdToken = (idToken: string): User | null => {
+  const payload = decodeJwtPayload(idToken)
+  if (!payload) return null
+  return {
+    email: (payload.email as string) ?? '',
+    groups: (payload['cognito:groups'] as string[]) ?? [],
   }
 }
 
 const isTokenResult = (result: AuthResult): result is AuthTokens =>
   'accessToken' in result
 
-export const AuthContext = createContext<AuthContextValue>({
-  user: null,
-  isAuthenticated: false,
-  isAdmin: false,
-  loading: true,
-  login: async () => {
-    throw new Error('Not implemented')
-  },
-  logout: () => {},
-  getAccessToken: async () => {
-    throw new Error('Not implemented')
-  },
-})
-
-export const useAuth = () => useContext(AuthContext)
+const isTokenExpired = (token: string): boolean => {
+  const payload = decodeJwtPayload(token)
+  const exp = payload?.exp as number | undefined
+  return !exp || exp * 1000 < Date.now()
+}
 
 export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
   // Start loading so server and client first render match (server can't access
@@ -126,17 +112,4 @@ export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
-}
-
-const isTokenExpired = (token: string): boolean => {
-  try {
-    const parts = token.split('.')
-    if (parts.length !== 3) return true
-    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
-    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
-    const payload = JSON.parse(atob(padded))
-    return !payload.exp || payload.exp * 1000 < Date.now()
-  } catch {
-    return true
-  }
 }

--- a/src/contexts/AuthContext/context.ts
+++ b/src/contexts/AuthContext/context.ts
@@ -1,0 +1,28 @@
+import type { AuthResult, User } from '@models/auth'
+import { createContext, useContext } from 'react'
+
+export interface AuthContextValue {
+  user: User | null
+  isAuthenticated: boolean
+  isAdmin: boolean
+  loading: boolean
+  login: (email: string, password: string) => Promise<AuthResult>
+  logout: () => void
+  getAccessToken: () => Promise<string>
+}
+
+export const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  isAuthenticated: false,
+  isAdmin: false,
+  loading: true,
+  login: async () => {
+    throw new Error('Not implemented')
+  },
+  logout: () => {},
+  getAccessToken: async () => {
+    throw new Error('Not implemented')
+  },
+})
+
+export const useAuth = () => useContext(AuthContext)

--- a/src/contexts/AuthContext/index.ts
+++ b/src/contexts/AuthContext/index.ts
@@ -1,0 +1,2 @@
+export { AuthContext, useAuth, type AuthContextValue } from './context'
+export { AuthProvider } from './AuthProvider'


### PR DESCRIPTION
## Summary

Fixes the type error and ESLint Fast Refresh warnings in `AuthContext`.

- **Type error** — `decodeIdToken` was annotated to return `User` but returns `null` on decode failure, producing a `TS2322` error. Corrected to `User | null`.
- **Fast Refresh warnings** — `AuthContext.tsx` exported a context and a hook alongside the `AuthProvider` component, triggering two `react-refresh/only-export-components` warnings. Split into:
  - `context.ts` — `AuthContext`, `useAuth`, `AuthContextValue` (non-component exports)
  - `AuthProvider.tsx` — the `AuthProvider` component only
  - `index.ts` — barrel re-export, keeping the `@contexts/AuthContext` import path stable for all ~20 importers.
- **Cleanup (`/simplify`)** — extracted the duplicated base64url JWT-decode block shared by `decodeIdToken` and `isTokenExpired` into a single `decodeJwtPayload` helper.
- Bumped version `1.10.1` → `1.10.2`.

## Testing

- `pnpm test` — 636/636 passing
- `pnpm lint` — no new warnings (the 2 AuthContext Fast Refresh warnings are gone; 3 pre-existing warnings in unrelated files remain)
- `tsc --noEmit` — no AuthContext type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)