### PR TITLE
docs: paper redesign PRD + design reference bundle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ To write a new PRD, copy `docs/prds/template.md` and fill it in.
 
 - React 19 + TypeScript
 - React Router v7 (client-side routing)
-- Vite 6
+- Vite 7
 - CSS Modules
 - Vitest + Testing Library
 - Package manager: pnpm (do not use npm or yarn)
@@ -22,9 +22,9 @@ To write a new PRD, copy `docs/prds/template.md` and fill it in.
 - Components live in `src/components/<Name>/<Name>.tsx` with a barrel `index.ts`
 - Pages live in `src/pages/<Name>/<Name>.tsx` with a barrel `index.ts`
 - Each component/page has a co-located test file `<Name>.test.tsx`
-- Use path aliases: `@api/`, `@components/`, `@contexts/`, `@hooks/`, `@pages/`, `@types/`
+- Use path aliases: `@api/`, `@components/`, `@contexts/`, `@hooks/`, `@pages/`, `@models/` (→ `src/types/`)
 - Dark mode via `data-theme` attribute on the document root
-- Neo-brutalist design: use `var(--radius-none)` for border-radius — no rounded corners on any component
+- Neo-brutalist design: use `var(--radius-none)` for border-radius — no rounded corners on any component. **NOTE: a full redesign to a warm "paper" aesthetic (soft radii, hairline borders, Geist/JetBrains Mono) is specced in `docs/prds/paper-redesign.md` (source of truth `docs/design/paper/`). This neo-brutalist mandate applies to current code and will be replaced as that redesign lands.**
 - Use const arrow functions, not function declarations — enforced by ESLint (`func-style: expression`)
 - After modifying TSX files, run `pnpm exec eslint --fix` on changed files to auto-fix import order
 - Before creating new UI elements, check `src/components/` for existing reusable components (Image, Typography, Button, Card, Link, Loading, etc.). Always prefer existing components over raw HTML tags.

--- a/docs/design/paper/README.md
+++ b/docs/design/paper/README.md
@@ -1,0 +1,215 @@
+# Handoff: akli.dev Redesign
+
+## Overview
+
+A full redesign of **akli.dev** — Akli Aissat's personal site and recipe/blog platform — plus its authenticated **admin** area. The redesign moves the product from its original "neo-brutalist" look (black/white, hard 2px borders, hard-offset shadows, system fonts) to a **warm, editorial "paper" aesthetic** with a strict two-font pairing (Geist + JetBrains Mono), soft elevation, generous whitespace, and a first-class light/dark theme.
+
+This bundle contains **11 design pages** (6 public + 5 admin) and the **design system** extracted from them (tokens, reusable components, UI kits, guidelines).
+
+## About the design files
+
+The files in this bundle are **design references authored in HTML** — prototypes that show the intended look and behavior. They are **not production code to copy directly**.
+
+- The pages under `pages/` are `*.dc.html` files. They render as self-contained HTML documents (each has inline styles and its own copy of the theme tokens) and depend on the local `pages/support.js` runtime to mount. Open any of them in a browser to see the intended result.
+- Your task is to **recreate these designs in the existing `personal-website` codebase** (React 19 + TypeScript + Vite + CSS Modules) using its established patterns — component folders at `src/components/<Name>/<Name>.tsx`, tokens at `src/styles/tokens.css`. Do **not** ship the `.dc.html` files or the `support.js` runtime.
+- The `design_system/` folder is the canonical spec for tokens and components. Where the existing repo and these designs disagree, **the redesign wins** — it is the new direction.
+
+## Fidelity
+
+**High-fidelity (hifi).** Colors, typography, spacing, radii, shadows, copy, and interactions are all final. Recreate the UI to match, using the repo's existing libraries/patterns. Exact values are in the Design Tokens section below and in `design_system/tokens/`.
+
+---
+
+## Design tokens
+
+Full source: `design_system/tokens/` (`colors.css`, `typography.css`, `spacing.css`, `fonts.css`). Two naming layers exist — semantic `--color-*` (mirrors the repo's convention) and short working aliases (`--bg`, `--text`, `--surf`, `--accent`…). Both resolve to the same values.
+
+### Color — light (default)
+| Token | Hex |
+|---|---|
+| bg (paper) | `#FBFAF7` |
+| surface | `#F4F1EA` |
+| field (inputs) | `#FFFFFF` |
+| hover wash | `rgba(0,0,0,0.022)` |
+| text-strong (headings) | `#1C1A16` |
+| text (body) | `#3A3631` |
+| text-muted | `#6F6961` |
+| text-faint (eyebrows) | `#9A938A` |
+| border | `#ECE6DA` |
+| border-strong | `#E0DACE` |
+| primary/accent | `#1F66E0` |
+| button bg / fg | `#1C1A16` / `#FBFAF7` |
+| success / bg | `#1F8A5B` / `rgba(31,138,91,.10)` |
+| warning / bg | `#A66E0A` / `rgba(194,129,12,.12)` |
+| error / bg | `#C0392B` / `rgba(192,57,43,.07)` |
+
+### Color — dark (`[data-theme="dark"]`)
+| Token | Hex |
+|---|---|
+| bg | `#141310` |
+| surface | `#1C1A15` |
+| field | `#1B1914` |
+| hover wash | `rgba(255,255,255,0.04)` |
+| text-strong | `#F3F0E8` |
+| text (body) | `#CFC9BD` |
+| text-muted | `#A6A093` |
+| text-faint | `#6E685E` |
+| border | `#2A2823` |
+| border-strong | `#36342C` |
+| primary/accent | `#6BA0FF` |
+| button bg / fg | `#F3F0E8` / `#141310` |
+| success / warning / error | `#62C08D` / `#E0A93B` / `#E8786B` |
+
+Theming is **first-class**: every component must work in both themes. Theme is set via `data-theme` on a root ancestor and persisted to `localStorage('akli-theme')`; default falls back to `prefers-color-scheme`.
+
+### Typography
+- **Geist** — all UI + display. **JetBrains Mono** — eyebrows, meta lines, tags, code, numerics.
+- Display headings: Geist 600, tracking `-0.03em`, line-height ~1.08, fluid via `clamp()` — hero `clamp(40px,7vw,56px)`, page title `clamp(32px,5.6vw,46px)`, section h2 `clamp(23px,3.2vw,27px)`.
+- Body: 15px UI / 16px lists / 18px long-form; line-height 1.65 (body) to 1.75 (articles).
+- Mono eyebrow: 11px, `letter-spacing:0.16em`, uppercase, faint. Meta line: 12–13px, `letter-spacing:0.04em`, middot `·` separators.
+- 4-step text hierarchy (strong → body → muted → faint) does the work; secondary text leans muted.
+
+### Spacing / radius / shadow
+- Spacing: 4px base scale (`--space-1`=4px … `--space-24`=96px).
+- Radius: 6px chips · 10px inputs/buttons · 12px code/callouts · 16px cards/panels · 18px dialogs · full pills (CTAs, badges, toggle, avatars).
+- Shadow: soft/blurred/low-opacity only. `sm 0 1px 2px rgba(0,0,0,.05)` · `md 0 4px 14px rgba(0,0,0,.08)` · `lg 0 12px 30px rgba(0,0,0,.16)` · `xl 0 24px 60px rgba(0,0,0,.28)` (dialogs). **No hard-offset shadows.**
+- Focus ring: `0 0 0 3px color-mix(in srgb, var(--accent) 15%, transparent)`.
+- Layout widths: `1080px` shell · `720px` index/hero reading column · `680px` article column · `~54ch` hero measure.
+- Motion: `.18–.25s ease` transitions; spinner + shimmer for async; small pop/fade for dialogs, slide-in for toasts. **All animation respects `prefers-reduced-motion`.**
+
+### Iconography
+Inline **outline SVG only** — `stroke="currentColor"`, `stroke-width:2`, round caps/joins (Lucide-grade; Lucide is the drop-in match). No filled icons, no icon font. A few Unicode glyphs stand in: `☾`/`☀` toggle, `✓`/`✕`, `·`, `↗`/`←`. **Emoji only** in the article Callout (💡 tip, ⚠️ warning, ℹ️ info).
+
+---
+
+## Global shell (all pages)
+
+**Header** (`design_system/components/navigation/Header.jsx`) — sticky, translucent (`backdrop-filter: blur(10px)` over a `color-mix` bg), 1px bottom border, `1080px` inner width, `18px` vertical padding.
+- **Public variant:** wordmark "Akli Aissat" (→ `/`) on the left; nav links Apps / Recipes / Blog + `ThemeToggle` on the right.
+- **Admin variant:** same wordmark; nav links Recipes / Users; right cluster = signed-in email + "Log out" (outline button) + `ThemeToggle`.
+- Nav links: 14px, muted; **active link** is full-strength text, weight 500, **no underline bar**; hover tints to accent. Brand + links share the `.ds-link` hover treatment.
+
+**Footer** — 1px top border, `1080px` width. Public: "Elsewhere" label + GitHub / LinkedIn / Email links, and "akli.dev" at the right. Admin: "akli.dev admin" + "Signed in as {email}".
+
+**ThemeToggle** — 32px round outline button; ☾ in light / ☀ in dark. Hover shades subtly (theme-aware, not accent). Persists to `localStorage('akli-theme')`.
+
+---
+
+## Screens / views
+
+### PUBLIC
+
+#### 1. Home — `pages/Home.dc.html`
+- **Purpose:** Landing page; intro + jump-off points to Apps, Recipes, Blog.
+- **Layout:** Shell header; hero in the `720px` reading column (mono eyebrow → large Geist title → muted lead); then stacked link sections and a "From the Kitchen" recipe rail; footer.
+- **Sections:** "Apps & Experiments" and "Blog" render as **link sections** (a titled list of rows, each row a title + arrow that nudges on hover, with an "All →" link). The kitchen rail uses **RecipeCard**s. (These were inlined into the page from former shared components — see design system for the reusable versions.)
+- **Interactions:** Section-heading links and row arrows nudge right on hover; recipe cards lift + cover zooms.
+
+#### 2. Apps — `pages/Apps.dc.html`
+- **Purpose:** Grid of apps/experiments (e.g. Pokédex).
+- **Layout:** Header; hero (eyebrow + title + lead); a responsive grid of app cards, each with a preview image/placeholder, title, description, and tag chips; footer.
+- **Components:** App cards (rounded, hairline border, hover lift), mono tag chips, "Read the blog" link with a nudging icon.
+
+#### 3. Blog (index) — `pages/Blog.dc.html`
+- **Purpose:** Editorial post index — deliberately distinct from the card grids.
+- **Layout:** Header; hero; then a **reading list**: each post is a large tappable row with a mono meta line (`date · read-time`), a title that tints accent on hover (its `↗` nudges up-right), a description, and tech-tag chips.
+- **Interactions:** Tag chips are **live filters** — clicking filters the list, highlights the active tag (in the filter bar and within posts), updates the count ("2 posts tagged react"), and syncs `?tag=` in the URL; reads `?tag=` on load. A bordered "✕ clear" pill resets. Empty state if a tag has no matches.
+- **State:** `activeTag` (nullable), synced to URL query.
+
+#### 4. Blog post — `pages/Blog Post.dc.html`
+- **Purpose:** Long-form technical article (reference content = the Pokédex build).
+- **Layout:** Header; back link ("← All posts", icon nudges left); article header (meta line, big title, clickable tag chips → `/blog?tag=…`); hero cover image + caption; then the **680px prose column**.
+- **Components:** Prose (18px / 1.75); **CodeBlock** (filename header + Copy button that flips to "Copied ✓" ~1.6s; horizontal scroll; theme-aware); inline code chips; a file-tree block; a rendered architecture diagram (stack cards with region badges — mark `data-om-raster` equivalent if exporting); **Callout** (tip/warning/info — emoji + colored uppercase label + subtle tint, no left-accent-bar); Share (X / LinkedIn) row; a Related-posts card.
+
+#### 5. Recipes (index) — `pages/Recipes.dc.html`
+- **Purpose:** Recipe index.
+- **Layout:** Header; hero; a controls row = **search input** (rounded, magnifier icon, ✕ clear) + **category filter chips** (all / Pasta / Mains / Quick / Baking); a responsive **RecipeCard** grid; footer.
+- **Interactions:** Search filters title/description/category live; category chips filter and sync `?category=` in the URL; the two combine. Empty state ("Nothing in the kitchen matches that") with a bordered "✕ clear filters" pill. RecipeCards lift + cover zooms on hover.
+- **State:** `query` (string), `category` (nullable, URL-synced).
+
+#### 6. Recipe detail — `pages/Recipe.dc.html`
+- **Purpose:** Public read view of one recipe.
+- **Layout:** Header; back link; cover image; recipe header (title, mono meta `date · prep · cook · serves`, clickable tag chips, intro); then a **two-column** body — a **sticky Ingredients card** (left) beside the **numbered Method** (right). Collapses to one column on narrow screens.
+- **Interactions:** Tap any ingredient to check it off (checkbox fills accent, name strikes through). Ingredient-name color must NOT be transitioned (a `transition: color` on a `var()` token mis-renders across theme switch — set it directly).
+
+### ADMIN
+
+Admin pages sit inside the shell (admin variant), **except Login**. Each functional page includes a small **bottom-left preview switcher** (design-time only — segmented control to jump between states); this is a prototype affordance and should **not** be reproduced in production.
+
+#### 7. Login — `pages/Admin Login.dc.html`
+- **Purpose:** Authentication; the only page outside the admin shell (it uses the public header/footer).
+- **Layout:** Centered card, single column, on the paper background.
+- **States (never both at once):** (a) **Log in** — email + password + submit (shows a loading state while signing in) + inline error area ("Incorrect email or password"). (b) **Set new password** (first-time users) — new-password + confirm-password + submit + inline error ("Passwords do not match"). Log-in first, then the set-password step if the account requires it.
+
+#### 8. Recipe list (admin home) — `pages/Admin Recipes.dc.html`
+- **Purpose:** Manage all recipes, sorted by most-recently-updated.
+- **Layout:** Shell; page header ("Recipes" + count subtitle + prominent "New recipe" button); a bordered list. Each row: title, **StatusBadge** (Published=green / Draft=amber dot-pill), tag chips, last-updated date, and per-row actions (Edit / Preview / Publish↔Unpublish / Delete).
+- **Interactions:** Delete opens a **ConfirmDialog** ("Are you sure you want to delete …?"). **Toasts** appear bottom-right for events (e.g. access-denied) — quiet pill, click-anywhere to dismiss, faint ✕ reveals on hover, auto-dismiss ~3.6s.
+- **Secondary states:** empty ("No recipes yet" + "Create your first recipe"), loading (spinner panel), error (with Retry).
+
+#### 9. Recipe editor — `pages/Admin Recipe Editor.dc.html`
+- **Purpose:** Create/edit one recipe with **autosave** (no manual save button).
+- **Layout:** Shell; "← Back to recipes"; a status pill; a **two-column** body — long form (left) + **sticky action rail** (right).
+- **Form fields (grouped):** title; **URL slug** (live `akli.dev/recipes/[slug]` preview, "Reset to title" helper, and a **locked** state with explanation once any image exists); intro; **cover image** upload + alt-text field (alt appears only once an image is uploaded; required if an image exists); prep/cook/servings (numeric); **TagInput** (chips + add-on-Enter + suggestions from existing tags); **ingredients** (qty + name rows; add/remove/reorder); **steps** (each: text + optional own image upload **and its own alt-text field**, required only if that step image exists).
+- **Autosave indicator (rail):** debounces ~1.5s after typing → **Saving…** → **Saved just now / Saved at 2:30 PM**; on failure → **Couldn't save · Retry**.
+- **Actions (state-aware, rail):** a **draft** shows **Publish** + **Discard draft**; a **published** recipe shows **Update** + **Unpublish** + "View live recipe". **Publish is disabled** until a **"Before publishing" checklist** passes (title, intro, cover image, cover alt text, ≥1 ingredient, ≥1 step, no image still processing) — each item ticks green as satisfied.
+- **Async images:** upload shows a **processing shimmer** placeholder, then the image + remove + alt field. Images uploading = publish blocked.
+- **Supporting moments:** loading (draft init), **discard** confirm dialog, **unsaved-changes** dialog (if navigating away mid-save), **session-expired** banner ("Log in again"), **image-taking-longer** notice, success/error toasts.
+- **State:** `recipe` object (title, slug, slugEdited, intro, cover{state,url,alt}, prep, cook, servings, tags[], ingredients[{id,qty,name}], steps[{id,text,image{state,url,alt}}]); `save` {state, at}; dialog/banner flags. Image state machine: `empty → processing → ready`.
+
+#### 10. Recipe preview — `pages/Admin Recipe Preview.dc.html`
+- **Purpose:** Read-only view of exactly how a recipe will look on the public site, rendered with the real public recipe layout.
+- **Layout:** A **status banner** at the top, then the full public recipe below it.
+  - **Unpublished:** banner reads "Preview — this recipe is not yet published" with **Edit** and **Publish** actions.
+  - **Published:** banner reads "This recipe is published" with **Edit** and **View public page** actions.
+- The banner is translucent/blurred like the nav (so content reads softly beneath when sticky). Also needs **loading** and **"Recipe not found"** states.
+
+#### 11. User management (admin only) — `pages/Admin Users.dc.html`
+- **Purpose:** Manage access.
+- **Layout:** Shell; page header ("Users" + count + "Invite user" button); a bordered list — each user shows avatar/initial, email, **role** (Admin=accent pill / Contributor=neutral), **status** (Confirmed=green / Pending=amber dot), and a **Remove** action (except the current user, marked "YOU", who has none).
+- **Invite:** "Invite user" opens an **inline form** (slides down) — email field + role segmented control (Contributor / Admin) + Send/Cancel, aligned on one row beneath their labels. Send shows a spinner. Inline errors: "A user with this email already exists." / "Enter a valid email address." A role hint line explains each role.
+- **Remove:** **ConfirmDialog** ("Remove {email}? They will lose access immediately. This can't be undone.") with a danger (red) confirm.
+- **Toasts:** "Invite sent to {email}.", "User {email} removed."
+- **Secondary states:** loading (spinner), error (with Retry).
+- **Note:** the role segmented control must set its active background via inline style, not an attribute selector + transition (that mis-rendered in testing).
+
+---
+
+## Interactions & behavior (cross-cutting)
+
+- **Icon nudge (signature):** directional icons animate on hover via `transform` (`.25s ease`) — back chevrons slide left, forward/CTA arrows right, `↗` up-right. See `.ds-link` rules in `design_system/components/_helpers.css`.
+- **RecipeCard hover:** card lifts (`translateY(-4px)` + soft shadow), cover image zooms (`scale(1.04)`).
+- **Filter chips / dashed suggestions:** border + text tint to accent on hover; active filter fills solid accent.
+- **Toasts:** bottom-right stack, slide-in, click-anywhere dismiss, faint ✕ on hover, auto-dismiss ~3.6s.
+- **Dialogs:** scrim (`color-mix #000 38%`), pop-in, click-scrim or Cancel dismiss; danger variant = red confirm + alert icon.
+- **URL sync:** blog `?tag=`, recipes `?category=` — write on change, read on load.
+- **prefers-reduced-motion:** disables spinner/shimmer/nudge/card-lift transitions everywhere.
+
+## State management (summary)
+- **Theme:** `localStorage('akli-theme')` ('light'|'dark'), default from `prefers-color-scheme`, reflected on `data-theme`.
+- **Blog:** `activeTag` ↔ `?tag=`. **Recipes:** `query` + `category` ↔ `?category=`.
+- **Editor:** `recipe` model + debounced `save` state machine + async image state (`empty→processing→ready`) + publish-checklist derivation + dialog/banner flags.
+- **Users:** `users[]`, inline-invite form state (email/role/sending/error), `removeId` for the confirm dialog, `toasts[]`.
+- **Login:** `mode` ('login'|'setPassword'), field values, `loading`, inline `error`.
+
+## Assets
+- **Fonts:** Geist + JetBrains Mono (Google Fonts via `design_system/tokens/fonts.css`). The repo currently uses system fonts — adopting these is a deliberate redesign change. For production, consider self-hosting woff2 `@font-face` to avoid external requests.
+- **Images:** the pages reference real akli.dev images (recipe covers, blog cover) and some Unsplash placeholders for recipe cards. Replace placeholders with real assets; keep alt text.
+- **Logo:** none — the brand is a **wordmark only** ("Akli Aissat"). No favicon/mark was provided.
+- **Icons:** hand-inlined outline SVG; **Lucide** is the matching set to adopt in-repo.
+
+## Files in this bundle
+- `pages/` — the 11 `*.dc.html` design references + `support.js` (runtime needed only to view them; do not ship).
+- `design_system/` — canonical spec:
+  - `styles.css` (entry; `@import`s everything), `tokens/` (colors, typography, spacing, fonts)
+  - `components/` — reusable primitives grouped by concern (core, forms, feedback, overlays, navigation, content); each has `<Name>.jsx`, a `<Name>.d.ts` props contract, and a `<Name>.prompt.md` usage note; plus `_helpers.css` (hover/focus/animation rules)
+  - `ui_kits/` — `public/` and `admin/` full-screen compositions
+  - `guidelines/` — foundation specimen cards (Type, Colors, Spacing)
+  - `readme.md` — the design-system narrative (voice, visual foundations, iconography, old→new shift)
+  - `SKILL.md` — skill manifest
+
+## Suggested implementation order
+1. Land tokens into `src/styles/tokens.css` (both themes) + wire the theme toggle/persistence.
+2. Build shared primitives (Button, Link, Header, Card, Tag, StatusBadge, Input/Textarea, Toast, ConfirmDialog, ThemeToggle).
+3. Public pages (Home → Apps → Blog → Blog post → Recipes → Recipe).
+4. Admin shell + Login, then Recipe list → Editor (largest) → Preview → Users.

--- a/docs/design/paper/design_system/SKILL.md
+++ b/docs/design/paper/design_system/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: akli-dev-design
+description: Use this skill to generate well-branded interfaces and assets for akli.dev (Akli Aissat's personal site + recipe/blog platform), either for production or throwaway prototypes/mocks. Contains the warm-paper design language — colors, type, fonts, tokens, reusable components, and full-screen UI kits for the public site and admin.
+user-invocable: true
+---
+
+Read the `readme.md` file within this skill first, then explore the other files:
+
+- `styles.css` — link this one file; it `@import`s all tokens, fonts, and component helpers.
+- `tokens/` — colors (light + dark), typography (Geist + JetBrains Mono), spacing/radius/shadow.
+- `components/` — reusable React primitives grouped by concern (core, forms, feedback, overlays, navigation, content). Each has `<Name>.jsx`, a `<Name>.d.ts` props contract, and a `<Name>.prompt.md` usage note.
+- `ui_kits/public` and `ui_kits/admin` — full-screen recreations showing how the pieces compose.
+- `guidelines/` — foundation specimen cards (Type, Colors, Spacing).
+
+If creating visual artifacts (slides, mocks, throwaway prototypes), copy assets out and produce static HTML for the user to view. If working on production code, copy assets and follow the rules here to design as an expert in this brand.
+
+Core rules to honor:
+- Warm paper (`#FBFAF7`), never pure white; true warm near-black in dark mode. Light/dark theming is first-class — support both.
+- Two fonts only: Geist (UI/display) + JetBrains Mono (eyebrows/meta/tags/code).
+- One blue accent, used sparingly. Hairline borders, soft rounding, soft low-opacity shadows.
+- Voice: first-person, plain, dry. No hype, no cheese, sentence case, mono uppercase eyebrows only. No emoji except the three Callout glyphs.
+- Outline SVG icons (Lucide-grade); directional icons nudge on hover.
+
+If the user invokes this skill without other guidance, ask what they want to build, ask a few clarifying questions, and act as an expert designer who outputs HTML artifacts **or** production code depending on the need.

--- a/docs/design/paper/design_system/components/_helpers.css
+++ b/docs/design/paper/design_system/components/_helpers.css
@@ -1,0 +1,54 @@
+/* ── Component interaction helpers ─────────────────────────────
+   Hover/focus/animation rules that can't live in inline style objects.
+   Imported by styles.css so they ship with the system. */
+
+/* Fields */
+.ds-field:focus { border-color: var(--color-primary) !important; box-shadow: var(--ring); }
+.ds-field:disabled { background: var(--color-surface); color: var(--color-text-muted); cursor: not-allowed; }
+
+/* Links — hover tint + icon nudge */
+.ds-link:hover { color: var(--color-primary); }
+.ds-link .ds-link-ic { display: inline-flex; transition: transform .25s ease; }
+.ds-link.nudge-right:hover  .ds-link-ic { transform: translateX(3px); }
+.ds-link.nudge-left:hover   .ds-link-ic { transform: translateX(-3px); }
+.ds-link.nudge-up-right:hover .ds-link-ic { transform: translate(3px,-3px); }
+
+/* Cards & tags */
+.ds-card-hover:hover { background: var(--color-hover); }
+
+/* Recipe card — lift + cover zoom (the signature hover) */
+.ds-recipe-card { transition: transform .3s cubic-bezier(.2,.7,.2,1), box-shadow .3s ease; }
+.ds-recipe-card:hover { transform: translateY(-4px); box-shadow: 0 14px 34px rgba(0,0,0,0.10); }
+.ds-recipe-card .ds-recipe-img { transition: transform .5s cubic-bezier(.2,.7,.2,1); }
+.ds-recipe-card:hover .ds-recipe-img { transform: scale(1.04); }
+
+/* Toast — reveal the ✕ on hover */
+.ds-toast:hover { border-color: color-mix(in srgb, var(--color-text-strong) 18%, var(--color-border)); }
+.ds-toast:hover .ds-toast-x { opacity: 1; color: var(--color-text-muted); }
+.ds-tag-btn:hover { border-color: var(--color-primary); color: var(--color-primary); }
+.ds-suggest:hover { color: var(--color-primary); border-color: var(--color-primary); }
+.ds-upload:hover { border-color: var(--color-primary); background: var(--color-hover); }
+.ds-iconbtn-danger:hover { color: var(--color-error); border-color: color-mix(in srgb, var(--color-error) 40%, var(--color-border)); }
+
+/* Theme toggle — subtle theme-aware hover shade (no accent) */
+.ds-toggle:hover { border-color: var(--color-border-strong); background: color-mix(in srgb, var(--color-text-strong) 6%, transparent); }
+
+/* Header — sticky translucent blur */
+.ds-header-sticky { position: sticky; top: 0; z-index: var(--z-header); background: color-mix(in srgb, var(--color-bg) 84%, transparent); backdrop-filter: saturate(140%) blur(10px); -webkit-backdrop-filter: saturate(140%) blur(10px); }
+
+/* Spinner */
+.ds-spinner { width: 24px; height: 24px; border-radius: 50%; border: 3px solid var(--color-border); border-top-color: var(--color-primary); animation: ds-spin .7s linear infinite; }
+.ds-spinner.sm { width: 15px; height: 15px; border-width: 2px; }
+@keyframes ds-spin { to { transform: rotate(360deg); } }
+@keyframes btn-spin { to { transform: rotate(360deg); } }
+
+/* Shimmer (processing placeholders) */
+.ds-shimmer { background: linear-gradient(100deg, var(--color-surface) 30%, var(--color-hover) 50%, var(--color-surface) 70%); background-size: 200% 100%; animation: ds-sh 1.3s linear infinite; }
+@keyframes ds-sh { to { background-position: -200% 0; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .ds-spinner, .ds-shimmer, .ds-link-ic { animation: none; transition: none; }
+  .ds-recipe-card, .ds-recipe-card .ds-recipe-img { transition: none; }
+  .ds-recipe-card:hover { transform: none; }
+  .ds-recipe-card:hover .ds-recipe-img { transform: none; }
+}

--- a/docs/design/paper/design_system/components/content/CodeBlock.d.ts
+++ b/docs/design/paper/design_system/components/content/CodeBlock.d.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Content" subtitle="Code panel — filename header + copy button" viewport="700x200"
+ */
+export interface CodeBlockProps {
+  /** Header label (path). Omit for a bare panel. */
+  filename?: string;
+  code: string;
+}
+
+export function CodeBlock(props: CodeBlockProps): JSX.Element;

--- a/docs/design/paper/design_system/components/content/CodeBlock.jsx
+++ b/docs/design/paper/design_system/components/content/CodeBlock.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+/**
+ * CodeBlock — fenced code panel with a filename header and a Copy button that
+ * flips to "Copied". Theme-aware (light/dark) via tokens.
+ */
+export function CodeBlock({ filename, code = '' }) {
+  const [copied, setCopied] = React.useState(false);
+  const copy = () => {
+    try { navigator.clipboard.writeText(code); } catch (e) {}
+    setCopied(true); setTimeout(() => setCopied(false), 1600);
+  };
+  return (
+    <div style={{ margin: '28px 0', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-lg)', overflow: 'hidden', background: 'var(--color-surface)' }}>
+      {filename && (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '12px', fontFamily: 'var(--font-mono)', fontSize: '12px', color: 'var(--color-text-muted)', padding: '8px 10px 8px 16px', borderBottom: '1px solid var(--color-border)' }}>
+          <span>{filename}</span>
+          <button onClick={copy} className="ds-tag-btn" style={{ fontFamily: 'var(--font-mono)', fontSize: '11px', color: copied ? 'var(--color-primary)' : 'var(--color-text-muted)', background: 'transparent', border: '1px solid ' + (copied ? 'var(--color-primary)' : 'var(--color-border)'), padding: '3px 9px', borderRadius: 'var(--radius-sm)', cursor: 'pointer' }}>{copied ? 'Copied' : 'Copy'}</button>
+        </div>
+      )}
+      <pre style={{ margin: 0, padding: '18px 16px', overflowX: 'auto', fontFamily: 'var(--font-mono)', fontSize: '13px', lineHeight: 1.7, color: 'var(--color-text)', whiteSpace: 'pre' }}>{code}</pre>
+    </div>
+  );
+}

--- a/docs/design/paper/design_system/components/content/CodeBlock.prompt.md
+++ b/docs/design/paper/design_system/components/content/CodeBlock.prompt.md
@@ -1,0 +1,5 @@
+**CodeBlock** — fenced code in blog articles. Filename header on the left, a Copy button on the right that flips to "Copied" for ~1.6s. Horizontal scroll for long lines; theme-aware.
+
+```jsx
+<CodeBlock filename="lib/pokedex-stack.ts" code={src} />
+```

--- a/docs/design/paper/design_system/components/content/RecipeCard.d.ts
+++ b/docs/design/paper/design_system/components/content/RecipeCard.d.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Content" subtitle="Recipe grid card — cover, title, meta" viewport="700x340"
+ */
+export interface RecipeCardProps {
+  href?: string;
+  img?: string;
+  title: string;
+  desc?: string;
+  prep?: string;
+  cook?: string;
+  serves?: string;
+}
+
+export function RecipeCard(props: RecipeCardProps): JSX.Element;

--- a/docs/design/paper/design_system/components/content/RecipeCard.jsx
+++ b/docs/design/paper/design_system/components/content/RecipeCard.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+/**
+ * RecipeCard — image-topped card for the recipe grid: cover photo, title,
+ * one-line description, and a mono prep/cook/serves meta row.
+ */
+export function RecipeCard({ href = '#', img, title, desc, prep, cook, serves }) {
+  return (
+    <a href={href} className="ds-recipe-card" style={{ display: 'flex', flexDirection: 'column', textDecoration: 'none', color: 'inherit', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-xl)', overflow: 'hidden', background: 'var(--color-bg)' }}>
+      <div style={{ aspectRatio: '3/2', background: 'var(--color-surface)', overflow: 'hidden' }}>
+        {img && <img className="ds-recipe-img" src={img} alt="" style={{ display: 'block', width: '100%', height: '100%', objectFit: 'cover' }} />}
+      </div>
+      <div style={{ padding: '18px 20px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <h3 style={{ fontSize: '18px', fontWeight: 600, letterSpacing: '-0.02em', margin: 0, color: 'var(--color-text-strong)' }}>{title}</h3>
+        <p style={{ fontSize: '14px', lineHeight: 1.55, color: 'var(--color-text-muted)', margin: 0 }}>{desc}</p>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 14px', marginTop: '6px', fontFamily: 'var(--font-mono)', fontSize: '12px', color: 'var(--color-text-faint)' }}>
+          {prep && <span>Prep: {prep}</span>}
+          {cook && <span>Cook: {cook}</span>}
+          {serves && <span>Serves: {serves}</span>}
+        </div>
+      </div>
+    </a>
+  );
+}

--- a/docs/design/paper/design_system/components/content/RecipeCard.prompt.md
+++ b/docs/design/paper/design_system/components/content/RecipeCard.prompt.md
@@ -1,0 +1,8 @@
+**RecipeCard** — image-topped card for the recipes grid (and the home "From the Kitchen" rail). Cover photo (3:2), title, one-line description, mono prep/cook/serves meta. On hover the whole card lifts (translateY + soft shadow) and the cover zooms slightly — the site's signature card interaction (needs `.ds-recipe-card` / `.ds-recipe-img` from the bundle; both respect `prefers-reduced-motion`).
+
+```jsx
+<RecipeCard href="/recipes/thai-basa" img={cover}
+  title="Mild Thai-Style Basa & Coconut Rice"
+  desc="A comforting Thai-infused rice and fish one pot."
+  prep="5 min" cook="30 min" serves="2" />
+```

--- a/docs/design/paper/design_system/components/content/content.card.html
+++ b/docs/design/paper/design_system/components/content/content.card.html
@@ -1,0 +1,33 @@
+<!-- @dsCard group="Components" viewport="700x360" subtitle="CodeBlock · RecipeCard" name="Content" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:24px; display:flex; gap:22px; flex-wrap:wrap; align-items:flex-start; }
+  .code { width:330px; border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; background:var(--surf); }
+  .chead { display:flex; align-items:center; justify-content:space-between; font-family:var(--font-mono); font-size:12px; color:var(--muted); padding:8px 10px 8px 16px; border-bottom:1px solid var(--line); }
+  .copy { font-family:var(--font-mono); font-size:11px; color:var(--muted); background:transparent; border:1px solid var(--line); padding:3px 9px; border-radius:var(--radius-sm); }
+  pre { margin:0; padding:16px; font-family:var(--font-mono); font-size:12.5px; line-height:1.7; color:var(--subtle); overflow-x:auto; }
+  .rc { width:240px; border:1px solid var(--line); border-radius:var(--radius-xl); overflow:hidden; background:var(--bg); text-decoration:none; color:inherit; display:block; }
+  .rcimg { aspect-ratio:3/2; background:linear-gradient(135deg,#E8DFC9,#D6C7A8); }
+  .rcbody { padding:16px 18px; }
+  .rctitle { font-size:17px; font-weight:600; letter-spacing:-0.02em; margin:0 0 6px; }
+  .rcdesc { font-size:13.5px; line-height:1.5; color:var(--muted); margin:0 0 12px; }
+  .rcmeta { font-family:var(--font-mono); font-size:11.5px; color:var(--faint); display:flex; gap:12px; flex-wrap:wrap; }
+</style></head>
+<body>
+  <div class="code">
+    <div class="chead"><span>lib/pokedex-stack.ts</span><button class="copy">Copy</button></div>
+    <pre>const hash = crypto
+  .createHash('md5')
+  .update(data)
+  .digest('hex')</pre>
+  </div>
+  <a class="rc">
+    <div class="rcimg"></div>
+    <div class="rcbody">
+      <h3 class="rctitle">Weekend Shakshuka</h3>
+      <p class="rcdesc">Eggs poached in a spiced tomato and pepper sauce.</p>
+      <div class="rcmeta"><span>Prep: 10 min</span><span>Cook: 25 min</span><span>Serves: 2</span></div>
+    </div>
+  </a>
+</body></html>

--- a/docs/design/paper/design_system/components/core/Button.d.ts
+++ b/docs/design/paper/design_system/components/core/Button.d.ts
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Core" subtitle="Primary action control — solid, outline, danger; pill or rounded" viewport="700x150"
+ */
+export interface ButtonProps {
+  /** Visual weight. @default 'solid' */
+  variant?: 'solid' | 'outline' | 'danger';
+  /** Corner treatment. `pill` for marketing CTAs, `rounded` for forms. @default 'rounded' */
+  shape?: 'rounded' | 'pill';
+  /** @default 'md' */
+  size?: 'sm' | 'md';
+  type?: 'button' | 'submit' | 'reset';
+  disabled?: boolean;
+  /** Shows a spinner and blocks interaction. @default false */
+  loading?: boolean;
+  iconLeft?: React.ReactNode;
+  iconRight?: React.ReactNode;
+  fullWidth?: boolean;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+export function Button(props: ButtonProps): JSX.Element;

--- a/docs/design/paper/design_system/components/core/Button.jsx
+++ b/docs/design/paper/design_system/components/core/Button.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+/**
+ * Button — the brand's primary action control.
+ * Two form factors from the redesign: `pill` (public marketing CTAs) and
+ * `rounded` (10px, admin/forms). Variants map to the warm-paper palette.
+ */
+export function Button({
+  variant = 'solid',     // 'solid' | 'outline' | 'danger'
+  shape = 'rounded',     // 'rounded' | 'pill'
+  size = 'md',           // 'sm' | 'md'
+  type = 'button',
+  disabled = false,
+  loading = false,
+  iconLeft = null,
+  iconRight = null,
+  fullWidth = false,
+  onClick,
+  children,
+  style = {},
+}) {
+  const pad = size === 'sm'
+    ? (shape === 'pill' ? '8px 16px' : '8px 13px')
+    : (shape === 'pill' ? '12px 24px' : '11px 16px');
+
+  const base = {
+    fontFamily: 'var(--font-sans)',
+    fontSize: size === 'sm' ? '13px' : '14px',
+    fontWeight: variant === 'outline' ? 500 : 600,
+    lineHeight: 1.2,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '8px',
+    padding: pad,
+    borderRadius: shape === 'pill' ? 'var(--radius-full)' : 'var(--radius-md)',
+    cursor: disabled || loading ? 'not-allowed' : 'pointer',
+    width: fullWidth ? '100%' : 'auto',
+    opacity: disabled ? 0.45 : 1,
+    transition: 'opacity .2s ease, border-color .2s ease, color .2s ease, background .2s ease, transform .06s ease',
+    whiteSpace: 'nowrap',
+  };
+
+  const variants = {
+    solid:   { color: 'var(--color-btn-fg)', background: 'var(--color-btn-bg)', border: '1px solid var(--color-btn-bg)' },
+    outline: { color: 'var(--color-text)', background: 'transparent', border: '1px solid var(--color-border-strong)' },
+    danger:  { color: '#fff', background: 'var(--color-error)', border: '1px solid var(--color-error)' },
+  };
+
+  return (
+    <button
+      type={type}
+      disabled={disabled || loading}
+      onClick={onClick}
+      style={{ ...base, ...variants[variant], ...style }}
+    >
+      {loading && <Spinner />}
+      {!loading && iconLeft}
+      {children}
+      {!loading && iconRight}
+    </button>
+  );
+}
+
+function Spinner() {
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: '14px', height: '14px', borderRadius: '50%',
+        border: '2px solid currentColor', borderTopColor: 'transparent',
+        display: 'inline-block', animation: 'btn-spin .7s linear infinite',
+      }}
+    />
+  );
+}

--- a/docs/design/paper/design_system/components/core/Button.prompt.md
+++ b/docs/design/paper/design_system/components/core/Button.prompt.md
@@ -1,0 +1,13 @@
+**Button** — the brand's primary action control; use for any submit/confirm/CTA. Solid (inverted dark on paper) for the main action, outline for secondary, danger for destructive.
+
+```jsx
+<Button variant="solid" onClick={save}>Publish</Button>
+<Button variant="outline">Discard draft</Button>
+<Button variant="solid" shape="pill" iconRight={<Arrow/>}>Email me</Button>
+<Button variant="danger" loading>Removing…</Button>
+```
+
+- **shape**: `pill` for public marketing CTAs, `rounded` (10px) for admin/forms.
+- **variant**: `solid` | `outline` | `danger`.
+- **loading** swaps content for a spinner and disables the button.
+- Requires the `@keyframes btn-spin` from the components bundle (or define `0%→360%` rotate) for the loading spinner.

--- a/docs/design/paper/design_system/components/core/Card.d.ts
+++ b/docs/design/paper/design_system/components/core/Card.d.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Core" subtitle="Rounded container — hairline border, optional fill + hover" viewport="700x200"
+ */
+export interface CardProps {
+  as?: keyof JSX.IntrinsicElements;
+  /** Surface fill vs page background. @default false */
+  fill?: boolean;
+  /** CSS padding value. @default var(--space-6) */
+  padding?: string;
+  /** CSS border-radius. @default var(--radius-xl) */
+  radius?: string;
+  /** Subtle hover wash for clickable cards. @default false */
+  hover?: boolean;
+  onClick?: (e: React.MouseEvent) => void;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+export function Card(props: CardProps): JSX.Element;

--- a/docs/design/paper/design_system/components/core/Card.jsx
+++ b/docs/design/paper/design_system/components/core/Card.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * Card — generic rounded container: hairline border, optional surface fill,
+ * optional hover wash (for clickable cards). The base box for recipe cards,
+ * panels, callouts, dialogs.
+ */
+export function Card({
+  as = 'div',
+  fill = false,          // true → surface background, false → bg
+  padding = 'var(--space-6)',
+  radius = 'var(--radius-xl)',
+  hover = false,         // subtle hover wash for interactive cards
+  onClick,
+  children,
+  style = {},
+}) {
+  const Tag = as;
+  return (
+    <Tag
+      onClick={onClick}
+      className={hover ? 'ds-card-hover' : undefined}
+      style={{
+        background: fill ? 'var(--color-surface)' : 'var(--color-bg)',
+        border: '1px solid var(--color-border)',
+        borderRadius: radius,
+        padding,
+        transition: 'background .25s ease, border-color .25s ease',
+        ...style,
+      }}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/docs/design/paper/design_system/components/core/Card.prompt.md
+++ b/docs/design/paper/design_system/components/core/Card.prompt.md
@@ -1,0 +1,10 @@
+**Card** — the brand's rounded container (16px radius, hairline border). Base box for recipe cards, side panels, callouts, dialogs.
+
+```jsx
+<Card fill padding="22px">Ingredients…</Card>
+<Card hover onClick={open}>Clickable recipe card</Card>
+```
+
+- **fill** uses the surface tone; default uses page background.
+- **hover** adds the subtle wash used on interactive cards (needs the bundle's `.ds-card-hover:hover{background:var(--hover)}`).
+- Soft elevation isn't on by default — pass `style={{ boxShadow: 'var(--shadow-md)' }}` when a card should lift.

--- a/docs/design/paper/design_system/components/core/Link.d.ts
+++ b/docs/design/paper/design_system/components/core/Link.d.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Core" subtitle="Text link with hover tint + nudging directional icon" viewport="700x120"
+ */
+export interface LinkProps {
+  href?: string;
+  /** @default 'inherit' */
+  tone?: 'inherit' | 'muted' | 'accent';
+  /** Optional icon (chevron/arrow) that animates on hover. */
+  icon?: React.ReactNode;
+  /** @default 'right' */
+  iconSide?: 'left' | 'right';
+  /** Direction the icon nudges on hover. @default 'right' */
+  nudge?: 'left' | 'right' | 'up-right' | 'none';
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+export function Link(props: LinkProps): JSX.Element;

--- a/docs/design/paper/design_system/components/core/Link.jsx
+++ b/docs/design/paper/design_system/components/core/Link.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+/**
+ * Link — inline/standalone text link. Inherits color, tints to accent on hover.
+ * Optional directional icon that nudges on hover (the brand's signature micro-interaction).
+ */
+export function Link({
+  href = '#',
+  tone = 'inherit',        // 'inherit' | 'muted' | 'accent'
+  icon = null,
+  iconSide = 'right',      // 'left' | 'right'
+  nudge = 'right',         // 'left' | 'right' | 'up-right' | 'none'
+  onClick,
+  children,
+  style = {},
+  ...rest
+}) {
+  const color = tone === 'muted' ? 'var(--color-text-muted)'
+    : tone === 'accent' ? 'var(--color-primary)'
+    : 'inherit';
+
+  const cls = 'ds-link nudge-' + nudge;
+
+  return (
+    <a
+      href={href}
+      onClick={onClick}
+      className={cls}
+      style={{
+        color,
+        textDecoration: 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '7px',
+        transition: 'color .25s ease',
+        ...style,
+      }}
+      {...rest}
+    >
+      {icon && iconSide === 'left' && <span className="ds-link-ic">{icon}</span>}
+      {children}
+      {icon && iconSide === 'right' && <span className="ds-link-ic">{icon}</span>}
+    </a>
+  );
+}

--- a/docs/design/paper/design_system/components/core/Link.prompt.md
+++ b/docs/design/paper/design_system/components/core/Link.prompt.md
@@ -1,0 +1,9 @@
+**Link** — text link that inherits color and tints to accent on hover; an optional directional icon nudges on hover (the site's signature micro-interaction).
+
+```jsx
+<Link href="/blog" tone="muted" icon={<ChevronLeft/>} iconSide="left" nudge="left">All posts</Link>
+<Link href="/recipe" tone="accent" icon={<UpRight/>} nudge="up-right">View public page</Link>
+```
+
+- **nudge**: `left` (back links), `right` (forward), `up-right` (external ↗).
+- Relies on the bundle's `.ds-link` / `.ds-link-ic` hover rules (color + transform). In a standalone context, replicate: `.ds-link:hover{color:var(--accent)} .ds-link-ic{transition:transform .25s}`.

--- a/docs/design/paper/design_system/components/core/StatusBadge.d.ts
+++ b/docs/design/paper/design_system/components/core/StatusBadge.d.ts
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Core" subtitle="Dot-pill record status — success/warning/error/neutral" viewport="700x100"
+ */
+export interface StatusBadgeProps {
+  /** @default 'neutral' */
+  tone?: 'success' | 'warning' | 'error' | 'neutral';
+  /** Show the leading dot. @default true */
+  dot?: boolean;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+export function StatusBadge(props: StatusBadgeProps): JSX.Element;

--- a/docs/design/paper/design_system/components/core/StatusBadge.jsx
+++ b/docs/design/paper/design_system/components/core/StatusBadge.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+/**
+ * StatusBadge — a small dot-pill for record state: draft/published,
+ * confirmed/pending, etc. Tone drives the color; label is free text.
+ */
+export function StatusBadge({
+  tone = 'neutral',     // 'success' | 'warning' | 'error' | 'neutral'
+  children,
+  dot = true,
+  style = {},
+}) {
+  const tones = {
+    success: { fg: 'var(--color-success)', bg: 'var(--color-success-bg)' },
+    warning: { fg: 'var(--color-warning)', bg: 'var(--color-warning-bg)' },
+    error:   { fg: 'var(--color-error)',   bg: 'var(--color-error-bg)' },
+    neutral: { fg: 'var(--color-text-muted)', bg: 'var(--color-surface)' },
+  };
+  const t = tones[tone] || tones.neutral;
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: '6px',
+      fontFamily: 'var(--font-mono)', fontSize: '10.5px',
+      letterSpacing: '0.06em', textTransform: 'uppercase',
+      padding: '4px 11px', borderRadius: 'var(--radius-full)',
+      color: t.fg, background: t.bg, ...style,
+    }}>
+      {dot && <span style={{ width: '5px', height: '5px', borderRadius: '50%', background: t.fg }} />}
+      {children}
+    </span>
+  );
+}

--- a/docs/design/paper/design_system/components/core/StatusBadge.prompt.md
+++ b/docs/design/paper/design_system/components/core/StatusBadge.prompt.md
@@ -1,0 +1,7 @@
+**StatusBadge** — mono dot-pill for record state. Map domain states to tones: Published/Confirmed → `success`, Draft/Pending → `warning`, Failed → `error`.
+
+```jsx
+<StatusBadge tone="success">Published</StatusBadge>
+<StatusBadge tone="warning">Draft</StatusBadge>
+<StatusBadge tone="neutral" dot={false}>Archived</StatusBadge>
+```

--- a/docs/design/paper/design_system/components/core/Tag.d.ts
+++ b/docs/design/paper/design_system/components/core/Tag.d.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Core" subtitle="Mono chip — tech tag, category, removable, or filter button" viewport="700x120"
+ */
+export interface TagProps {
+  /** `span` for display, `button` for an interactive filter chip. @default 'span' */
+  as?: 'span' | 'button';
+  /** Selected filter state (accent fill). @default false */
+  active?: boolean;
+  /** Adds a ✕ remove control (editor tag input). @default false */
+  removable?: boolean;
+  onRemove?: (e: React.MouseEvent) => void;
+  onClick?: (e: React.MouseEvent) => void;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+export function Tag(props: TagProps): JSX.Element;

--- a/docs/design/paper/design_system/components/core/Tag.jsx
+++ b/docs/design/paper/design_system/components/core/Tag.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+/**
+ * Tag — mono chip used for tech tags, recipe categories, and filters.
+ * `removable` adds a ✕ (editor input); `active` is the selected filter state;
+ * `as="button"` makes it an interactive filter chip.
+ */
+export function Tag({
+  as = 'span',
+  active = false,
+  removable = false,
+  onRemove,
+  onClick,
+  children,
+  style = {},
+}) {
+  const Tag = as;
+  const base = {
+    display: 'inline-flex', alignItems: 'center', gap: '7px',
+    fontFamily: 'var(--font-mono)', fontSize: '11px', letterSpacing: '0.04em',
+    padding: removable ? '5px 7px 5px 11px' : '5px 10px',
+    borderRadius: 'var(--radius-sm)',
+    border: '1px solid ' + (active ? 'var(--color-primary)' : 'var(--color-border)'),
+    background: active ? 'var(--color-primary)' : 'var(--color-surface)',
+    color: active ? '#fff' : 'var(--color-text-muted)',
+    cursor: as === 'button' ? 'pointer' : 'default',
+    transition: 'color .2s ease, border-color .2s ease, background .2s ease',
+  };
+  return (
+    <Tag onClick={onClick} className={as === 'button' ? 'ds-tag-btn' : undefined} style={{ ...base, ...style }}>
+      {children}
+      {removable && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onRemove && onRemove(e); }}
+          aria-label="Remove"
+          style={{ background: 'transparent', border: 'none', color: 'var(--color-text-faint)', cursor: 'pointer', fontSize: '12px', lineHeight: 1, padding: '1px', display: 'inline-flex' }}
+        >✕</button>
+      )}
+    </Tag>
+  );
+}

--- a/docs/design/paper/design_system/components/core/Tag.prompt.md
+++ b/docs/design/paper/design_system/components/core/Tag.prompt.md
@@ -1,0 +1,12 @@
+**Tag** — mono chip for tech tags, recipe categories, and filters.
+
+```jsx
+<Tag>react</Tag>                                   {/* static tech tag */}
+<Tag as="button" active>all</Tag>                  {/* selected filter */}
+<Tag as="button" onClick={pick}>Baking</Tag>       {/* filter chip */}
+<Tag removable onRemove={drop}>Thai</Tag>          {/* editor input */}
+```
+
+- **active** fills with accent (selected filter).
+- **removable** appends a ✕; pair with `TagInput` for the editor.
+- Hover tint on filter buttons comes from the bundle's `.ds-tag-btn:hover`.

--- a/docs/design/paper/design_system/components/core/core.card.html
+++ b/docs/design/paper/design_system/components/core/core.card.html
@@ -1,0 +1,69 @@
+<!-- @dsCard group="Components" viewport="700x430" subtitle="Button · Link · Card · StatusBadge · Tag" name="Core" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:24px; }
+  .grid { display:flex; flex-direction:column; gap:22px; }
+  .lbl { font-family:var(--font-mono); font-size:10.5px; letter-spacing:0.1em; text-transform:uppercase; color:var(--faint); margin-bottom:11px; }
+  .row { display:flex; flex-wrap:wrap; gap:12px; align-items:center; }
+  /* buttons */
+  .btn { font-family:var(--font-sans); font-size:14px; font-weight:600; display:inline-flex; align-items:center; gap:8px; padding:11px 16px; border-radius:var(--radius-md); border:1px solid transparent; cursor:pointer; }
+  .solid { color:var(--btn-fg); background:var(--btn-bg); border-color:var(--btn-bg); }
+  .outline { color:var(--subtle); background:transparent; border-color:var(--btn-border); font-weight:500; }
+  .danger { color:#fff; background:var(--danger); border-color:var(--danger); }
+  .pill { border-radius:var(--radius-full); padding:12px 24px; }
+  .disabled { opacity:.45; }
+  /* link */
+  .lnk { color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:7px; }
+  .lnk.acc { color:var(--accent); }
+  .lnk.mut { color:var(--muted); }
+  /* card */
+  .card { background:var(--surf); border:1px solid var(--line); border-radius:var(--radius-xl); padding:16px 18px; font-size:14px; color:var(--subtle); width:180px; }
+  /* badge */
+  .badge { display:inline-flex; align-items:center; gap:6px; font-family:var(--font-mono); font-size:10.5px; letter-spacing:0.06em; text-transform:uppercase; padding:4px 11px; border-radius:var(--radius-full); }
+  .dot { width:5px; height:5px; border-radius:50%; }
+  /* tag */
+  .tag { display:inline-flex; align-items:center; gap:7px; font-family:var(--font-mono); font-size:11px; letter-spacing:0.04em; padding:5px 10px; border-radius:var(--radius-sm); border:1px solid var(--line); background:var(--surf); color:var(--muted); }
+  .tag.active { background:var(--accent); border-color:var(--accent); color:#fff; }
+</style></head>
+<body>
+  <div class="grid">
+    <div>
+      <div class="lbl">Button — variants &amp; shapes</div>
+      <div class="row">
+        <button class="btn solid">Publish</button>
+        <button class="btn outline">Discard draft</button>
+        <button class="btn danger">Remove user</button>
+        <button class="btn solid pill">Email me&nbsp;→</button>
+        <button class="btn solid disabled">Disabled</button>
+      </div>
+    </div>
+    <div>
+      <div class="lbl">Link — tones &amp; icon</div>
+      <div class="row" style="gap:24px;">
+        <a class="lnk mut" href="#">← All posts</a>
+        <a class="lnk" href="#">Inline link</a>
+        <a class="lnk acc" href="#">View public page ↗</a>
+      </div>
+    </div>
+    <div class="row" style="gap:24px; align-items:flex-start;">
+      <div>
+        <div class="lbl">Card</div>
+        <div class="card">A rounded container with a hairline border.</div>
+      </div>
+      <div>
+        <div class="lbl">StatusBadge</div>
+        <div class="row">
+          <span class="badge" style="color:var(--green); background:var(--green-bg);"><span class="dot" style="background:var(--green);"></span>Published</span>
+          <span class="badge" style="color:var(--amber); background:var(--amber-bg);"><span class="dot" style="background:var(--amber);"></span>Draft</span>
+        </div>
+        <div class="lbl" style="margin-top:18px;">Tag</div>
+        <div class="row">
+          <span class="tag">react</span>
+          <span class="tag active">all</span>
+          <span class="tag">Thai&nbsp; ✕</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/components/feedback/AutosaveStatus.d.ts
+++ b/docs/design/paper/design_system/components/feedback/AutosaveStatus.d.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Feedback" subtitle="Autosave indicator — saving / saved / error+retry" viewport="700x100"
+ */
+export interface AutosaveStatusProps {
+  /** @default 'saved' */
+  state?: 'saving' | 'saved' | 'error';
+  /** Relative-time label, e.g. "Saved just now". @default 'Saved' */
+  savedLabel?: string;
+  onRetry?: () => void;
+}
+
+export function AutosaveStatus(props: AutosaveStatusProps): JSX.Element;

--- a/docs/design/paper/design_system/components/feedback/AutosaveStatus.jsx
+++ b/docs/design/paper/design_system/components/feedback/AutosaveStatus.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+/**
+ * AutosaveStatus — inline saving indicator for autosave forms.
+ * States: saving (spinner) · saved (check + relative time) · error (retry).
+ */
+export function AutosaveStatus({ state = 'saved', savedLabel = 'Saved', onRetry }) {
+  if (state === 'saving') return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '9px' }}>
+      <span className="ds-spinner sm" aria-hidden="true" />
+      <span style={{ fontSize: '13px', color: 'var(--color-text-muted)' }}>Saving…</span>
+    </span>
+  );
+  if (state === 'error') return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '9px', width: '100%' }}>
+      <span style={{ color: 'var(--color-error)', display: 'inline-flex' }} aria-hidden="true">&#9888;</span>
+      <span style={{ fontSize: '13px', color: 'var(--color-error)' }}>Couldn't save</span>
+      <button onClick={onRetry} style={{ fontSize: '12.5px', color: 'var(--color-primary)', background: 'transparent', border: 'none', cursor: 'pointer', fontWeight: 500, marginLeft: 'auto' }}>Retry</button>
+    </span>
+  );
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '9px' }}>
+      <span style={{ color: 'var(--color-success)', display: 'inline-flex' }} aria-hidden="true">&#10003;</span>
+      <span style={{ fontSize: '13px', color: 'var(--color-text-muted)' }}>{savedLabel}</span>
+    </span>
+  );
+}

--- a/docs/design/paper/design_system/components/feedback/AutosaveStatus.prompt.md
+++ b/docs/design/paper/design_system/components/feedback/AutosaveStatus.prompt.md
@@ -1,0 +1,7 @@
+**AutosaveStatus** — inline indicator for no-save-button forms (the recipe editor). Drive `state` from your debounced save; compute `savedLabel` as a relative time ("Saved just now", "Saved at 2:30 PM").
+
+```jsx
+<AutosaveStatus state="saving" />
+<AutosaveStatus state="saved" savedLabel="Saved just now" />
+<AutosaveStatus state="error" onRetry={save} />
+```

--- a/docs/design/paper/design_system/components/feedback/Callout.d.ts
+++ b/docs/design/paper/design_system/components/feedback/Callout.d.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Feedback" subtitle="Article note — tip / warning / info" viewport="700x140"
+ */
+export interface CalloutProps {
+  /** @default 'tip' */
+  type?: 'tip' | 'warning' | 'info';
+  children?: React.ReactNode;
+}
+
+export function Callout(props: CalloutProps): JSX.Element;

--- a/docs/design/paper/design_system/components/feedback/Callout.jsx
+++ b/docs/design/paper/design_system/components/feedback/Callout.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+/**
+ * Callout — inline note block inside articles. Three types, each with an emoji,
+ * a colored uppercase label, and a matching tint. No accent-bar trope.
+ */
+export function Callout({ type = 'tip', children }) {
+  const map = {
+    tip:     { emoji: '\uD83D\uDCA1', label: 'Tip',     fg: 'var(--color-success)', tintC: '#1F8A5B' },
+    warning: { emoji: '\u26A0\uFE0F', label: 'Warning', fg: 'var(--color-warning)', tintC: '#C2810C' },
+    info:    { emoji: '\u2139\uFE0F', label: 'Info',    fg: 'var(--color-primary)', tintC: 'var(--color-primary)' },
+  };
+  const c = map[type] || map.tip;
+  return (
+    <div style={{ margin: '30px 0', border: '1px solid color-mix(in srgb, ' + c.tintC + ' 24%, var(--color-border))', background: 'color-mix(in srgb, ' + c.tintC + ' 6%, var(--color-surface))', borderRadius: 'var(--radius-lg)', padding: '18px 20px', display: 'flex', gap: '14px', alignItems: 'flex-start' }}>
+      <span aria-hidden="true" style={{ fontSize: '17px', lineHeight: 1.5, flexShrink: 0 }}>{c.emoji}</span>
+      <div>
+        <div style={{ fontFamily: 'var(--font-mono)', fontSize: '11px', letterSpacing: '0.14em', textTransform: 'uppercase', color: c.fg, marginBottom: '7px' }}>{c.label}</div>
+        <p style={{ fontSize: '15.5px', lineHeight: 1.65, color: 'var(--color-text)', margin: 0 }}>{children}</p>
+      </div>
+    </div>
+  );
+}

--- a/docs/design/paper/design_system/components/feedback/Callout.prompt.md
+++ b/docs/design/paper/design_system/components/feedback/Callout.prompt.md
@@ -1,0 +1,6 @@
+**Callout** — inline note inside blog/recipe articles. Emoji + colored uppercase label + subtle matching tint (green/amber/blue). Avoids the rounded-box-with-left-accent-bar trope.
+
+```jsx
+<Callout type="tip">CDK Custom Resources are great for one-time setup.</Callout>
+<Callout type="warning">A full table scan won't scale past a few hundred rows.</Callout>
+```

--- a/docs/design/paper/design_system/components/feedback/Loading.d.ts
+++ b/docs/design/paper/design_system/components/feedback/Loading.d.ts
@@ -1,0 +1,4 @@
+import * as React from 'react';
+/** Centered spinner + label for whole-view loading. */
+export interface LoadingProps { label?: string; }
+export function Loading(props: LoadingProps): JSX.Element;

--- a/docs/design/paper/design_system/components/feedback/Loading.jsx
+++ b/docs/design/paper/design_system/components/feedback/Loading.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+/** Loading — centered spinner + label for whole-view loading states. */
+export function Loading({ label = 'Loading…' }) {
+  return (
+    <div style={{ border: '1px solid var(--color-border)', borderRadius: 'var(--radius-xl)', padding: 'clamp(56px,10vw,110px) 24px', textAlign: 'center', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '18px' }}>
+      <span className="ds-spinner" aria-hidden="true" />
+      <p style={{ fontSize: '14px', color: 'var(--color-text-muted)', margin: 0 }}>{label}</p>
+    </div>
+  );
+}

--- a/docs/design/paper/design_system/components/feedback/Loading.prompt.md
+++ b/docs/design/paper/design_system/components/feedback/Loading.prompt.md
@@ -1,0 +1,5 @@
+**Loading** — full-panel loading state (spinner + label) for initializing views (recipe list, editor draft, users).
+
+```jsx
+<Loading label="Loading recipe…" />
+```

--- a/docs/design/paper/design_system/components/feedback/ProcessingPlaceholder.d.ts
+++ b/docs/design/paper/design_system/components/feedback/ProcessingPlaceholder.d.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+/** Shimmer placeholder for an asset still processing. */
+export interface ProcessingPlaceholderProps {
+  /** @default '16/9' */
+  aspect?: string;
+  height?: string;
+  label?: string;
+  /** Compact variant (step thumbnails). @default false */
+  small?: boolean;
+}
+export function ProcessingPlaceholder(props: ProcessingPlaceholderProps): JSX.Element;

--- a/docs/design/paper/design_system/components/feedback/ProcessingPlaceholder.jsx
+++ b/docs/design/paper/design_system/components/feedback/ProcessingPlaceholder.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+/**
+ * ProcessingPlaceholder — shimmer block standing in for an image (or any asset)
+ * that is still processing. Use while an upload finishes server-side.
+ */
+export function ProcessingPlaceholder({ aspect = '16/9', height, label = 'Processing…', small = false }) {
+  return (
+    <div className="ds-shimmer" style={{ border: '1px solid var(--color-border)', borderRadius: 'var(--radius-lg)', aspectRatio: height ? undefined : aspect, height, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '9px' }}>
+      <span className={small ? 'ds-spinner sm' : 'ds-spinner'} aria-hidden="true" />
+      <span style={{ fontSize: small ? '12.5px' : '13px', color: 'var(--color-text-muted)' }}>{label}</span>
+    </div>
+  );
+}

--- a/docs/design/paper/design_system/components/feedback/ProcessingPlaceholder.prompt.md
+++ b/docs/design/paper/design_system/components/feedback/ProcessingPlaceholder.prompt.md
@@ -1,0 +1,6 @@
+**ProcessingPlaceholder** — shimmer block for an image still processing server-side. The middle state of an async upload; `ImageUpload` uses the same treatment.
+
+```jsx
+<ProcessingPlaceholder aspect="16/9" />
+<ProcessingPlaceholder height="96px" small />
+```

--- a/docs/design/paper/design_system/components/feedback/Toast.d.ts
+++ b/docs/design/paper/design_system/components/feedback/Toast.d.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Feedback" subtitle="Quiet dismissible toast — success/error/info" viewport="700x120"
+ */
+export interface ToastProps {
+  /** @default 'info' */
+  tone?: 'success' | 'error' | 'info';
+  children?: React.ReactNode;
+  /** Click-anywhere dismiss handler. */
+  onDismiss?: () => void;
+}
+
+export function Toast(props: ToastProps): JSX.Element;

--- a/docs/design/paper/design_system/components/feedback/Toast.jsx
+++ b/docs/design/paper/design_system/components/feedback/Toast.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+/**
+ * Toast — quiet dismissible notification (bottom-right stack). The whole pill
+ * is the dismiss target; a faint ✕ appears on hover. Tone sets the icon dot.
+ */
+export function Toast({ tone = 'info', children, onDismiss }) {
+  const tones = {
+    success: { fg: 'var(--color-success)', dot: 'var(--color-success-bg)', icon: '\u2713' },
+    error:   { fg: 'var(--color-error)',   dot: 'var(--color-error-bg)',   icon: '\u2715' },
+    info:    { fg: 'var(--color-primary)', dot: 'color-mix(in srgb, var(--color-primary) 14%, transparent)', icon: '\u203a' },
+  };
+  const t = tones[tone] || tones.info;
+  return (
+    <button type="button" onClick={onDismiss} aria-label="Dismiss notification" className="ds-toast"
+      style={{ display: 'flex', alignItems: 'center', gap: '11px', width: '100%', textAlign: 'left', background: 'var(--color-bg)', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-lg)', padding: '12px 15px', boxShadow: 'var(--shadow-lg)', cursor: 'pointer', fontFamily: 'inherit' }}>
+      <span aria-hidden="true" style={{ width: '18px', height: '18px', flexShrink: 0, borderRadius: '50%', background: t.dot, color: t.fg, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: '11px', lineHeight: 1 }}>{t.icon}</span>
+      <span style={{ fontSize: '13.5px', lineHeight: 1.45, color: 'var(--color-text)', flex: 1 }}>{children}</span>
+      <span className="ds-toast-x" aria-hidden="true" style={{ flexShrink: 0, color: 'var(--color-text-faint)', fontSize: '12px', opacity: 0.5, transition: 'opacity .18s ease, color .18s ease' }}>\u2715</span>
+    </button>
+  );
+}

--- a/docs/design/paper/design_system/components/feedback/Toast.prompt.md
+++ b/docs/design/paper/design_system/components/feedback/Toast.prompt.md
@@ -1,0 +1,6 @@
+**Toast** — quiet notification in a bottom-right stack. The whole pill dismisses on click; a faint ✕ fades in on hover (no always-on close button, no bold accent bar). Auto-dismiss after ~3.6s in your container logic.
+
+```jsx
+<Toast tone="success" onDismiss={drop}>Invite sent to sam@acme.com.</Toast>
+```
+Needs `.ds-toast:hover .ds-toast-x{opacity:1}` from the bundle.

--- a/docs/design/paper/design_system/components/feedback/feedback.card.html
+++ b/docs/design/paper/design_system/components/feedback/feedback.card.html
@@ -1,0 +1,39 @@
+<!-- @dsCard group="Components" viewport="700x340" subtitle="Toast · Callout · AutosaveStatus · Loading" name="Feedback" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:24px; }
+  .grid { display:flex; flex-direction:column; gap:18px; max-width:520px; }
+  .lbl { font-family:var(--font-mono); font-size:10.5px; letter-spacing:0.1em; text-transform:uppercase; color:var(--faint); margin-bottom:9px; }
+  .row { display:flex; flex-wrap:wrap; gap:12px; align-items:center; }
+  .toast { display:flex; align-items:center; gap:11px; background:var(--bg); border:1px solid var(--line); border-radius:var(--radius-lg); padding:12px 15px; box-shadow:var(--shadow-md); width:280px; }
+  .tdot { width:18px; height:18px; flex-shrink:0; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-size:11px; }
+  .tmsg { font-size:13.5px; color:var(--subtle); flex:1; }
+  .tx { color:var(--faint); font-size:12px; opacity:.5; }
+  .callout { border:1px solid color-mix(in srgb,#1F8A5B 24%, var(--line)); background:color-mix(in srgb,#1F8A5B 6%, var(--surf)); border-radius:var(--radius-lg); padding:16px 18px; display:flex; gap:13px; }
+  .clabel { font-family:var(--font-mono); font-size:11px; letter-spacing:0.14em; text-transform:uppercase; color:var(--green); margin-bottom:6px; }
+  .ctext { font-size:14.5px; line-height:1.6; color:var(--subtle); margin:0; }
+  .save { display:inline-flex; align-items:center; gap:9px; font-size:13px; color:var(--muted); }
+</style></head>
+<body>
+  <div class="grid">
+    <div>
+      <div class="lbl">Toast</div>
+      <div class="row">
+        <div class="toast"><span class="tdot" style="background:var(--green-bg);color:var(--green);">✓</span><span class="tmsg">Recipe published — it's now live.</span><span class="tx">✕</span></div>
+        <div class="toast"><span class="tdot" style="background:var(--danger-bg);color:var(--danger);">✕</span><span class="tmsg">Access denied.</span><span class="tx">✕</span></div>
+      </div>
+    </div>
+    <div>
+      <div class="lbl">Callout</div>
+      <div class="callout"><span style="font-size:17px;">💡</span><div><div class="clabel">Tip</div><p class="ctext">CDK Custom Resources are great for one-time setup tasks.</p></div></div>
+    </div>
+    <div>
+      <div class="lbl">AutosaveStatus</div>
+      <div class="row" style="gap:28px;">
+        <span class="save"><span style="color:var(--green);">✓</span> Saved just now</span>
+        <span class="save"><span style="color:var(--danger);">⚠</span> <span style="color:var(--danger);">Couldn't save</span> · <span style="color:var(--accent);">Retry</span></span>
+      </div>
+    </div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/components/forms/ImageUpload.d.ts
+++ b/docs/design/paper/design_system/components/forms/ImageUpload.d.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Forms" subtitle="Async image field — empty / processing / ready" viewport="700x220"
+ */
+export interface ImageUploadProps {
+  /** @default 'empty' */
+  state?: 'empty' | 'processing' | 'ready';
+  /** Preview URL when ready. */
+  url?: string;
+  label?: string;
+  hint?: string;
+  /** CSS aspect-ratio for the frame. @default '16/9' */
+  aspect?: string;
+  /** Fixed height instead of aspect (e.g. step thumbnails). */
+  height?: string;
+  onUpload?: () => void;
+  onRemove?: () => void;
+}
+
+export function ImageUpload(props: ImageUploadProps): JSX.Element;

--- a/docs/design/paper/design_system/components/forms/ImageUpload.jsx
+++ b/docs/design/paper/design_system/components/forms/ImageUpload.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * ImageUpload — async image field with three states: empty (dropzone),
+ * processing (shimmer + spinner), ready (preview + remove). Drives the
+ * cover and step-image uploads in the editor.
+ */
+export function ImageUpload({ state = 'empty', url = '', label = 'Upload an image', hint = 'JPG, PNG or WebP', onUpload, onRemove, aspect = '16/9', height }) {
+  if (state === 'processing') {
+    return (
+      <div style={{ border: '1px solid var(--color-border)', borderRadius: 'var(--radius-lg)', overflow: 'hidden' }}>
+        <div className="ds-shimmer" style={{ aspectRatio: height ? undefined : aspect, height, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '10px' }}>
+          <span className="ds-spinner" aria-hidden="true" />
+          <span style={{ fontSize: '13px', color: 'var(--color-text-muted)' }}>Processing image…</span>
+        </div>
+      </div>
+    );
+  }
+  if (state === 'ready') {
+    return (
+      <div style={{ position: 'relative', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-lg)', overflow: 'hidden', display: 'inline-block', width: '100%' }}>
+        <img src={url} alt="" style={{ display: 'block', width: '100%', aspectRatio: height ? undefined : aspect, height, objectFit: 'cover' }} />
+        <button onClick={onRemove} aria-label="Remove image" className="ds-iconbtn-danger"
+          style={{ position: 'absolute', top: '10px', right: '10px', width: '30px', height: '30px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', border: '1px solid var(--color-border)', background: 'var(--color-bg)', borderRadius: 'var(--radius-sm)', color: 'var(--color-text-muted)', cursor: 'pointer' }}>✕</button>
+      </div>
+    );
+  }
+  return (
+    <div role="button" tabIndex={0} onClick={onUpload} className="ds-upload"
+      style={{ border: '1px dashed var(--color-border-strong)', borderRadius: 'var(--radius-lg)', background: 'var(--color-surface)', padding: '22px', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '10px', cursor: 'pointer', textAlign: 'center' }}>
+      <span style={{ fontSize: '14px', fontWeight: 500, color: 'var(--color-text)' }}>{label}</span>
+      <span style={{ fontSize: '12.5px', color: 'var(--color-text-faint)' }}>{hint}</span>
+    </div>
+  );
+}

--- a/docs/design/paper/design_system/components/forms/ImageUpload.prompt.md
+++ b/docs/design/paper/design_system/components/forms/ImageUpload.prompt.md
@@ -1,0 +1,7 @@
+**ImageUpload** — async image field with three states. Drive `state` from your upload lifecycle: `empty` (dropzone) → `processing` (shimmer) → `ready` (preview + remove). Pair the ready state with a separate alt-text Input.
+
+```jsx
+<ImageUpload state={cover.state} url={cover.url} onUpload={pick} onRemove={clear} />
+<ImageUpload state={s} height="96px" label="Add step image" />  {/* step thumb */}
+```
+Needs the bundle's `.ds-shimmer`, `.ds-spinner` animations.

--- a/docs/design/paper/design_system/components/forms/Input.d.ts
+++ b/docs/design/paper/design_system/components/forms/Input.d.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Forms" subtitle="Text field with focus ring, prefix icon, invalid state" viewport="700x120"
+ */
+export interface InputProps {
+  type?: string;
+  value?: string;
+  placeholder?: string;
+  /** Error border + ring. @default false */
+  invalid?: boolean;
+  disabled?: boolean;
+  /** Leading icon (e.g. search). */
+  prefixIcon?: React.ReactNode;
+  /** Trailing node (e.g. clear ✕). */
+  suffix?: React.ReactNode;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  style?: React.CSSProperties;
+}
+
+export function Input(props: InputProps): JSX.Element;

--- a/docs/design/paper/design_system/components/forms/Input.jsx
+++ b/docs/design/paper/design_system/components/forms/Input.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+/**
+ * Input — single-line text field with the brand's focus ring.
+ * `invalid` switches the border/ring to error. `prefixIcon` for search etc.
+ */
+export function Input({
+  type = 'text', value, placeholder, invalid = false, disabled = false,
+  prefixIcon = null, suffix = null, onChange, onKeyDown, style = {}, ...rest
+}) {
+  return (
+    <div style={{ position: 'relative', width: '100%' }}>
+      {prefixIcon && (
+        <span style={{ position: 'absolute', left: '13px', top: '50%', transform: 'translateY(-50%)', display: 'flex', color: 'var(--color-text-faint)', pointerEvents: 'none' }}>{prefixIcon}</span>
+      )}
+      <input
+        type={type} value={value} placeholder={placeholder} disabled={disabled}
+        onChange={onChange} onKeyDown={onKeyDown}
+        className="ds-field"
+        style={{
+          width: '100%', fontFamily: 'var(--font-sans)', fontSize: '15px',
+          color: 'var(--color-text-strong)', background: disabled ? 'var(--color-surface)' : 'var(--color-field)',
+          border: '1px solid ' + (invalid ? 'var(--color-error)' : 'var(--color-border)'),
+          borderRadius: 'var(--radius-md)',
+          padding: '12px 13px', paddingLeft: prefixIcon ? '40px' : '13px', paddingRight: suffix ? '40px' : '13px',
+          outline: 'none', transition: 'border-color .18s ease, box-shadow .18s ease', ...style,
+        }}
+        {...rest}
+      />
+      {suffix && <span style={{ position: 'absolute', right: '10px', top: '50%', transform: 'translateY(-50%)' }}>{suffix}</span>}
+    </div>
+  );
+}

--- a/docs/design/paper/design_system/components/forms/Input.prompt.md
+++ b/docs/design/paper/design_system/components/forms/Input.prompt.md
@@ -1,0 +1,7 @@
+**Input** — single-line field. Focus shows the accent ring; `invalid` turns it error-red. Use `prefixIcon` for search, `suffix` for a clear button.
+
+```jsx
+<Input placeholder="name@example.com" invalid />
+<Input prefixIcon={<Search/>} suffix={<Clear/>} placeholder="Search recipes…" />
+```
+Needs the bundle's `.ds-field:focus{border-color:var(--accent);box-shadow:var(--ring)}`.

--- a/docs/design/paper/design_system/components/forms/TagInput.d.ts
+++ b/docs/design/paper/design_system/components/forms/TagInput.d.ts
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Forms" subtitle="Chips + add-on-Enter field + suggestions" viewport="700x180"
+ */
+export interface TagInputProps {
+  tags: string[];
+  /** Pool of existing tags to suggest (filtered against current). */
+  suggestions?: string[];
+  onAdd?: (tag: string) => void;
+  onRemove?: (tag: string) => void;
+  placeholder?: string;
+}
+
+export function TagInput(props: TagInputProps): JSX.Element;

--- a/docs/design/paper/design_system/components/forms/TagInput.jsx
+++ b/docs/design/paper/design_system/components/forms/TagInput.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Tag } from '../core/Tag.jsx';
+
+/**
+ * TagInput — editor control: removable chips + a text field that adds on Enter,
+ * with clickable suggestions drawn from existing tags.
+ */
+export function TagInput({ tags = [], suggestions = [], onAdd, onRemove, placeholder = 'Type a tag and press Enter' }) {
+  const [draft, setDraft] = React.useState('');
+  const commit = (v) => { const t = (v ?? draft).trim(); if (t) { onAdd && onAdd(t); setDraft(''); } };
+  const avail = suggestions.filter((s) => !tags.some((t) => t.toLowerCase() === s.toLowerCase()));
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+      {tags.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+          {tags.map((t) => <Tag key={t} removable onRemove={() => onRemove && onRemove(t)}>{t}</Tag>)}
+        </div>
+      )}
+      <input
+        value={draft} placeholder={placeholder} className="ds-field"
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); commit(); } }}
+        style={{ width: '100%', fontFamily: 'var(--font-sans)', fontSize: '15px', color: 'var(--color-text-strong)', background: 'var(--color-field)', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-md)', padding: '12px 13px', outline: 'none' }}
+      />
+      {avail.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '8px' }}>
+          <span style={{ fontSize: '12.5px', color: 'var(--color-text-faint)' }}>Suggestions:</span>
+          {avail.slice(0, 6).map((s) => (
+            <button key={s} onClick={() => commit(s)} className="ds-suggest"
+              style={{ fontFamily: 'var(--font-mono)', fontSize: '11.5px', color: 'var(--color-text-muted)', border: '1px dashed var(--color-border)', background: 'transparent', padding: '5px 10px', borderRadius: 'var(--radius-sm)', cursor: 'pointer' }}>+ {s}</button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docs/design/paper/design_system/components/forms/TagInput.prompt.md
+++ b/docs/design/paper/design_system/components/forms/TagInput.prompt.md
@@ -1,0 +1,6 @@
+**TagInput** — the recipe-editor tag control: removable chips, an add-on-Enter field, and clickable suggestions from the existing tag pool. Manages its own draft text; you own the `tags` array.
+
+```jsx
+<TagInput tags={tags} suggestions={allTags} onAdd={add} onRemove={remove} />
+```
+Composes `Tag`. Needs `.ds-suggest:hover{color:var(--accent);border-color:var(--accent)}` from the bundle.

--- a/docs/design/paper/design_system/components/forms/Textarea.d.ts
+++ b/docs/design/paper/design_system/components/forms/Textarea.d.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+/** Multi-line text field; shares Input's styling. */
+export interface TextareaProps {
+  value?: string;
+  placeholder?: string;
+  rows?: number;
+  disabled?: boolean;
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  style?: React.CSSProperties;
+}
+
+export function Textarea(props: TextareaProps): JSX.Element;

--- a/docs/design/paper/design_system/components/forms/Textarea.jsx
+++ b/docs/design/paper/design_system/components/forms/Textarea.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+/** Textarea — multi-line field; same styling language as Input. */
+export function Textarea({ value, placeholder, rows = 3, disabled = false, onChange, style = {}, ...rest }) {
+  return (
+    <textarea
+      value={value} placeholder={placeholder} rows={rows} disabled={disabled} onChange={onChange}
+      className="ds-field"
+      style={{
+        width: '100%', fontFamily: 'var(--font-sans)', fontSize: '15px', lineHeight: 1.6,
+        color: 'var(--color-text-strong)', background: 'var(--color-field)',
+        border: '1px solid var(--color-border)', borderRadius: 'var(--radius-md)',
+        padding: '12px 13px', outline: 'none', resize: 'vertical', minHeight: '84px',
+        transition: 'border-color .18s ease, box-shadow .18s ease', ...style,
+      }}
+      {...rest}
+    />
+  );
+}

--- a/docs/design/paper/design_system/components/forms/Textarea.prompt.md
+++ b/docs/design/paper/design_system/components/forms/Textarea.prompt.md
@@ -1,0 +1,5 @@
+**Textarea** — multi-line field (intro, step text). Vertically resizable, same focus ring as Input.
+
+```jsx
+<Textarea placeholder="Describe this step…" rows={3} />
+```

--- a/docs/design/paper/design_system/components/forms/forms.card.html
+++ b/docs/design/paper/design_system/components/forms/forms.card.html
@@ -1,0 +1,42 @@
+<!-- @dsCard group="Components" viewport="700x430" subtitle="Input · Textarea · TagInput · ImageUpload" name="Forms" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:24px; }
+  .grid { display:flex; flex-direction:column; gap:20px; max-width:560px; }
+  .lbl { font-family:var(--font-mono); font-size:10.5px; letter-spacing:0.1em; text-transform:uppercase; color:var(--faint); margin-bottom:9px; }
+  .field { width:100%; box-sizing:border-box; font-family:var(--font-sans); font-size:15px; color:var(--text); background:var(--field); border:1px solid var(--line); border-radius:var(--radius-md); padding:12px 13px; outline:none; }
+  .field.err { border-color:var(--danger); box-shadow:0 0 0 3px var(--danger-bg); }
+  .row { display:flex; flex-wrap:wrap; gap:8px; align-items:center; }
+  .chip { display:inline-flex; align-items:center; gap:7px; font-family:var(--font-mono); font-size:11px; color:var(--text); border:1px solid var(--line); background:var(--surf); padding:5px 7px 5px 11px; border-radius:var(--radius-sm); }
+  .chip span { color:var(--faint); }
+  .suggest { font-family:var(--font-mono); font-size:11.5px; color:var(--muted); border:1px dashed var(--line); background:transparent; padding:5px 10px; border-radius:var(--radius-sm); }
+  .upload { border:1px dashed var(--btn-border); border-radius:var(--radius-lg); background:var(--surf); padding:20px; display:flex; flex-direction:column; align-items:center; gap:8px; text-align:center; }
+  .upmain { font-size:14px; font-weight:500; color:var(--subtle); }
+  .uphint { font-size:12.5px; color:var(--faint); }
+</style></head>
+<body>
+  <div class="grid">
+    <div>
+      <div class="lbl">Input — default &amp; invalid</div>
+      <div style="display:flex; gap:12px;">
+        <input class="field" placeholder="name@example.com">
+        <input class="field err" value="not-an-email">
+      </div>
+    </div>
+    <div>
+      <div class="lbl">Textarea</div>
+      <textarea class="field" rows="2" placeholder="A sentence or two on what makes this worth cooking."></textarea>
+    </div>
+    <div>
+      <div class="lbl">TagInput — chips + suggestions</div>
+      <div class="row" style="margin-bottom:10px;"><span class="chip">Thai <span>✕</span></span><span class="chip">Fish <span>✕</span></span></div>
+      <input class="field" placeholder="Type a tag and press Enter" style="margin-bottom:10px;">
+      <div class="row"><span style="font-size:12.5px;color:var(--faint);">Suggestions:</span><span class="suggest">+ Rice</span><span class="suggest">+ Coconut</span><span class="suggest">+ One Pot</span></div>
+    </div>
+    <div>
+      <div class="lbl">ImageUpload — empty state</div>
+      <div class="upload"><span class="upmain">Upload a cover image</span><span class="uphint">JPG, PNG or WebP — landscape works best.</span></div>
+    </div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/components/navigation/Header.d.ts
+++ b/docs/design/paper/design_system/components/navigation/Header.d.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Navigation" subtitle="Site shell top bar — public & admin variants" viewport="1080x88"
+ */
+export interface HeaderLink {
+  label: string;
+  href: string;
+  /** Marks the current page (full-strength text). */
+  active?: boolean;
+}
+
+export interface HeaderProps {
+  /** @default 'public' */
+  variant?: 'public' | 'admin';
+  /** Wordmark text. @default 'Akli Aissat' */
+  brand?: string;
+  brandHref?: string;
+  links?: HeaderLink[];
+  /** Sticky + translucent blur. @default true */
+  sticky?: boolean;
+  /** Admin: signed-in email shown at right. */
+  email?: string;
+  /** Admin: Log out handler (renders the button when set). */
+  onLogout?: () => void;
+  /** @default 'light' */
+  theme?: 'light' | 'dark';
+  onToggle?: () => void;
+}
+
+export function Header(props: HeaderProps): JSX.Element;

--- a/docs/design/paper/design_system/components/navigation/Header.jsx
+++ b/docs/design/paper/design_system/components/navigation/Header.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { ThemeToggle } from './ThemeToggle.jsx';
+
+/**
+ * Header — the site shell's top bar. One component for both surfaces:
+ *  • variant="public" — brand + nav links + theme toggle.
+ *  • variant="admin"  — brand + nav links + signed-in email + Log out + toggle.
+ * Sticky + translucent-blur by default (the brand's header treatment).
+ */
+export function Header({
+  variant = 'public',
+  brand = 'Akli Aissat',
+  brandHref = '/',
+  links = [],            // [{ label, href, active }]
+  sticky = true,
+  email,                 // admin: signed-in address
+  onLogout,              // admin: Log out handler
+  theme = 'light',
+  onToggle,
+}) {
+  return (
+    <header className={sticky ? 'ds-header ds-header-sticky' : 'ds-header'}
+      style={{ borderBottom: '1px solid var(--color-border)' }}>
+      <div style={{ maxWidth: 'var(--max-w-site)', margin: '0 auto', padding: '18px clamp(20px,5vw,28px)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '20px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'clamp(18px,4vw,30px)' }}>
+          <a className="ds-link" href={brandHref} style={{ fontSize: '15px', fontWeight: 600, letterSpacing: '-0.01em', color: 'var(--color-text-strong)', textDecoration: 'none' }}>{brand}</a>
+          <nav aria-label={variant === 'admin' ? 'Admin' : 'Primary'} style={{ display: 'flex', alignItems: 'center', gap: variant === 'admin' ? '22px' : 'clamp(18px,4vw,28px)', fontSize: '14px', color: 'var(--color-text-muted)' }}>
+            {links.map((l) => (
+              <a key={l.href + l.label} className="ds-link" href={l.href}
+                aria-current={l.active ? 'page' : undefined}
+                style={l.active ? { color: 'var(--color-text-strong)', fontWeight: 500, textDecoration: 'none' } : { color: 'inherit', textDecoration: 'none' }}>{l.label}</a>
+            ))}
+          </nav>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '14px' }}>
+          {variant === 'admin' && email && <span style={{ fontSize: '13px', color: 'var(--color-text-muted)' }}>{email}</span>}
+          {variant === 'admin' && onLogout && (
+            <button onClick={onLogout} style={{ fontFamily: 'var(--font-sans)', fontSize: '13px', fontWeight: 500, color: 'var(--color-text)', background: 'transparent', border: '1px solid var(--color-border-strong)', borderRadius: 'var(--radius-md)', padding: '7px 13px', cursor: 'pointer' }}>Log out</button>
+          )}
+          {onToggle && <ThemeToggle theme={theme} onToggle={onToggle} />}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/docs/design/paper/design_system/components/navigation/Header.prompt.md
+++ b/docs/design/paper/design_system/components/navigation/Header.prompt.md
@@ -1,0 +1,16 @@
+**Header** — the site shell's top bar, one component for both surfaces. Composes `ThemeToggle`; links tint to accent on hover, the active link is full-strength text (no underline bar). Sticky + translucent-blur by default.
+
+```jsx
+// public
+<Header variant="public"
+  links={[{label:'Apps',href:'/apps'},{label:'Recipes',href:'/recipes',active:true},{label:'Blog',href:'/blog'}]}
+  theme={theme} onToggle={toggle} />
+
+// admin — adds email + Log out
+<Header variant="admin" email="akli@akli.dev" onLogout={logout}
+  links={[{label:'Recipes',href:'/admin',active:true},{label:'Users',href:'/admin/users'}]}
+  theme={theme} onToggle={toggle} />
+```
+
+- Sticky blur needs `.ds-header-sticky` from the bundle (`position:sticky` + `backdrop-filter`).
+- Pair with the matching **footer** from the UI kits (not a separate component — it's a small static block).

--- a/docs/design/paper/design_system/components/navigation/ThemeToggle.d.ts
+++ b/docs/design/paper/design_system/components/navigation/ThemeToggle.d.ts
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Navigation" subtitle="Round light/dark toggle" viewport="700x90"
+ */
+export interface ThemeToggleProps {
+  /** @default 'light' */
+  theme?: 'light' | 'dark';
+  onToggle?: () => void;
+}
+
+export function ThemeToggle(props: ThemeToggleProps): JSX.Element;

--- a/docs/design/paper/design_system/components/navigation/ThemeToggle.jsx
+++ b/docs/design/paper/design_system/components/navigation/ThemeToggle.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+/**
+ * ThemeToggle — round icon button that flips light/dark. Persist the choice in
+ * localStorage('akli-theme') and reflect it on a [data-theme] ancestor.
+ */
+export function ThemeToggle({ theme = 'light', onToggle }) {
+  const dark = theme === 'dark';
+  return (
+    <button onClick={onToggle} className="ds-toggle" aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'} title={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+      style={{ display: 'inline-flex', width: '32px', height: '32px', alignItems: 'center', justifyContent: 'center', fontSize: '13px', color: 'var(--color-text-strong)', background: 'transparent', border: '1px solid var(--color-border-strong)', borderRadius: '50%', cursor: 'pointer', transition: 'background .2s ease, border-color .2s ease' }}>
+      {dark ? '\u2600' : '\u263E'}
+    </button>
+  );
+}

--- a/docs/design/paper/design_system/components/navigation/ThemeToggle.prompt.md
+++ b/docs/design/paper/design_system/components/navigation/ThemeToggle.prompt.md
@@ -1,0 +1,5 @@
+**ThemeToggle** — round icon button in the header that flips the theme. On hover it shades subtly (darker in light mode, lighter in dark) via `.ds-toggle:hover`. Persist to `localStorage('akli-theme')` and set `[data-theme]` on a root ancestor.
+
+```jsx
+<ThemeToggle theme={theme} onToggle={() => setTheme(t => t === 'dark' ? 'light' : 'dark')} />
+```

--- a/docs/design/paper/design_system/components/navigation/header.card.html
+++ b/docs/design/paper/design_system/components/navigation/header.card.html
@@ -1,0 +1,37 @@
+<!-- @dsCard group="Components" viewport="760x260" subtitle="Header — public & admin variants" name="Header" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); }
+  .stack { display:flex; flex-direction:column; gap:20px; padding:22px; }
+  .lbl { font-family:var(--font-mono); font-size:10.5px; letter-spacing:0.1em; text-transform:uppercase; color:var(--faint); margin-bottom:10px; }
+  .hdr { border:1px solid var(--line); border-radius:var(--radius-lg); overflow:hidden; }
+  .bar { display:flex; align-items:center; justify-content:space-between; gap:20px; padding:16px 20px; }
+  .left { display:flex; align-items:center; gap:26px; }
+  .brand { font-size:15px; font-weight:600; letter-spacing:-0.01em; color:var(--text); text-decoration:none; }
+  .links { display:flex; align-items:center; gap:22px; font-size:14px; color:var(--muted); }
+  .links a { color:inherit; text-decoration:none; }
+  .links a.active { color:var(--text); font-weight:500; }
+  .right { display:flex; align-items:center; gap:14px; }
+  .email { font-size:13px; color:var(--muted); }
+  .logout { font-size:13px; font-weight:500; color:var(--text); background:transparent; border:1px solid var(--btn-border); border-radius:var(--radius-md); padding:7px 13px; }
+  .toggle { width:32px; height:32px; display:inline-flex; align-items:center; justify-content:center; border:1px solid var(--btn-border); border-radius:50%; color:var(--text); background:transparent; }
+</style></head>
+<body>
+  <div class="stack">
+    <div>
+      <div class="lbl">variant="public"</div>
+      <div class="hdr"><div class="bar">
+        <div class="left"><a class="brand">Akli Aissat</a><nav class="links"><a>Apps</a><a class="active">Recipes</a><a>Blog</a></nav></div>
+        <div class="right"><button class="toggle">☾</button></div>
+      </div></div>
+    </div>
+    <div>
+      <div class="lbl">variant="admin"</div>
+      <div class="hdr"><div class="bar">
+        <div class="left"><a class="brand">Akli Aissat</a><nav class="links"><a class="active">Recipes</a><a>Users</a></nav></div>
+        <div class="right"><span class="email">akli@akli.dev</span><button class="logout">Log out</button><button class="toggle">☾</button></div>
+      </div></div>
+    </div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/components/navigation/navigation.card.html
+++ b/docs/design/paper/design_system/components/navigation/navigation.card.html
@@ -1,0 +1,16 @@
+<!-- @dsCard group="Components" viewport="700x110" subtitle="ThemeToggle — light & dark" name="Navigation" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  body { margin:0; font-family:var(--font-sans); display:flex; }
+  .pane { flex:1; padding:28px; display:flex; align-items:center; gap:12px; }
+  .light { background:#FBFAF7; }
+  .toggle { display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; border-radius:50%; cursor:pointer; }
+  .l { color:#1C1A16; background:transparent; border:1px solid #E0DACE; }
+  .d { color:#F3F0E8; background:transparent; border:1px solid #36342C; }
+  .cap { font-family:var(--font-mono); font-size:11px; }
+</style></head>
+<body>
+  <div class="pane light"><button class="toggle l">☾</button><span class="cap" style="color:#6F6961;">light</span></div>
+  <div class="pane" style="background:#141310;"><button class="toggle d">☀</button><span class="cap" style="color:#A6A093;">dark</span></div>
+</body></html>

--- a/docs/design/paper/design_system/components/overlays/ConfirmDialog.d.ts
+++ b/docs/design/paper/design_system/components/overlays/ConfirmDialog.d.ts
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+/**
+ * @startingPoint section="Overlays" subtitle="Modal confirm — optional danger styling" viewport="700x260"
+ */
+export interface ConfirmDialogProps {
+  open?: boolean;
+  title?: string;
+  children?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Danger icon + red confirm button (destructive actions). @default false */
+  danger?: boolean;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}
+
+export function ConfirmDialog(props: ConfirmDialogProps): JSX.Element;

--- a/docs/design/paper/design_system/components/overlays/ConfirmDialog.jsx
+++ b/docs/design/paper/design_system/components/overlays/ConfirmDialog.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+/**
+ * ConfirmDialog — modal confirmation over a scrim. Optional danger icon and
+ * destructive confirm button. Click-scrim and Cancel both dismiss.
+ */
+export function ConfirmDialog({
+  open = true, title, children, confirmLabel = 'Confirm', cancelLabel = 'Cancel',
+  danger = false, onConfirm, onCancel,
+}) {
+  if (!open) return null;
+  return (
+    <div role="dialog" aria-modal="true" onClick={onCancel}
+      style={{ position: 'fixed', inset: 0, zIndex: 'var(--z-overlay)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px', background: 'color-mix(in srgb, #000 38%, transparent)' }}>
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ width: '100%', maxWidth: '430px', background: 'var(--color-bg)', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-2xl)', padding: '26px', boxShadow: 'var(--shadow-xl)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '12px' }}>
+          {danger && (
+            <span style={{ width: '38px', height: '38px', flexShrink: 0, borderRadius: 'var(--radius-md)', background: 'var(--color-error-bg)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--color-error)', fontSize: '18px' }}>&#9888;</span>
+          )}
+          <h2 style={{ fontSize: '18px', fontWeight: 600, letterSpacing: '-0.02em', margin: 0 }}>{title}</h2>
+        </div>
+        <p style={{ fontSize: '14.5px', lineHeight: 1.6, color: 'var(--color-text)', margin: '0 0 24px' }}>{children}</p>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
+          <button onClick={onCancel} style={{ fontFamily: 'var(--font-sans)', fontSize: '14px', fontWeight: 500, color: 'var(--color-text)', background: 'transparent', border: '1px solid var(--color-border-strong)', borderRadius: 'var(--radius-md)', padding: '10px 16px', cursor: 'pointer' }}>{cancelLabel}</button>
+          <button onClick={onConfirm} style={{ fontFamily: 'var(--font-sans)', fontSize: '14px', fontWeight: 600, color: danger ? '#fff' : 'var(--color-btn-fg)', background: danger ? 'var(--color-error)' : 'var(--color-btn-bg)', border: 'none', borderRadius: 'var(--radius-md)', padding: '11px 16px', cursor: 'pointer' }}>{confirmLabel}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/design/paper/design_system/components/overlays/ConfirmDialog.prompt.md
+++ b/docs/design/paper/design_system/components/overlays/ConfirmDialog.prompt.md
@@ -1,0 +1,8 @@
+**ConfirmDialog** — modal confirmation over a scrim. Use `danger` for destructive actions (delete recipe, remove user, discard draft). Scrim-click and Cancel both dismiss.
+
+```jsx
+<ConfirmDialog danger title="Remove user" confirmLabel="Remove user"
+  onConfirm={remove} onCancel={close}>
+  Remove sam@acme.com? They will lose access immediately.
+</ConfirmDialog>
+```

--- a/docs/design/paper/design_system/components/overlays/overlays.card.html
+++ b/docs/design/paper/design_system/components/overlays/overlays.card.html
@@ -1,0 +1,27 @@
+<!-- @dsCard group="Components" viewport="700x300" subtitle="ConfirmDialog — neutral & danger" name="Overlays" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  body { margin:0; background:var(--surf); font-family:var(--font-sans); padding:24px; display:flex; gap:20px; flex-wrap:wrap; }
+  .dlg { width:300px; background:var(--bg); border:1px solid var(--line); border-radius:var(--radius-2xl); padding:24px; box-shadow:var(--shadow-xl); }
+  .hd { display:flex; align-items:center; gap:12px; margin-bottom:12px; }
+  .ic { width:36px; height:36px; border-radius:var(--radius-md); background:var(--danger-bg); display:flex; align-items:center; justify-content:center; color:var(--danger); font-size:17px; }
+  h2 { font-size:17px; font-weight:600; letter-spacing:-0.02em; margin:0; color:var(--text); }
+  p { font-size:14px; line-height:1.6; color:var(--subtle); margin:0 0 22px; }
+  .acts { display:flex; justify-content:flex-end; gap:10px; }
+  .ghost { font-size:13.5px; font-weight:500; color:var(--text); background:transparent; border:1px solid var(--btn-border); border-radius:var(--radius-md); padding:9px 15px; }
+  .solid { font-size:13.5px; font-weight:600; color:var(--btn-fg); background:var(--btn-bg); border:none; border-radius:var(--radius-md); padding:10px 15px; }
+  .ddanger { font-size:13.5px; font-weight:600; color:#fff; background:var(--danger); border:none; border-radius:var(--radius-md); padding:10px 15px; }
+</style></head>
+<body>
+  <div class="dlg">
+    <h2 style="margin-bottom:10px;">Discard this draft?</h2>
+    <p>This draft and everything in it will be permanently deleted.</p>
+    <div class="acts"><button class="ghost">Keep editing</button><button class="solid">Discard</button></div>
+  </div>
+  <div class="dlg">
+    <div class="hd"><span class="ic">⚠</span><h2>Remove user</h2></div>
+    <p>Remove sam@acme.com? They will lose access immediately.</p>
+    <div class="acts"><button class="ghost">Cancel</button><button class="ddanger">Remove user</button></div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/guidelines/colors-brand.html
+++ b/docs/design/paper/design_system/guidelines/colors-brand.html
@@ -1,0 +1,18 @@
+<!-- @dsCard group="Colors" viewport="700x150" subtitle="Accent, CTA & focus" name="Brand & accent" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:22px; }
+  .row { display:flex; gap:14px; flex-wrap:wrap; }
+  .sw { display:flex; flex-direction:column; gap:8px; }
+  .chip { width:150px; height:54px; border-radius:var(--radius-md); border:1px solid var(--line); display:flex; align-items:flex-end; padding:8px 10px; box-sizing:border-box; }
+  .name { font-size:12px; font-weight:600; color:var(--text); }
+  .hex { font-family:var(--font-mono); font-size:11px; color:var(--muted); }
+</style></head>
+<body>
+  <div class="row">
+    <div class="sw"><div class="chip" style="background:var(--accent);"></div><div><div class="name">accent / primary</div><div class="hex">--color-primary</div></div></div>
+    <div class="sw"><div class="chip" style="background:var(--btn-bg);"></div><div><div class="name">button (inverted)</div><div class="hex">--color-btn-bg</div></div></div>
+    <div class="sw"><div class="chip" style="background:var(--bg); box-shadow:var(--ring);"></div><div><div class="name">focus ring</div><div class="hex">--ring</div></div></div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/guidelines/colors-semantic.html
+++ b/docs/design/paper/design_system/guidelines/colors-semantic.html
@@ -1,0 +1,18 @@
+<!-- @dsCard group="Colors" viewport="700x150" subtitle="Success, warning & error (with tints)" name="Semantic" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:22px; }
+  .row { display:flex; gap:14px; flex-wrap:wrap; }
+  .sw { display:flex; flex-direction:column; gap:8px; }
+  .chip { width:150px; height:54px; border-radius:var(--radius-md); display:flex; align-items:center; justify-content:center; font-family:var(--font-mono); font-size:11px; }
+  .name { font-size:12px; font-weight:600; }
+  .hex { font-family:var(--font-mono); font-size:11px; color:var(--muted); }
+</style></head>
+<body>
+  <div class="row">
+    <div class="sw"><div class="chip" style="background:var(--green-bg); color:var(--green);">Confirmed</div><div><div class="name" style="color:var(--green);">success</div><div class="hex">--color-success</div></div></div>
+    <div class="sw"><div class="chip" style="background:var(--amber-bg); color:var(--amber);">Pending</div><div><div class="name" style="color:var(--amber);">warning</div><div class="hex">--color-warning</div></div></div>
+    <div class="sw"><div class="chip" style="background:var(--danger-bg); color:var(--danger);">Failed</div><div><div class="name" style="color:var(--danger);">error</div><div class="hex">--color-error</div></div></div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/guidelines/colors-surface.html
+++ b/docs/design/paper/design_system/guidelines/colors-surface.html
@@ -1,0 +1,19 @@
+<!-- @dsCard group="Colors" viewport="700x150" subtitle="Backgrounds, surfaces & borders" name="Surfaces" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:22px; }
+  .row { display:flex; gap:14px; flex-wrap:wrap; }
+  .sw { display:flex; flex-direction:column; gap:8px; }
+  .chip { width:148px; height:54px; border-radius:var(--radius-md); border:1px solid var(--line); }
+  .name { font-size:12px; font-weight:600; }
+  .hex { font-family:var(--font-mono); font-size:11px; color:var(--muted); }
+</style></head>
+<body>
+  <div class="row">
+    <div class="sw"><div class="chip" style="background:var(--bg);"></div><div><div class="name">bg — paper</div><div class="hex">--color-bg</div></div></div>
+    <div class="sw"><div class="chip" style="background:var(--surf);"></div><div><div class="name">surface</div><div class="hex">--color-surface</div></div></div>
+    <div class="sw"><div class="chip" style="background:var(--field);"></div><div><div class="name">field</div><div class="hex">--color-field</div></div></div>
+    <div class="sw"><div class="chip" style="background:var(--bg); border:2px solid var(--line);"></div><div><div class="name">border</div><div class="hex">--color-border</div></div></div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/guidelines/colors-text.html
+++ b/docs/design/paper/design_system/guidelines/colors-text.html
@@ -1,0 +1,19 @@
+<!-- @dsCard group="Colors" viewport="700x170" subtitle="4-step text hierarchy" name="Text" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin:0; background:var(--bg); font-family:var(--font-sans); padding:22px; }
+  .stack { display:flex; flex-direction:column; gap:10px; }
+  .line { display:flex; align-items:baseline; gap:14px; }
+  .swatch { width:18px; height:18px; border-radius:5px; border:1px solid var(--line); flex-shrink:0; }
+  .label { font-size:17px; font-weight:600; width:230px; }
+  .tok { font-family:var(--font-mono); font-size:11.5px; color:var(--muted); }
+</style></head>
+<body>
+  <div class="stack">
+    <div class="line"><span class="swatch" style="background:var(--text);"></span><span class="label" style="color:var(--text);">Strong — headings</span><span class="tok">--color-text-strong</span></div>
+    <div class="line"><span class="swatch" style="background:var(--subtle);"></span><span class="label" style="color:var(--subtle);">Body — long-form</span><span class="tok">--color-text</span></div>
+    <div class="line"><span class="swatch" style="background:var(--muted);"></span><span class="label" style="color:var(--muted);">Muted — secondary</span><span class="tok">--color-text-muted</span></div>
+    <div class="line"><span class="swatch" style="background:var(--faint);"></span><span class="label" style="color:var(--faint);">Faint — eyebrows</span><span class="tok">--color-text-faint</span></div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/guidelines/spacing-radius.html
+++ b/docs/design/paper/design_system/guidelines/spacing-radius.html
@@ -1,0 +1,19 @@
+<!-- @dsCard group="Spacing" viewport="700x150" subtitle="Soft, rounded corners" name="Radius" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:24px; }
+  .row { display:flex; gap:18px; align-items:flex-end; }
+  .col { display:flex; flex-direction:column; align-items:center; gap:8px; }
+  .box { width:60px; height:48px; background:var(--surf); border:1px solid var(--btn-border); }
+  .lab { font-family:var(--font-mono); font-size:10.5px; color:var(--muted); }
+</style></head>
+<body>
+  <div class="row">
+    <div class="col"><div class="box" style="border-radius:var(--radius-sm);"></div><div class="lab">sm · 6</div></div>
+    <div class="col"><div class="box" style="border-radius:var(--radius-md);"></div><div class="lab">md · 10</div></div>
+    <div class="col"><div class="box" style="border-radius:var(--radius-lg);"></div><div class="lab">lg · 12</div></div>
+    <div class="col"><div class="box" style="border-radius:var(--radius-xl);"></div><div class="lab">xl · 16</div></div>
+    <div class="col"><div class="box" style="border-radius:var(--radius-full); width:48px;"></div><div class="lab">full</div></div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/guidelines/spacing-scale.html
+++ b/docs/design/paper/design_system/guidelines/spacing-scale.html
@@ -1,0 +1,20 @@
+<!-- @dsCard group="Spacing" viewport="700x150" subtitle="4px base scale" name="Spacing scale" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:24px; }
+  .row { display:flex; align-items:flex-end; gap:16px; }
+  .col { display:flex; flex-direction:column; align-items:center; gap:8px; }
+  .bar { background:var(--accent); border-radius:3px; width:26px; }
+  .lab { font-family:var(--font-mono); font-size:10.5px; color:var(--muted); }
+</style></head>
+<body>
+  <div class="row">
+    <div class="col"><div class="bar" style="height:8px;"></div><div class="lab">2 · 8</div></div>
+    <div class="col"><div class="bar" style="height:16px;"></div><div class="lab">4 · 16</div></div>
+    <div class="col"><div class="bar" style="height:24px;"></div><div class="lab">6 · 24</div></div>
+    <div class="col"><div class="bar" style="height:32px;"></div><div class="lab">8 · 32</div></div>
+    <div class="col"><div class="bar" style="height:48px;"></div><div class="lab">12 · 48</div></div>
+    <div class="col"><div class="bar" style="height:64px;"></div><div class="lab">16 · 64</div></div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/guidelines/spacing-shadow.html
+++ b/docs/design/paper/design_system/guidelines/spacing-shadow.html
@@ -1,0 +1,18 @@
+<!-- @dsCard group="Spacing" viewport="700x160" subtitle="Soft elevation, no hard offsets" name="Shadow" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:28px; }
+  .row { display:flex; gap:28px; align-items:center; }
+  .col { display:flex; flex-direction:column; align-items:center; gap:12px; }
+  .box { width:80px; height:52px; background:var(--field); border:1px solid var(--line); border-radius:var(--radius-lg); }
+  .lab { font-family:var(--font-mono); font-size:10.5px; color:var(--muted); }
+</style></head>
+<body>
+  <div class="row">
+    <div class="col"><div class="box" style="box-shadow:var(--shadow-sm);"></div><div class="lab">sm</div></div>
+    <div class="col"><div class="box" style="box-shadow:var(--shadow-md);"></div><div class="lab">md</div></div>
+    <div class="col"><div class="box" style="box-shadow:var(--shadow-lg);"></div><div class="lab">lg</div></div>
+    <div class="col"><div class="box" style="box-shadow:var(--shadow-xl);"></div><div class="lab">xl · dialogs</div></div>
+  </div>
+</body></html>

--- a/docs/design/paper/design_system/guidelines/type-body.html
+++ b/docs/design/paper/design_system/guidelines/type-body.html
@@ -1,0 +1,15 @@
+<!-- @dsCard group="Type" viewport="700x200" subtitle="Geist — body & UI" name="Body & UI" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin:0; background:var(--bg); font-family:var(--font-sans); padding:24px; }
+  .lead { font-size:var(--font-size-lg); line-height:var(--line-height-loose); color:var(--subtle); margin:0; max-width:54ch; }
+  .ui { font-size:var(--font-size-base); color:var(--muted); margin:12px 0 0; }
+  .tok { font-family:var(--font-mono); font-size:11px; color:var(--faint); margin-top:6px; }
+</style></head>
+<body>
+  <p class="lead">A walk through my recipe app by following one recipe from the moment I click "New" to the moment a visitor reads it.</p>
+  <div class="tok">--font-size-lg · 18px · line-height 1.75</div>
+  <p class="ui">Secondary UI text, nav links, and meta sit at 15px in muted.</p>
+  <div class="tok">--font-size-base · 15px · --color-text-muted</div>
+</body></html>

--- a/docs/design/paper/design_system/guidelines/type-display.html
+++ b/docs/design/paper/design_system/guidelines/type-display.html
@@ -1,0 +1,15 @@
+<!-- @dsCard group="Type" viewport="700x200" subtitle="Geist — fluid display scale" name="Display" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:24px; }
+  .hero { font-size:var(--font-display-hero); font-weight:600; line-height:var(--line-height-tight); letter-spacing:var(--tracking-tight); margin:0; }
+  .title { font-size:var(--font-display-title); font-weight:600; line-height:1.1; letter-spacing:var(--tracking-tight); margin:14px 0 0; }
+  .tok { font-family:var(--font-mono); font-size:11px; color:var(--muted); margin-top:4px; }
+</style></head>
+<body>
+  <p class="hero">Things I keep coming back to.</p>
+  <div class="tok">--font-display-hero · Geist 600 · clamp(40&ndash;56px)</div>
+  <p class="title">Edit recipe</p>
+  <div class="tok">--font-display-title · clamp(32&ndash;46px)</div>
+</body></html>

--- a/docs/design/paper/design_system/guidelines/type-mono.html
+++ b/docs/design/paper/design_system/guidelines/type-mono.html
@@ -1,0 +1,15 @@
+<!-- @dsCard group="Type" viewport="700x180" subtitle="JetBrains Mono — eyebrows, meta, tags" name="Mono" -->
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<link rel="stylesheet" href="../styles.css">
+<style>
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); padding:24px; display:flex; flex-direction:column; gap:16px; }
+  .eyebrow { font-family:var(--font-mono); font-size:var(--font-size-xs); letter-spacing:var(--tracking-eyebrow); text-transform:uppercase; color:var(--faint); }
+  .meta { font-family:var(--font-mono); font-size:var(--font-size-sm); letter-spacing:var(--tracking-meta); color:var(--muted); }
+  .tags { display:flex; gap:8px; }
+  .tag { font-family:var(--font-mono); font-size:var(--font-size-xs); letter-spacing:0.04em; color:var(--muted); border:1px solid var(--line); background:var(--surf); padding:5px 10px; border-radius:var(--radius-sm); }
+</style></head>
+<body>
+  <div class="eyebrow">From the Kitchen</div>
+  <div class="meta">27 June 2026 · 7 min read</div>
+  <div class="tags"><span class="tag">react</span><span class="tag">aws</span><span class="tag">lambda</span><span class="tag">dynamodb</span></div>
+</body></html>

--- a/docs/design/paper/design_system/readme.md
+++ b/docs/design/paper/design_system/readme.md
@@ -1,0 +1,103 @@
+# akli.dev Design System
+
+The design system behind **akli.dev** — the personal site and recipe/blog platform of Akli Aissat (full-stack engineer). It captures the **2026 redesign**: a warm, editorial "paper" aesthetic with a strict two-font pairing, soft elevation, and a first-class light/dark theme.
+
+> **Source of truth: the redesign.** Where the redesign and the existing codebase disagree, the redesign wins. The repo is used here for component **names and inventory**, not visuals.
+
+---
+
+## Sources
+
+- **Redesign (this project):** 11 redesigned `.dc.html` pages — `Home`, `Apps`, `Blog`, `Building a Pokedex` (blog post), `Recipes`, `Mild Thai Basa Coconut Rice` (recipe detail), and admin: `Admin Login`, `Admin Recipes`, `Admin Recipe Editor`, `Admin Recipe Preview`, `Admin Users`.
+- **Codebase:** GitHub `vandelay87/personal-website` (React 19 + TypeScript, Vite, CSS Modules). Original tokens at `src/styles/tokens.css`; components at `src/components/<Name>/<Name>.tsx`.
+  - The repo's original direction is described as "neo-brutalist" (black/white, hard 2px borders, hard-offset shadows, **system fonts**). The redesign deliberately replaces that with warm paper + Geist/JetBrains Mono + soft elevation. This system documents the **new** direction.
+
+---
+
+## What changed from the old system → redesign
+
+| Aspect | Old (repo) | Redesign (this system) |
+|---|---|---|
+| Background | `#FFFFFF` pure white | `#FBFAF7` warm paper |
+| Fonts | system-ui / system mono | **Geist** + **JetBrains Mono** |
+| Borders | `#000` 2px hard | `#ECE6DA` 1px hairline |
+| Shadows | hard offset, no blur (`4px 4px 0`) | soft, blurred, low-opacity |
+| Radii | `0` / `2px` (sharp) | `6–18px` (soft) |
+| Accent | `#2563EB` | `#1F66E0` (light) / `#6BA0FF` (dark) |
+| Text | 1 muted step | 4-step hierarchy (strong→faint) |
+
+---
+
+## Component inventory (repo → status in this system)
+
+**Reusable primitives** (built as design-system components):
+`Button`, `Link`, `Card`, `Header` (public + admin shell top bar), `Callout` (tip/warning/info), `CodeBlock` (with copy), `ConfirmDialog`, `Toast`, `StatusBadge`, `ThemeToggle`, `TagInput`, `ImageUpload`, `ProcessingPlaceholder`, `AutosaveStatus`, `Loading`, `RecipeSearch`, `RecipeTagFilter`, `FileTree`, `FileMeta`, `Typography`, `Grid`.
+
+**Recipe-domain** (primitives used by the recipe surfaces): `RecipeCard`, `IngredientList` / `RecipeIngredients`, `StepList` / `RecipeSteps`.
+
+**Layout / structural** (shell — surfaced via UI kits, not standalone primitives): `Layout`, `AdminLayout`, `FullPageHeader`, `ProtectedRoute`, `ScrollToTop`. *(`Header`/`Navigation` were promoted to a first-class `Header` component — see primitives above.)*
+
+**Page sections** (composed inside UI kits): `AppsCta`, `RecipesCta`, `RecipeDetailView`, `SocialCard`, `CVDownload`, `Image`.
+
+> Deliberately reconciled: several repo components are page-specific compositions rather than reusable primitives, so they live in the **UI kits** instead of the components library. `ProtectedRoute` / `ScrollToTop` are behavioural and have no visual surface, so they are documented only.
+
+---
+
+## Index / manifest
+
+- `styles.css` — global entry point (link this one file). `@import`s only.
+- `tokens/` — `fonts.css`, `colors.css` (light + dark), `typography.css`, `spacing.css`.
+- `components/` — reusable React primitives (one dir each: `<Name>.jsx`, `<Name>.d.ts`, `<Name>.prompt.md`, one `@dsCard` html).
+- `ui_kits/` — full-screen recreations: `public/` (marketing + content pages) and `admin/` (authenticated shell).
+- `guidelines/` — foundation specimen cards (Type, Colors, Spacing, Brand).
+- `SKILL.md` — Agent-Skill manifest for downloading into Claude Code.
+
+---
+
+## Content fundamentals
+
+**Voice.** First-person, calm, and dry. Akli writes as himself ("I build…", "recipes I cook on repeat", "I write these mostly to document how I solved a problem"). Confident but unshowy — it states what something is and moves on.
+
+**Tone rules learned from the redesign:**
+- **No cheese, no hype.** Avoid aspirational filler, exclamation marks, and rallying-cry closers. Lines like "earned a permanent spot in the rotation" or "mostly web, mostly honest" were explicitly rejected as too cheesy/cute. When in doubt, cut the last sentence.
+- **Plain over clever.** "Email me" beats "Get in touch" (say what the button does). "Elsewhere" labels a links list better than "Contact" when it's mostly profiles.
+- **Don't echo.** Body copy shouldn't restate the heading (the recipes intro was reworded specifically to stop mirroring "things I keep coming back to").
+- **You + I, sparingly.** Direct address is fine but light; the "(and you)" parenthetical was dropped as too cute.
+
+**Casing.** Sentence case everywhere for headings and UI. Section eyebrows are the one uppercase moment — short mono labels ("FROM THE KITCHEN", "THE BLOG", "TIP"). Earlier ALL-CAPS section headings were softened to sentence case at the user's request.
+
+**Mechanics.** En-dashes and em-dashes for asides ("— written down so they're easy to make again."). Mid-dot separators in meta lines ("27 June 2026 · 7 min read"). Numerals for times/quantities. No emoji in product copy — the only emoji are the three `Callout` glyphs (💡 ⚠️ ℹ️).
+
+**Examples (good):**
+> Things I keep coming back to.
+> A small, growing collection of recipes I cook on repeat — written down so they're easy to make again.
+> I write these mostly to document how I solved a problem, in case it's useful to someone hitting the same wall.
+
+---
+
+## Visual foundations
+
+**Overall feel.** Warm, editorial, paper-like. Generous whitespace, narrow reading columns, quiet hairlines, soft elevation. A refined inversion of the repo's original loud neo-brutalism.
+
+- **Color & background.** Flat warm off-white (`#FBFAF7`), never pure white; no gradients, textures, or images behind text. Surfaces are a slightly deeper paper tone. Dark mode is a true warm near-black (`#141310`), not blue-black.
+- **Type.** Two families only — **Geist** (UI + display, 600 for headings, tight negative tracking) and **JetBrains Mono** (eyebrows, meta, tags, code). Display headings use fluid `clamp()`; long-form body is 18px / 1.75.
+- **Accent.** A single blue (`#1F66E0` light, `#6BA0FF` dark) for links, focus, active filters, and the one-word "View" links. Used sparingly — most of the page is ink-on-paper.
+- **Borders & radius.** 1px hairlines (`#ECE6DA`). Soft rounding: 6px chips, 10px inputs/buttons, 12px panels, 16–18px cards/dialogs, full pills for CTAs, badges, the theme toggle, and avatars.
+- **Shadows.** Soft, blurred, low-opacity (`0 4px 14px rgba(0,0,0,.08)`), reserved for toasts, dropdowns, and dialogs. Cards are flat (border only) until they lift. No hard-offset shadows.
+- **Hover states.** Links tint to accent; directional icons **nudge** (chevrons slide, ↗ lifts up-right) on a `.25s ease` transform. Filter chips/dashed suggestions border-tint to accent. Cards get a barely-there wash (`rgba(0,0,0,.022)`). The theme toggle shades subtly (theme-aware, not accent).
+- **Press / active.** Buttons dip 1px; active filter chips fill solid accent.
+- **Motion.** Restrained — `.18–.25s ease` color/border/transform transitions, spinner + shimmer for async, a small pop/fade for dialogs and slide-in for toasts. All animation respects `prefers-reduced-motion`.
+- **Transparency / blur.** Only the sticky header — a `color-mix` translucent bg with `backdrop-filter: blur(10px)` so content scrolls softly beneath.
+- **Layout.** Centered, max-width columns: 1080px shell, 720px index/hero reading column, 680px article column, ~54ch hero measure. Sticky header; in the editor a sticky right action rail.
+
+---
+
+## Iconography
+
+- **Style.** Inline SVG, outline only — `stroke="currentColor"`, ~`stroke-width: 2`, round caps/joins (Lucide-grade geometry). No filled icons, no icon font, no PNG icons. Icons inherit text color and sit at 13–18px.
+- **Where.** Sparingly and functionally: chevrons (back/forward), ↗ external, search glyph, eye (preview), trash (delete/remove), plus (add), upload, lock (locked slug), check / alert (status, autosave), arrows in CTAs. Directional icons animate on hover.
+- **Emoji.** Only the three `Callout` type glyphs (💡 tip, ⚠️ warning, ℹ️ info). Never elsewhere in product copy.
+- **Unicode.** A few typographic glyphs stand in for icons in dense spots: `☾`/`☀` (theme toggle), `✓`/`✕` (toast/tag/checklist), `·` (meta separators), `↗`/`←` (links).
+- **Substitution note.** Icons in this system are hand-inlined SVG paths matched to the redesign; if you need a fuller set, **Lucide** (same outline weight) is the drop-in match.
+
+> **Fonts:** Geist + JetBrains Mono load from Google Fonts (`tokens/fonts.css`). The original repo used system-font stacks; this is a deliberate redesign change. Swap to self-hosted woff2 `@font-face` for production if you want zero external requests.

--- a/docs/design/paper/design_system/styles.css
+++ b/docs/design/paper/design_system/styles.css
@@ -1,0 +1,8 @@
+/* akli.dev Design System — global entry point.
+   Consumers link THIS file. It is a manifest of @imports only. */
+
+@import "./tokens/fonts.css";
+@import "./tokens/colors.css";
+@import "./tokens/typography.css";
+@import "./tokens/spacing.css";
+@import "./components/_helpers.css";

--- a/docs/design/paper/design_system/tokens/colors.css
+++ b/docs/design/paper/design_system/tokens/colors.css
@@ -1,0 +1,100 @@
+/* ── Colors ───────────────────────────────────────────────────
+   The redesign's "warm paper" palette. Light is the default;
+   [data-theme="dark"] overrides. Every value below is the new
+   direction — it supersedes the old neo-brutalist black/white set.
+
+   Two naming layers are provided:
+     • Semantic --color-* names (mirror the app's existing convention)
+     • Short working aliases (--bg, --text, --surf …) used verbatim
+       across the redesigned pages and the UI kits.
+   They resolve to the same values; use whichever your context prefers.
+   ──────────────────────────────────────────────────────────── */
+
+:root {
+  color-scheme: light;
+
+  /* Surfaces */
+  --color-bg:            #FBFAF7;   /* page background — warm off-white paper */
+  --color-surface:       #F4F1EA;   /* cards, chips, inset panels */
+  --color-field:         #FFFFFF;   /* form inputs */
+  --color-hover:         rgba(0,0,0,0.022); /* subtle row/cell hover wash */
+
+  /* Text — a 4-step hierarchy (strong → faint) */
+  --color-text-strong:   #1C1A16;   /* headings, primary text */
+  --color-text:          #3A3631;   /* long-form body */
+  --color-text-muted:    #6F6961;   /* secondary text, nav, meta */
+  --color-text-faint:    #9A938A;   /* eyebrows, captions, placeholders */
+
+  /* Borders */
+  --color-border:        #ECE6DA;   /* hairlines, dividers, card edges */
+  --color-border-strong: #E0DACE;   /* button outlines, interactive borders */
+
+  /* Brand / accent */
+  --color-primary:       #1F66E0;   /* links, focus, active filter, accents */
+  --color-on-primary:    #FFFFFF;
+  --color-link:          #1F66E0;
+
+  /* Inverted button (primary CTA) */
+  --color-btn-bg:        #1C1A16;
+  --color-btn-fg:        #FBFAF7;
+
+  /* Semantic status */
+  --color-success:       #1F8A5B;
+  --color-success-bg:    rgba(31,138,91,0.10);
+  --color-warning:       #A66E0A;
+  --color-warning-bg:    rgba(194,129,12,0.12);
+  --color-error:         #C0392B;
+  --color-error-bg:      rgba(192,57,43,0.07);
+
+  /* ── Short working aliases (used across pages + UI kits) ── */
+  --bg:        var(--color-bg);
+  --surf:      var(--color-surface);
+  --field:     var(--color-field);
+  --hover:     var(--color-hover);
+  --text:      var(--color-text-strong);
+  --subtle:    var(--color-text);
+  --muted:     var(--color-text-muted);
+  --faint:     var(--color-text-faint);
+  --line:      var(--color-border);
+  --btn-border: var(--color-border-strong);
+  --accent:    var(--color-primary);
+  --btn-bg:    var(--color-btn-bg);
+  --btn-fg:    var(--color-btn-fg);
+  --green:     var(--color-success);
+  --green-bg:  var(--color-success-bg);
+  --amber:     var(--color-warning);
+  --amber-bg:  var(--color-warning-bg);
+  --danger:    var(--color-error);
+  --danger-bg: var(--color-error-bg);
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+
+  --color-bg:            #141310;
+  --color-surface:       #1C1A15;
+  --color-field:         #1B1914;
+  --color-hover:         rgba(255,255,255,0.04);
+
+  --color-text-strong:   #F3F0E8;
+  --color-text:          #CFC9BD;
+  --color-text-muted:    #A6A093;
+  --color-text-faint:    #6E685E;
+
+  --color-border:        #2A2823;
+  --color-border-strong: #36342C;
+
+  --color-primary:       #6BA0FF;
+  --color-on-primary:    #11151F;
+  --color-link:          #6BA0FF;
+
+  --color-btn-bg:        #F3F0E8;
+  --color-btn-fg:        #141310;
+
+  --color-success:       #62C08D;
+  --color-success-bg:    rgba(98,192,141,0.12);
+  --color-warning:       #E0A93B;
+  --color-warning-bg:    rgba(224,169,59,0.14);
+  --color-error:         #E8786B;
+  --color-error-bg:      rgba(232,120,107,0.12);
+}

--- a/docs/design/paper/design_system/tokens/fonts.css
+++ b/docs/design/paper/design_system/tokens/fonts.css
@@ -1,0 +1,6 @@
+/* Webfonts.
+   The redesign uses Geist (UI/display) and JetBrains Mono (mono / eyebrows / meta).
+   Loaded from Google Fonts. If you need fully self-hosted binaries for production,
+   swap these @imports for local @font-face rules pointing at woff2 files. */
+
+@import url("https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");

--- a/docs/design/paper/design_system/tokens/spacing.css
+++ b/docs/design/paper/design_system/tokens/spacing.css
@@ -1,0 +1,57 @@
+/* ── Spacing, radius, shadow, layout ──────────────────────────
+   The redesign trades the old hard-offset brutalist shadows for
+   soft, low-opacity elevation and generous rounding.
+   ──────────────────────────────────────────────────────────── */
+
+:root {
+  /* Spacing scale (4px base) */
+  --space-1:  0.25rem;  /* 4px  */
+  --space-2:  0.5rem;   /* 8px  */
+  --space-3:  0.75rem;  /* 12px */
+  --space-4:  1rem;     /* 16px */
+  --space-5:  1.25rem;  /* 20px */
+  --space-6:  1.5rem;   /* 24px */
+  --space-8:  2rem;     /* 32px */
+  --space-10: 2.5rem;   /* 40px */
+  --space-12: 3rem;     /* 48px */
+  --space-16: 4rem;     /* 64px */
+  --space-20: 5rem;     /* 80px */
+  --space-24: 6rem;     /* 96px */
+
+  /* Border radius — soft, rounded */
+  --radius-sm:   6px;   /* chips, small controls */
+  --radius-md:   10px;  /* inputs, buttons */
+  --radius-lg:   12px;  /* code panels, callouts */
+  --radius-xl:   16px;  /* cards, panels, dialogs */
+  --radius-2xl:  18px;  /* modals */
+  --radius-full: 999px; /* pills, avatars, toggle */
+
+  /* Border widths */
+  --border-width:       1px;  /* default hairline */
+  --border-width-thick: 1.5px;/* checkboxes, emphasis */
+
+  /* Shadows — soft elevation, no hard offsets */
+  --shadow-sm:  0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md:  0 4px 14px rgba(0,0,0,0.08);
+  --shadow-lg:  0 12px 30px rgba(0,0,0,0.16);
+  --shadow-xl:  0 24px 60px rgba(0,0,0,0.28); /* dialogs */
+
+  /* Focus ring */
+  --ring: 0 0 0 3px color-mix(in srgb, var(--color-primary) 15%, transparent);
+
+  /* Layout */
+  --max-w-site:    1080px; /* shell / header / footer width */
+  --max-w-reading: 720px;  /* index + hero reading column */
+  --max-w-article: 680px;  /* long-form article column */
+  --max-w-prose:   54ch;   /* hero paragraph measure */
+
+  /* Z-index */
+  --z-header:  20;
+  --z-overlay: 60;
+  --z-toast:   80;
+
+  /* Transitions */
+  --duration-fast: 180ms;
+  --duration-base: 250ms;
+  --easing-default: ease;
+}

--- a/docs/design/paper/design_system/tokens/typography.css
+++ b/docs/design/paper/design_system/tokens/typography.css
@@ -1,0 +1,49 @@
+/* ── Typography ───────────────────────────────────────────────
+   Two families only:
+     • Geist — everything UI and display (sans).
+     • JetBrains Mono — eyebrows, meta lines, code, tags, numerics.
+   Sizes lean on clamp() at the display end for fluid headings;
+   the fixed scale below covers body and UI.
+   ──────────────────────────────────────────────────────────── */
+
+:root {
+  --font-sans: 'Geist', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+
+  /* Font sizes */
+  --font-size-xs:   0.6875rem; /* 11px — mono eyebrows, tags */
+  --font-size-sm:   0.8125rem; /* 13px — meta, labels */
+  --font-size-base: 0.9375rem; /* 15px — UI text, inputs */
+  --font-size-md:   1rem;      /* 16px — list body */
+  --font-size-lg:   1.125rem;  /* 18px — long-form body */
+  --font-size-xl:   1.3125rem; /* 21px — lead/intro */
+  --font-size-2xl:  1.5rem;    /* 24px */
+  --font-size-3xl:  1.8125rem; /* 29px — card/section titles */
+  --font-size-4xl:  2.875rem;  /* 46px — page titles */
+  --font-size-5xl:  3.5rem;    /* 56px — hero */
+
+  /* Fluid display sizes (hero / page titles) */
+  --font-display-hero:  clamp(40px, 7vw, 56px);
+  --font-display-title: clamp(32px, 5.6vw, 46px);
+  --font-display-h2:    clamp(23px, 3.2vw, 27px);
+
+  /* Weights — Geist */
+  --font-weight-normal:   400;
+  --font-weight-medium:   500;
+  --font-weight-semibold: 600;
+  --font-weight-bold:     700;
+
+  /* Line heights */
+  --line-height-tight:   1.08;  /* display headings */
+  --line-height-snug:    1.25;  /* section headings */
+  --line-height-normal:  1.5;   /* UI text */
+  --line-height-relaxed: 1.65;  /* body */
+  --line-height-loose:   1.75;  /* long-form article body */
+
+  /* Letter spacing */
+  --tracking-tight:  -0.03em;   /* hero / page titles */
+  --tracking-snug:   -0.02em;   /* section + card titles */
+  --tracking-normal: 0;
+  --tracking-eyebrow: 0.16em;   /* mono uppercase eyebrows */
+  --tracking-meta:    0.04em;   /* mono meta lines */
+}

--- a/docs/design/paper/design_system/ui_kits/admin/README.md
+++ b/docs/design/paper/design_system/ui_kits/admin/README.md
@@ -1,0 +1,13 @@
+# Admin — UI kit
+
+A recreation of the **authenticated admin** surface: a common shell wrapping every logged-in view.
+
+`index.html` shows the **Recipe list** (admin home): the shell header (brand → public site, Recipes/Users nav, signed-in email, Log out, theme toggle), the page header with "New recipe", and the recipe rows — each with title, tags, a `StatusBadge` (Published/Draft), last-updated date, and per-row actions (Edit / Preview / Publish-Unpublish / Delete).
+
+The same shell carries the other admin views:
+- **Recipe editor** — long autosave form (`AutosaveStatus`, `TagInput`, `ImageUpload`, `ProcessingPlaceholder`) with a sticky action rail + publish checklist.
+- **Recipe preview** — read-only public render behind a status banner.
+- **Users** — role/status table, inline invite form, `ConfirmDialog` on remove.
+- **Login** — the one screen *outside* the shell (centered card, with the public header/footer).
+
+**Composes:** `StatusBadge`, `Button`, `ConfirmDialog`, `Toast`, `ThemeToggle`, plus the editor form components.

--- a/docs/design/paper/design_system/ui_kits/admin/index.html
+++ b/docs/design/paper/design_system/ui_kits/admin/index.html
@@ -1,0 +1,72 @@
+<!-- @dsCard group="Admin" viewport="1080x760" subtitle="Recipe list — admin shell, rows, status, actions" name="Admin" -->
+<!-- @startingPoint section="Admin" subtitle="Recipe management list — authenticated shell" viewport="1080x760" -->
+<!DOCTYPE html><html lang="en" data-theme="light"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:var(--max-w-site); margin:0 auto; padding:0 28px; }
+  /* shell header */
+  header { border-bottom:1px solid var(--line); }
+  .nav { display:flex; align-items:center; justify-content:space-between; gap:20px; padding:18px 0; }
+  .left { display:flex; align-items:center; gap:30px; }
+  .brand { font-size:15px; font-weight:600; letter-spacing:-0.01em; color:var(--text); text-decoration:none; }
+  .links { display:flex; align-items:center; gap:22px; font-size:14px; color:var(--muted); }
+  .links a { color:inherit; text-decoration:none; }
+  .links a.active { color:var(--text); font-weight:500; }
+  .right { display:flex; align-items:center; gap:14px; }
+  .email { font-size:13px; color:var(--muted); }
+  .ghost { font-size:13px; font-weight:500; color:var(--subtle); background:transparent; border:1px solid var(--btn-border); border-radius:var(--radius-md); padding:7px 13px; cursor:pointer; }
+  .toggle { width:32px; height:32px; display:inline-flex; align-items:center; justify-content:center; border:1px solid var(--btn-border); border-radius:50%; color:var(--text); background:transparent; cursor:pointer; }
+  /* page */
+  main { max-width:var(--max-w-site); margin:0 auto; padding:44px 28px 64px; }
+  .head { display:flex; flex-wrap:wrap; gap:16px; align-items:flex-end; justify-content:space-between; margin-bottom:30px; }
+  h1 { font-size:var(--font-display-title); font-weight:600; letter-spacing:-0.025em; margin:0 0 6px; }
+  .sub { font-size:14.5px; color:var(--muted); margin:0; }
+  .primary { font-size:14px; font-weight:600; color:var(--btn-fg); background:var(--btn-bg); border:none; border-radius:var(--radius-md); padding:11px 18px; cursor:pointer; display:inline-flex; align-items:center; gap:8px; }
+  .list { border:1px solid var(--line); border-radius:var(--radius-xl); overflow:hidden; background:var(--field); }
+  .row { display:flex; flex-wrap:wrap; gap:14px 18px; align-items:center; justify-content:space-between; padding:18px 22px; border-top:1px solid var(--line); }
+  .row:first-child { border-top:none; }
+  .rtitle { font-size:16px; font-weight:600; letter-spacing:-0.01em; margin:0 0 7px; }
+  .rtags { display:flex; gap:7px; }
+  .tag { font-family:var(--font-mono); font-size:11px; color:var(--muted); border:1px solid var(--line); background:var(--surf); padding:4px 9px; border-radius:var(--radius-sm); }
+  .rmeta { display:flex; align-items:center; gap:14px; }
+  .badge { display:inline-flex; align-items:center; gap:6px; font-family:var(--font-mono); font-size:10.5px; letter-spacing:0.06em; text-transform:uppercase; padding:4px 11px; border-radius:var(--radius-full); }
+  .dot { width:5px; height:5px; border-radius:50%; }
+  .date { font-family:var(--font-mono); font-size:12px; color:var(--faint); }
+  .acts { display:flex; gap:6px; }
+  .act { font-size:13px; color:var(--muted); background:transparent; border:1px solid transparent; border-radius:var(--radius-sm); padding:6px 10px; cursor:pointer; }
+  .act:hover { background:var(--hover); color:var(--text); }
+  footer { border-top:1px solid var(--line); }
+  .foot { display:flex; justify-content:space-between; padding:22px 28px; max-width:var(--max-w-site); margin:0 auto; font-size:12.5px; color:var(--faint); }
+</style></head>
+<body>
+  <header><div class="wrap"><div class="nav">
+    <div class="left"><a class="brand" href="#">Akli Aissat</a><nav class="links"><a class="active" href="#">Recipes</a><a href="#">Users</a></nav></div>
+    <div class="right"><span class="email">akli@akli.dev</span><button class="ghost">Log out</button><button class="toggle">☾</button></div>
+  </div></div></header>
+
+  <main>
+    <div class="head">
+      <div><h1>Recipes</h1><p class="sub">5 recipes · sorted by recently updated</p></div>
+      <button class="primary">+ New recipe</button>
+    </div>
+    <div class="list">
+      <div class="row">
+        <div><h2 class="rtitle">Mild Thai-Style Basa &amp; Coconut Rice</h2><div class="rtags"><span class="tag">Thai</span><span class="tag">Fish</span><span class="tag">One Pot</span></div></div>
+        <div class="rmeta"><span class="badge" style="color:var(--green);background:var(--green-bg);"><span class="dot" style="background:var(--green);"></span>Published</span><span class="date">27 Jun 2026</span><div class="acts"><button class="act">Edit</button><button class="act">Preview</button><button class="act">Unpublish</button></div></div>
+      </div>
+      <div class="row">
+        <div><h2 class="rtitle">Weeknight Beef Ragù</h2><div class="rtags"><span class="tag">Pasta</span><span class="tag">Beef</span></div></div>
+        <div class="rmeta"><span class="badge" style="color:var(--amber);background:var(--amber-bg);"><span class="dot" style="background:var(--amber);"></span>Draft</span><span class="date">24 Jun 2026</span><div class="acts"><button class="act">Edit</button><button class="act">Preview</button><button class="act">Publish</button></div></div>
+      </div>
+      <div class="row">
+        <div><h2 class="rtitle">Rosemary Olive Oil Focaccia</h2><div class="rtags"><span class="tag">Baking</span><span class="tag">Bread</span></div></div>
+        <div class="rmeta"><span class="badge" style="color:var(--green);background:var(--green-bg);"><span class="dot" style="background:var(--green);"></span>Published</span><span class="date">19 Jun 2026</span><div class="acts"><button class="act">Edit</button><button class="act">Preview</button><button class="act">Unpublish</button></div></div>
+      </div>
+    </div>
+  </main>
+
+  <footer><div class="foot"><span>akli.dev admin</span><span>Signed in as akli@akli.dev</span></div></footer>
+</body></html>

--- a/docs/design/paper/design_system/ui_kits/public/README.md
+++ b/docs/design/paper/design_system/ui_kits/public/README.md
@@ -1,0 +1,9 @@
+# Public site — UI kit
+
+A full-fidelity recreation of the **public akli.dev** content surface in the redesign's warm-paper aesthetic.
+
+`index.html` shows the **Recipes index** as a representative screen: the sticky site header (brand + Apps/Recipes/Blog + theme toggle), the mono-eyebrow hero, the search + category-filter row, the recipe grid, and the footer ("Elsewhere" + akli.dev).
+
+The same shell, type, and components carry every public page — Home, Apps, Blog, blog post (long-form article column + `CodeBlock` + `Callout`), and recipe detail (sticky ingredients card + numbered method).
+
+**Composes:** `Link`, `Tag` (filter chips), `Input` (search), `RecipeCard`, `ThemeToggle`, plus the header/footer shell.

--- a/docs/design/paper/design_system/ui_kits/public/index.html
+++ b/docs/design/paper/design_system/ui_kits/public/index.html
@@ -1,0 +1,82 @@
+<!-- @dsCard group="Public site" viewport="1080x760" subtitle="Recipes index — header, hero, filter, grid, footer" name="Public site" -->
+<!-- @startingPoint section="Public site" subtitle="Recipes index screen — full marketing/content layout" viewport="1080x760" -->
+<!DOCTYPE html><html lang="en" data-theme="light"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--text); font-family:var(--font-sans); -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:var(--max-w-site); margin:0 auto; padding:0 28px; }
+  /* header */
+  header { border-bottom:1px solid var(--line); }
+  .nav { display:flex; align-items:center; justify-content:space-between; padding:22px 0; }
+  .brand { font-size:15px; font-weight:600; letter-spacing:-0.01em; color:var(--text); text-decoration:none; }
+  .links { display:flex; align-items:center; gap:28px; font-size:14px; color:var(--muted); }
+  .links a { color:inherit; text-decoration:none; }
+  .links a.active { color:var(--text); font-weight:500; }
+  .toggle { width:32px; height:32px; display:inline-flex; align-items:center; justify-content:center; border:1px solid var(--btn-border); border-radius:50%; color:var(--text); background:transparent; cursor:pointer; }
+  /* hero */
+  .hero { max-width:var(--max-w-reading); margin:0 auto; padding:96px 28px 48px; }
+  .eyebrow { font-family:var(--font-mono); font-size:12px; letter-spacing:var(--tracking-eyebrow); text-transform:uppercase; color:var(--faint); margin-bottom:22px; }
+  h1 { font-size:var(--font-display-hero); font-weight:600; line-height:var(--line-height-tight); letter-spacing:var(--tracking-tight); margin:0 0 22px; }
+  .lead { font-size:var(--font-size-lg); line-height:var(--line-height-relaxed); color:var(--muted); margin:0; max-width:54ch; }
+  /* recipes */
+  .section { padding:24px 28px 96px; max-width:var(--max-w-site); margin:0 auto; }
+  .count { display:flex; align-items:baseline; gap:12px; font-family:var(--font-mono); font-size:12px; letter-spacing:0.06em; color:var(--faint); margin-bottom:18px; }
+  .count .rule { flex:1; height:1px; background:var(--line); }
+  .controls { display:flex; flex-wrap:wrap; align-items:center; gap:14px 12px; margin-bottom:34px; }
+  .search { position:relative; flex:1 1 280px; max-width:420px; }
+  .search input { width:100%; font-family:var(--font-sans); font-size:15px; color:var(--text); background:var(--surf); border:1px solid var(--line); border-radius:var(--radius-full); padding:12px 16px 12px 42px; outline:none; }
+  .search svg { position:absolute; left:15px; top:50%; transform:translateY(-50%); color:var(--faint); }
+  .chips { display:flex; flex-wrap:wrap; gap:8px; }
+  .chip { font-family:var(--font-mono); font-size:11px; letter-spacing:0.04em; color:var(--muted); border:1px solid var(--line); background:var(--surf); padding:6px 12px; border-radius:var(--radius-sm); cursor:pointer; }
+  .chip.active { background:var(--accent); border-color:var(--accent); color:#fff; }
+  .grid { display:grid; grid-template-columns:repeat(3, 1fr); gap:26px; }
+  .card { border:1px solid var(--line); border-radius:var(--radius-xl); overflow:hidden; background:var(--bg); text-decoration:none; color:inherit; }
+  .card .img { aspect-ratio:3/2; }
+  .card .body { padding:18px 20px; }
+  .card h3 { font-size:18px; font-weight:600; letter-spacing:-0.02em; margin:0 0 7px; }
+  .card p { font-size:14px; line-height:1.55; color:var(--muted); margin:0 0 14px; }
+  .meta { font-family:var(--font-mono); font-size:11.5px; color:var(--faint); display:flex; gap:12px; flex-wrap:wrap; }
+  /* footer */
+  footer { border-top:1px solid var(--line); }
+  .foot { display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between; padding:40px 0; }
+  .foot .col { display:flex; flex-direction:column; gap:12px; }
+  .foot .lbl { font-size:15px; font-weight:600; }
+  .foot .social { display:flex; gap:20px; font-size:14px; color:var(--muted); }
+  .foot .social a { color:inherit; text-decoration:none; }
+  .foot .dom { font-size:13px; font-weight:500; color:var(--muted); }
+</style></head>
+<body>
+  <header><div class="wrap"><div class="nav">
+    <a class="brand" href="#">Akli Aissat</a>
+    <nav class="links"><a href="#">Apps</a><a class="active" href="#">Recipes</a><a href="#">Blog</a><button class="toggle">☾</button></nav>
+  </div></div></header>
+
+  <section class="hero">
+    <div class="eyebrow">From the Kitchen</div>
+    <h1>Things I keep<br>coming back to.</h1>
+    <p class="lead">A small, growing collection of recipes I cook on repeat — written down so they're easy to make again. Tried, tweaked, and worth the effort.</p>
+  </section>
+
+  <section class="section">
+    <div class="count"><span>6 recipes</span><span class="rule"></span></div>
+    <div class="controls">
+      <div class="search">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.5" y2="16.5"></line></svg>
+        <input placeholder="Search recipes…">
+      </div>
+      <div class="chips"><span class="chip active">all</span><span class="chip">Pasta</span><span class="chip">Mains</span><span class="chip">Quick</span><span class="chip">Baking</span></div>
+    </div>
+    <div class="grid">
+      <a class="card"><div class="img" style="background:linear-gradient(135deg,#cfe3c4,#9fc77f);"></div><div class="body"><h3>Weeknight Beef Ragù</h3><p>Slow-simmered beef and pork over wide pappardelle.</p><div class="meta"><span>Prep: 20 min</span><span>Cook: 3 hr</span><span>Serves: 4</span></div></div></a>
+      <a class="card"><div class="img" style="background:linear-gradient(135deg,#e6c79a,#c98f55);"></div><div class="body"><h3>Lemon Roast Chicken</h3><p>One pan, crisp skin, soft potatoes underneath.</p><div class="meta"><span>Prep: 20 min</span><span>Cook: 1 hr 20</span><span>Serves: 4</span></div></div></a>
+      <a class="card"><div class="img" style="background:linear-gradient(135deg,#e8a87c,#d2603a);"></div><div class="body"><h3>Weekend Shakshuka</h3><p>Eggs poached in a spiced tomato and pepper sauce.</p><div class="meta"><span>Prep: 10 min</span><span>Cook: 25 min</span><span>Serves: 2</span></div></div></a>
+    </div>
+  </section>
+
+  <footer><div class="wrap"><div class="foot">
+    <div class="col"><span class="lbl">Elsewhere</span><div class="social"><a href="#">GitHub</a><a href="#">LinkedIn</a><a href="#">Email</a></div></div>
+    <span class="dom">akli.dev</span>
+  </div></div></footer>
+</body></html>

--- a/docs/design/paper/pages/Admin Login.dc.html
+++ b/docs/design/paper/pages/Admin Login.dc.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --surf:#F4F1EA; --hover:rgba(0,0,0,0.022); --field:#FFFFFF;
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --accent:#1F66E0; --danger:#C0392B; --danger-bg:rgba(192,57,43,0.07);
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --surf:#1C1A15; --hover:rgba(255,255,255,0.04); --field:#1B1914;
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --accent:#6BA0FF; --danger:#E8786B; --danger-bg:rgba(232,120,107,0.10);
+  }
+  .field { width:100%; font-family:'Geist',system-ui,sans-serif; font-size:15px; color:var(--text); background:var(--field); border:1px solid var(--line); border-radius:10px; padding:13px 14px; outline:none; transition: border-color .18s ease, box-shadow .18s ease; }
+  .field::placeholder { color:var(--faint); }
+  .field:focus { border-color:var(--accent); box-shadow:0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent); }
+  .submit { width:100%; font-family:'Geist',system-ui,sans-serif; font-size:15px; font-weight:600; color:var(--btn-fg); background:var(--btn-bg); border:none; border-radius:10px; padding:14px 16px; cursor:pointer; display:inline-flex; align-items:center; justify-content:center; gap:9px; transition: opacity .18s ease, transform .06s ease; }
+  .submit:hover { opacity:.9; }
+  .submit:active { transform:translateY(1px); }
+  .submit:disabled { opacity:.62; cursor:default; }
+  .spinner { width:15px; height:15px; border-radius:50%; border:2px solid color-mix(in srgb, var(--btn-fg) 35%, transparent); border-top-color:var(--btn-fg); animation:spin .7s linear infinite; }
+  @keyframes spin { to { transform:rotate(360deg); } }
+  .seg { display:inline-flex; background:var(--surf); border:1px solid var(--line); border-radius:9px; padding:3px; gap:2px; }
+  .seg button { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.03em; color:var(--muted); background:transparent; border:none; padding:6px 11px; border-radius:6px; cursor:pointer; transition: background .18s ease, color .18s ease; }
+  .seg button[data-on="true"] { background:var(--field); color:var(--text); box-shadow:0 1px 2px rgba(0,0,0,0.05); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  .lnk { transition: color .25s ease, opacity .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .site-header { position: sticky; top:0; z-index:20; background: color-mix(in srgb, var(--bg) 82%, transparent); backdrop-filter: saturate(140%) blur(10px); -webkit-backdrop-filter: saturate(140%) blur(10px); }
+  a:focus-visible, button:focus-visible, .field:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius:6px; }
+  @media (prefers-reduced-motion: reduce) { .spinner{animation:none;} }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased; display:flex; flex-direction:column;">
+
+  <!-- ===== ADMIN HEADER (logged-out variant) ===== -->
+  <header class="site-header">
+    <div style="max-width:1080px; margin:0 auto; padding:22px clamp(20px,5vw,28px); display:flex; align-items:center; justify-content:space-between;">
+      <a class="lnk" href="/" style="font-size:15px; font-weight:600; letter-spacing:-0.01em;">Akli Aissat</a>
+      <div style="display:flex; align-items:center; gap:16px;">
+        <span style="font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.16em; text-transform:uppercase; color:var(--faint);">Admin</span>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </div>
+    </div>
+  </header>
+
+  <!-- preview switcher (design-time only) -->
+  <div style="position:fixed; bottom:18px; right:18px; z-index:30;">
+    <div class="seg" role="group" aria-label="Preview state">
+      <button data-on="{{ isSignin }}" onClick="{{ showSignin }}">Sign in</button>
+      <button data-on="{{ isSetpw }}" onClick="{{ showSetpw }}">Set password</button>
+    </div>
+  </div>
+
+  <main style="flex:1; display:flex; align-items:center; justify-content:center; padding:48px 24px;">
+    <div style="width:100%; max-width:392px;">
+
+      <!-- card -->
+      <div style="background:var(--surf); border:1px solid var(--line); border-radius:18px; padding:clamp(26px,4vw,34px);">
+
+        <header style="margin-bottom:24px;">
+          <h1 style="font-size:22px; font-weight:600; letter-spacing:-0.02em; margin:0 0 6px;">{{ heading }}</h1>
+          <p style="font-size:14px; line-height:1.55; color:var(--muted); margin:0;">{{ subheading }}</p>
+        </header>
+
+        <!-- inline error -->
+        <sc-if value="{{ hasError }}" hint-placeholder-val="{{ false }}">
+          <div role="alert" style="display:flex; align-items:flex-start; gap:9px; background:var(--danger-bg); border:1px solid color-mix(in srgb, var(--danger) 34%, transparent); border-radius:10px; padding:11px 13px; margin-bottom:18px;">
+            <span aria-hidden="true" style="color:var(--danger); font-size:13px; line-height:1.5; flex-shrink:0;">●</span>
+            <span style="font-size:13.5px; line-height:1.5; color:var(--danger);">{{ errorMsg }}</span>
+          </div>
+        </sc-if>
+
+        <form onSubmit="{{ onSubmit }}" novalidate="true" style="display:flex; flex-direction:column; gap:16px;">
+
+          <!-- SIGN IN -->
+          <sc-if value="{{ isSignin }}" hint-placeholder-val="{{ true }}">
+            <label style="display:flex; flex-direction:column; gap:7px;">
+              <span style="font-size:13px; font-weight:500; color:var(--subtle);">Email</span>
+              <input class="field" type="email" name="email" autocomplete="username" placeholder="you@akli.dev" value="{{ email }}" onChange="{{ onEmail }}">
+            </label>
+            <label style="display:flex; flex-direction:column; gap:7px;">
+              <span style="font-size:13px; font-weight:500; color:var(--subtle);">Password</span>
+              <input class="field" type="password" name="password" autocomplete="current-password" placeholder="••••••••••" value="{{ password }}" onChange="{{ onPassword }}">
+            </label>
+          </sc-if>
+
+          <!-- SET NEW PASSWORD -->
+          <sc-if value="{{ isSetpw }}" hint-placeholder-val="{{ false }}">
+            <label style="display:flex; flex-direction:column; gap:7px;">
+              <span style="font-size:13px; font-weight:500; color:var(--subtle);">New password</span>
+              <input class="field" type="password" name="newPassword" autocomplete="new-password" placeholder="At least 8 characters" value="{{ newPassword }}" onChange="{{ onNewPassword }}">
+            </label>
+            <label style="display:flex; flex-direction:column; gap:7px;">
+              <span style="font-size:13px; font-weight:500; color:var(--subtle);">Confirm password</span>
+              <input class="field" type="password" name="confirmPassword" autocomplete="new-password" placeholder="Re-enter your new password" value="{{ confirmPassword }}" onChange="{{ onConfirm }}">
+            </label>
+          </sc-if>
+
+          <button class="submit" type="submit" disabled="{{ loading }}" style="margin-top:6px;">
+            <sc-if value="{{ loading }}" hint-placeholder-val="{{ false }}"><span class="spinner" aria-hidden="true"></span></sc-if>
+            {{ buttonLabel }}
+          </button>
+        </form>
+
+        <!-- set-password footnote -->
+        <sc-if value="{{ isSetpw }}" hint-placeholder-val="{{ false }}">
+          <p style="font-size:12.5px; line-height:1.5; color:var(--faint); margin:18px 0 0; text-align:center;">First time signing in? Choose a password to finish setting up your account.</p>
+        </sc-if>
+      </div>
+
+      <p style="text-align:center; font-size:12px; color:var(--faint); margin:22px 0 0;">Authorized access only.</p>
+    </div>
+  </main>
+
+  <!-- ===== FOOTER ===== -->
+  <footer style="border-top:1px solid var(--line);">
+    <div style="max-width:1080px; margin:0 auto; padding:clamp(34px,5vw,44px) clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between;">
+      <nav aria-label="Elsewhere" style="display:flex; flex-direction:column; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:var(--text);">Elsewhere</span>
+        <div style="display:flex; flex-wrap:wrap; gap:20px; font-size:14px; color:var(--muted);">
+          <a class="lnk" href="https://github.com/vandelay87">GitHub</a>
+          <a class="lnk" href="https://www.linkedin.com/in/akli-aissat-b08119115/">LinkedIn</a>
+          <a class="lnk" href="mailto:akliaissat@outlook.com?subject=Hello">Email</a>
+        </div>
+      </nav>
+      <span style="font-size:13px; font-weight:500; color:var(--muted);">akli.dev</span>
+    </div>
+  </footer>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{}">
+class Component extends DCLogic {
+  state = {
+    theme: 'light',
+    mode: 'signin',           // 'signin' | 'setpw'
+    email: '', password: '',
+    newPassword: '', confirmPassword: '',
+    loading: false,
+    error: ''
+  };
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') this.setState({ theme: saved });
+      else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) this.setState({ theme: 'dark' });
+    } catch (e) {}
+  }
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  showSignin = () => this.setState({ mode: 'signin', error: '', loading: false });
+  showSetpw  = () => this.setState({ mode: 'setpw', error: '', loading: false });
+
+  onEmail = (e) => this.setState({ email: e.target.value });
+  onPassword = (e) => this.setState({ password: e.target.value });
+  onNewPassword = (e) => this.setState({ newPassword: e.target.value });
+  onConfirm = (e) => this.setState({ confirmPassword: e.target.value });
+
+  onSubmit = (e) => {
+    if (e && e.preventDefault) e.preventDefault();
+    const s = this.state;
+    if (s.mode === 'setpw') {
+      if (s.newPassword.length < 8) return this.setState({ error: 'Password must be at least 8 characters.' });
+      if (s.newPassword !== s.confirmPassword) return this.setState({ error: 'Passwords do not match.' });
+    }
+    // demo: show the loading state briefly, then a representative error
+    this.setState({ loading: true, error: '' });
+    clearTimeout(this._t);
+    this._t = setTimeout(() => {
+      this.setState({
+        loading: false,
+        error: s.mode === 'signin' ? 'Incorrect email or password.' : ''
+      });
+    }, 1300);
+  };
+
+  componentWillUnmount() { clearTimeout(this._t); }
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    const isSetpw = this.state.mode === 'setpw';
+    return {
+      theme: this.state.theme,
+      isSignin: !isSetpw,
+      isSetpw,
+      heading: isSetpw ? 'Set a new password' : 'Sign in',
+      subheading: isSetpw
+        ? 'Your account needs a password before you can continue.'
+        : 'Enter your credentials to access the admin.',
+      buttonLabel: this.state.loading
+        ? (isSetpw ? 'Saving…' : 'Signing in…')
+        : (isSetpw ? 'Set password & continue' : 'Sign in'),
+      email: this.state.email, password: this.state.password,
+      newPassword: this.state.newPassword, confirmPassword: this.state.confirmPassword,
+      loading: this.state.loading,
+      hasError: !!this.state.error,
+      errorMsg: this.state.error,
+      onSubmit: this.onSubmit,
+      onEmail: this.onEmail, onPassword: this.onPassword,
+      onNewPassword: this.onNewPassword, onConfirm: this.onConfirm,
+      showSignin: this.showSignin, showSetpw: this.showSetpw,
+      toggle: this.toggle,
+      toggleIcon: isDark ? '☀' : '☾',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode'
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/Admin Recipe Editor.dc.html
+++ b/docs/design/paper/pages/Admin Recipe Editor.dc.html
@@ -1,0 +1,785 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --surf:#F4F1EA; --hover:rgba(0,0,0,0.022); --field:#FFFFFF;
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --accent:#1F66E0;
+    --green:#1F8A5B; --green-bg:rgba(31,138,91,0.10);
+    --amber:#A66E0A; --amber-bg:rgba(194,129,12,0.12);
+    --danger:#C0392B; --danger-bg:rgba(192,57,43,0.07);
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --surf:#1C1A15; --hover:rgba(255,255,255,0.04); --field:#1B1914;
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --accent:#6BA0FF;
+    --green:#62C08D; --green-bg:rgba(98,192,141,0.12);
+    --amber:#E0A93B; --amber-bg:rgba(224,169,59,0.14);
+    --danger:#E8786B; --danger-bg:rgba(232,120,107,0.12);
+  }
+  .lnk { transition: color .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .lnk svg { transition: transform .25s ease; }
+  .lnk:hover .ic-left { transform: translateX(-3px); }
+  .lnk:hover .ic-right { transform: translateX(3px); }
+  .site-header { position: sticky; top:0; z-index:20; background: color-mix(in srgb, var(--bg) 84%, transparent); backdrop-filter: saturate(140%) blur(10px); -webkit-backdrop-filter: saturate(140%) blur(10px); border-bottom:1px solid var(--line); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  .seclabel { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.14em; text-transform:uppercase; color:var(--faint); }
+  .flabel { font-size:13px; font-weight:500; color:var(--subtle); margin-bottom:7px; display:block; }
+  .fhint { font-size:12.5px; color:var(--faint); line-height:1.5; }
+  .field { width:100%; font-family:'Geist',system-ui,sans-serif; font-size:15px; color:var(--text); background:var(--field); border:1px solid var(--line); border-radius:10px; padding:12px 13px; outline:none; transition: border-color .18s ease, box-shadow .18s ease; }
+  .field::placeholder { color:var(--faint); }
+  .field:focus { border-color:var(--accent); box-shadow:0 0 0 3px color-mix(in srgb, var(--accent) 15%, transparent); }
+  .field:disabled { background:var(--surf); color:var(--muted); cursor:not-allowed; }
+  textarea.field { resize:vertical; line-height:1.6; min-height:84px; }
+  .primary-btn { font-family:'Geist',system-ui,sans-serif; font-size:14px; font-weight:600; color:var(--btn-fg); background:var(--btn-bg); border:none; border-radius:10px; padding:11px 16px; cursor:pointer; display:inline-flex; align-items:center; justify-content:center; gap:8px; width:100%; transition: opacity .2s ease, transform .06s ease; }
+  .primary-btn:hover { opacity:.9; } .primary-btn:active { transform:translateY(1px); }
+  .primary-btn:disabled { opacity:.45; cursor:not-allowed; }
+  .ghost-btn { font-family:'Geist',system-ui,sans-serif; font-size:14px; font-weight:500; color:var(--subtle); background:transparent; border:1px solid var(--btn-border); border-radius:10px; padding:10px 16px; cursor:pointer; display:inline-flex; align-items:center; justify-content:center; gap:8px; width:100%; transition: border-color .2s ease, color .2s ease, background .2s ease; }
+  .ghost-btn:hover { border-color:var(--accent); color:var(--accent); background:var(--hover); }
+  .ghost-btn.danger:hover { border-color:var(--danger); color:var(--danger); background:var(--danger-bg); }
+  .danger-solid { font-family:'Geist',system-ui,sans-serif; font-size:14px; font-weight:600; color:#fff; background:var(--danger); border:none; border-radius:10px; padding:11px 16px; cursor:pointer; transition: opacity .2s ease; }
+  [data-theme="dark"] .danger-solid { color:#1A1410; } .danger-solid:hover { opacity:.9; }
+  .iconbtn { width:30px; height:30px; flex-shrink:0; display:inline-flex; align-items:center; justify-content:center; border:1px solid var(--line); background:var(--field); border-radius:8px; color:var(--muted); cursor:pointer; transition: color .18s ease, border-color .18s ease, background .18s ease; }
+  .iconbtn:hover { color:var(--text); border-color:var(--btn-border); background:var(--hover); }
+  .iconbtn.danger:hover { color:var(--danger); border-color:color-mix(in srgb,var(--danger) 40%,var(--line)); background:var(--danger-bg); }
+  .iconbtn:disabled { opacity:.35; cursor:not-allowed; }
+  .iconbtn svg { width:15px; height:15px; }
+  .chip { display:inline-flex; align-items:center; gap:7px; font-family:'JetBrains Mono',monospace; font-size:11.5px; letter-spacing:0.02em; color:var(--text); border:1px solid var(--line); background:var(--surf); padding:5px 7px 5px 11px; border-radius:8px; }
+  .chip button { background:transparent; border:none; color:var(--faint); cursor:pointer; font-size:12px; line-height:1; padding:1px; display:inline-flex; transition:color .15s ease; }
+  .chip button:hover { color:var(--danger); }
+  .suggest { font-family:'JetBrains Mono',monospace; font-size:11.5px; letter-spacing:0.02em; color:var(--muted); border:1px dashed var(--line); background:transparent; padding:5px 10px; border-radius:8px; cursor:pointer; transition: color .18s ease, border-color .18s ease; }
+  .suggest:hover { color:var(--accent); border-color:var(--accent); }
+  .upload { border:1px dashed var(--btn-border); border-radius:12px; background:var(--surf); padding:22px; display:flex; flex-direction:column; align-items:center; gap:10px; cursor:pointer; transition: border-color .2s ease, background .2s ease; text-align:center; }
+  .upload:hover { border-color:var(--accent); background:var(--hover); }
+  .spinner { width:24px; height:24px; border-radius:50%; border:3px solid var(--line); border-top-color:var(--accent); animation:spin .7s linear infinite; }
+  .spinner.sm { width:15px; height:15px; border-width:2px; }
+  @keyframes spin { to { transform:rotate(360deg); } }
+  .shimmer { background:linear-gradient(100deg, var(--surf) 30%, var(--hover) 50%, var(--surf) 70%); background-size:200% 100%; animation:sh 1.3s linear infinite; }
+  @keyframes sh { to { background-position:-200% 0; } }
+  .seg { display:inline-flex; background:var(--surf); border:1px solid var(--line); border-radius:9px; padding:3px; gap:2px; box-shadow:0 4px 14px rgba(0,0,0,0.08); flex-wrap:wrap; }
+  .seg button { font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--muted); background:transparent; border:none; padding:6px 9px; border-radius:6px; cursor:pointer; transition: background .18s ease, color .18s ease; }
+  .seg button[data-on="true"] { background:var(--field); color:var(--text); box-shadow:0 1px 2px rgba(0,0,0,0.05); }
+  .overlay { position:fixed; inset:0; z-index:60; display:flex; align-items:center; justify-content:center; padding:24px; background:color-mix(in srgb, #000 38%, transparent); animation:fade .15s ease; }
+  @keyframes fade { from { opacity:0; } }
+  @keyframes pop { from { opacity:0; transform:translateY(8px) scale(.98); } }
+  @keyframes toastIn { from { opacity:0; transform:translateX(16px); } }
+  .toast:hover { border-color: color-mix(in srgb, var(--text) 18%, var(--line)); }
+  .toast:hover .toast-x { opacity:1; color:var(--muted); }
+  a:focus-visible, button:focus-visible, .field:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius:6px; }
+  .editor-grid { display:grid; grid-template-columns:1fr; gap:clamp(28px,4vw,44px); }
+  @media (min-width:880px) { .editor-grid { grid-template-columns:minmax(0,1fr) 296px; align-items:start; } .rail { position:sticky; top:84px; } }
+  @media (prefers-reduced-motion: reduce) { .spinner,.shimmer{animation:none;} .overlay,.toast{animation:none;} }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased; display:flex; flex-direction:column;">
+
+  <!-- ===== SHELL HEADER ===== -->
+  <header class="site-header">
+    <div style="max-width:1080px; margin:0 auto; padding:18px clamp(20px,5vw,28px); display:flex; align-items:center; justify-content:space-between; gap:20px;">
+      <div style="display:flex; align-items:center; gap:clamp(18px,4vw,30px);">
+        <a class="lnk" href="/" style="font-size:15px; font-weight:600; letter-spacing:-0.01em;">Akli Aissat</a>
+        <nav aria-label="Admin" style="display:flex; align-items:center; gap:22px; font-size:14px; color:var(--muted);">
+          <a class="lnk" href="#" aria-current="page" style="color:var(--text); font-weight:500;">Recipes</a>
+          <a class="lnk" href="#">Users</a>
+        </nav>
+      </div>
+      <div style="display:flex; align-items:center; gap:14px;">
+        <span style="font-size:13px; color:var(--muted);">{{ email }}</span>
+        <button class="ghost-btn" style="width:auto; padding:7px 13px; font-size:13px;" onClick="{{ logout }}">Log out</button>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </div>
+    </div>
+  </header>
+
+  <main style="flex:1; max-width:1080px; width:100%; margin:0 auto; padding:clamp(22px,4vw,36px) clamp(20px,5vw,28px) 72px;">
+
+    <!-- ===== LOADING STATE ===== -->
+    <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
+      <div style="border:1px solid var(--line); border-radius:16px; padding:clamp(64px,12vw,120px) 24px; text-align:center; display:flex; flex-direction:column; align-items:center; gap:18px;">
+        <div class="spinner" aria-hidden="true"></div>
+        <p style="font-size:14px; color:var(--muted); margin:0;">Loading recipe…</p>
+      </div>
+    </sc-if>
+
+    <!-- ===== EDITOR ===== -->
+    <sc-if value="{{ isEditor }}" hint-placeholder-val="{{ true }}">
+
+      <!-- back -->
+      <a class="lnk" href="#" onClick="{{ onBack }}" style="display:inline-flex; align-items:center; gap:7px; font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.04em; color:var(--muted); margin-bottom:20px;">
+        <svg class="ic-left" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"></path></svg>
+        Back to recipes
+      </a>
+
+      <!-- banners -->
+      <sc-if value="{{ sessionExpired }}" hint-placeholder-val="{{ false }}">
+        <div role="alert" style="display:flex; flex-wrap:wrap; align-items:center; gap:12px; justify-content:space-between; background:var(--danger-bg); border:1px solid color-mix(in srgb, var(--danger) 34%, var(--line)); border-radius:12px; padding:13px 16px; margin-bottom:16px;">
+          <div style="display:flex; align-items:center; gap:10px;">
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="var(--danger)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+            <span style="font-size:13.5px; color:var(--subtle);">Your session has expired. Log in again to keep editing — your latest changes are saved.</span>
+          </div>
+          <button class="ghost-btn" style="width:auto; padding:7px 14px; font-size:13px;" onClick="{{ relogin }}">Log in again</button>
+        </div>
+      </sc-if>
+      <sc-if value="{{ imageProcessingNotice }}" hint-placeholder-val="{{ false }}">
+        <div role="status" style="display:flex; align-items:center; gap:10px; background:var(--amber-bg); border:1px solid color-mix(in srgb, var(--amber) 32%, var(--line)); border-radius:12px; padding:13px 16px; margin-bottom:16px;">
+          <span class="spinner sm" aria-hidden="true" style="border-top-color:var(--amber);"></span>
+          <span style="font-size:13.5px; color:var(--subtle);">An image is taking longer than expected to process. You can keep editing — publishing is paused until it's ready.</span>
+        </div>
+      </sc-if>
+
+      <!-- title bar row -->
+      <div style="display:flex; flex-wrap:wrap; gap:12px; align-items:center; justify-content:space-between; margin-bottom:26px;">
+        <h1 style="font-size:clamp(24px,3.4vw,30px); font-weight:600; letter-spacing:-0.025em; margin:0;">{{ pageHeading }}</h1>
+        <span style="display:inline-flex; align-items:center; gap:6px; font-family:'JetBrains Mono',monospace; font-size:10.5px; letter-spacing:0.06em; text-transform:uppercase; padding:4px 11px; border-radius:999px; background:{{ statusBg }}; color:{{ statusFg }};"><span style="width:5px; height:5px; border-radius:50%; background:{{ statusFg }};"></span>{{ statusLabel }}</span>
+      </div>
+
+      <div class="editor-grid">
+        <!-- ========== FORM ========== -->
+        <div style="display:flex; flex-direction:column; gap:30px; min-width:0;">
+
+          <!-- BASICS -->
+          <section style="display:flex; flex-direction:column; gap:18px;">
+            <div>
+              <label class="flabel" for="f-title">Title</label>
+              <input id="f-title" class="field" type="text" placeholder="e.g. Mild Thai-Style Basa & Coconut Rice" value="{{ title }}" onInput="{{ onTitle }}">
+            </div>
+
+            <div>
+              <label class="flabel" for="f-slug">URL slug</label>
+              <input id="f-slug" class="field" type="text" placeholder="recipe-url-slug" value="{{ slug }}" onInput="{{ onSlug }}" disabled="{{ slugLocked }}">
+              <div style="display:flex; flex-wrap:wrap; align-items:center; gap:6px 12px; margin-top:8px;">
+                <span class="fhint">Public URL: <span style="color:var(--muted); font-family:'JetBrains Mono',monospace; font-size:12px;">akli.dev/recipes/{{ slugPreview }}</span></span>
+                <sc-if value="{{ slugResettable }}" hint-placeholder-val="{{ false }}">
+                  <button class="lnk" onClick="{{ resetSlug }}" style="font-size:12.5px; color:var(--accent); background:transparent; border:none; cursor:pointer; padding:0; font-weight:500;">Reset to title</button>
+                </sc-if>
+              </div>
+              <sc-if value="{{ slugLocked }}" hint-placeholder-val="{{ false }}">
+                <div style="display:flex; align-items:center; gap:7px; margin-top:8px; font-size:12.5px; color:var(--amber);">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
+                  <span style="color:var(--muted);">Locked — images reference this URL. Remove all images to change it.</span>
+                </div>
+              </sc-if>
+            </div>
+
+            <div>
+              <label class="flabel" for="f-intro">Intro</label>
+              <textarea id="f-intro" class="field" placeholder="A sentence or two on what makes this recipe worth cooking." value="{{ intro }}" onInput="{{ onIntro }}"></textarea>
+            </div>
+          </section>
+
+          <!-- COVER -->
+          <section style="border-top:1px solid var(--line); padding-top:26px; display:flex; flex-direction:column; gap:16px;">
+            <span class="seclabel">Cover image</span>
+            <sc-if value="{{ coverEmpty }}" hint-placeholder-val="{{ true }}">
+              <div class="upload" role="button" tabindex="0" onClick="{{ uploadCover }}">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--muted)" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" y1="3" x2="12" y2="15"></line></svg>
+                <span style="font-size:14px; font-weight:500; color:var(--subtle);">Upload a cover image</span>
+                <span class="fhint">JPG, PNG or WebP — landscape works best.</span>
+              </div>
+            </sc-if>
+            <sc-if value="{{ coverProcessing }}" hint-placeholder-val="{{ false }}">
+              <div style="border:1px solid var(--line); border-radius:12px; overflow:hidden;">
+                <div class="shimmer" style="aspect-ratio:16/9; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:10px;">
+                  <span class="spinner" aria-hidden="true"></span>
+                  <span style="font-size:13px; color:var(--muted);">Processing image…</span>
+                </div>
+              </div>
+            </sc-if>
+            <sc-if value="{{ coverReady }}" hint-placeholder-val="{{ false }}">
+              <div style="position:relative; border:1px solid var(--line); border-radius:12px; overflow:hidden;">
+                {{ coverImgEl }}
+                <button class="iconbtn danger" onClick="{{ removeCover }}" title="Remove image" style="position:absolute; top:10px; right:10px; background:var(--bg);">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"></path><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path></svg>
+                </button>
+              </div>
+              <div>
+                <label class="flabel" for="f-alt">Alt text</label>
+                <input id="f-alt" class="field" type="text" placeholder="Describe the image for screen readers" value="{{ coverAlt }}" onInput="{{ onAlt }}">
+              </div>
+            </sc-if>
+          </section>
+
+          <!-- TIMING -->
+          <section style="border-top:1px solid var(--line); padding-top:26px; display:flex; flex-direction:column; gap:16px;">
+            <span class="seclabel">Timing &amp; servings</span>
+            <div style="display:grid; grid-template-columns:repeat(3, 1fr); gap:14px;">
+              <div>
+                <label class="flabel" for="f-prep">Prep (min)</label>
+                <input id="f-prep" class="field" type="text" inputmode="numeric" placeholder="5" value="{{ prep }}" onInput="{{ onPrep }}">
+              </div>
+              <div>
+                <label class="flabel" for="f-cook">Cook (min)</label>
+                <input id="f-cook" class="field" type="text" inputmode="numeric" placeholder="30" value="{{ cook }}" onInput="{{ onCook }}">
+              </div>
+              <div>
+                <label class="flabel" for="f-serves">Servings</label>
+                <input id="f-serves" class="field" type="text" inputmode="numeric" placeholder="2" value="{{ servings }}" onInput="{{ onServings }}">
+              </div>
+            </div>
+          </section>
+
+          <!-- TAGS -->
+          <section style="border-top:1px solid var(--line); padding-top:26px; display:flex; flex-direction:column; gap:14px;">
+            <span class="seclabel">Tags</span>
+            <sc-if value="{{ hasTags }}" hint-placeholder-val="{{ true }}">
+              <div style="display:flex; flex-wrap:wrap; gap:8px;">
+                <sc-for list="{{ tags }}" as="tag" hint-placeholder-count="2">
+                  <span class="chip">{{ tag.label }}<button onClick="{{ tag.remove }}" aria-label="Remove tag">✕</button></span>
+                </sc-for>
+              </div>
+            </sc-if>
+            <input class="field" type="text" placeholder="Type a tag and press Enter" value="{{ tagInput }}" onInput="{{ onTagInput }}" onKeyDown="{{ onTagKey }}">
+            <sc-if value="{{ hasSuggestions }}" hint-placeholder-val="{{ false }}">
+              <div style="display:flex; flex-wrap:wrap; align-items:center; gap:8px;">
+                <span class="fhint" style="margin-right:2px;">Suggestions:</span>
+                <sc-for list="{{ suggestions }}" as="s" hint-placeholder-count="4">
+                  <button class="suggest" onClick="{{ s.add }}">+ {{ s.label }}</button>
+                </sc-for>
+              </div>
+            </sc-if>
+          </section>
+
+          <!-- INGREDIENTS -->
+          <section style="border-top:1px solid var(--line); padding-top:26px; display:flex; flex-direction:column; gap:14px;">
+            <div style="display:flex; align-items:baseline; justify-content:space-between; gap:12px;">
+              <span class="seclabel">Ingredients</span>
+              <span class="fhint">{{ ingCountLabel }}</span>
+            </div>
+            <div style="display:flex; flex-direction:column; gap:10px;">
+              <sc-for list="{{ ingredients }}" as="ing" hint-placeholder-count="3">
+                <div style="display:flex; align-items:center; gap:8px;">
+                  <input class="field" style="width:96px; flex-shrink:0;" type="text" placeholder="Qty" value="{{ ing.qty }}" onInput="{{ ing.onQty }}">
+                  <input class="field" type="text" placeholder="Ingredient" value="{{ ing.name }}" onInput="{{ ing.onName }}">
+                  <button class="iconbtn" onClick="{{ ing.up }}" disabled="{{ ing.isFirst }}" title="Move up"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"></path></svg></button>
+                  <button class="iconbtn" onClick="{{ ing.down }}" disabled="{{ ing.isLast }}" title="Move down"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"></path></svg></button>
+                  <button class="iconbtn danger" onClick="{{ ing.remove }}" title="Remove"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></button>
+                </div>
+              </sc-for>
+            </div>
+            <button class="ghost-btn" style="width:auto; align-self:flex-start; padding:9px 15px; font-size:13.5px;" onClick="{{ addIngredient }}">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+              Add ingredient
+            </button>
+          </section>
+
+          <!-- STEPS -->
+          <section style="border-top:1px solid var(--line); padding-top:26px; display:flex; flex-direction:column; gap:14px;">
+            <div style="display:flex; align-items:baseline; justify-content:space-between; gap:12px;">
+              <span class="seclabel">Method</span>
+              <span class="fhint">{{ stepCountLabel }}</span>
+            </div>
+            <div style="display:flex; flex-direction:column; gap:14px;">
+              <sc-for list="{{ steps }}" as="step" hint-placeholder-count="2">
+                <div style="border:1px solid var(--line); border-radius:12px; padding:14px; background:var(--field);">
+                  <div style="display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:10px;">
+                    <span style="display:inline-flex; align-items:center; justify-content:center; width:26px; height:26px; border-radius:50%; background:var(--surf); border:1px solid var(--line); font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--accent);">{{ step.num }}</span>
+                    <div style="display:flex; gap:6px;">
+                      <button class="iconbtn" onClick="{{ step.up }}" disabled="{{ step.isFirst }}" title="Move up"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 15-6-6-6 6"></path></svg></button>
+                      <button class="iconbtn" onClick="{{ step.down }}" disabled="{{ step.isLast }}" title="Move down"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"></path></svg></button>
+                      <button class="iconbtn danger" onClick="{{ step.remove }}" title="Remove step"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></button>
+                    </div>
+                  </div>
+                  <textarea class="field" placeholder="Describe this step…" value="{{ step.text }}" onInput="{{ step.onText }}"></textarea>
+                  <div style="margin-top:10px;">
+                    <sc-if value="{{ step.imgEmpty }}" hint-placeholder-val="{{ true }}">
+                      <button class="ghost-btn" style="width:auto; padding:7px 13px; font-size:13px;" onClick="{{ step.addImg }}">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"></rect><circle cx="9" cy="9" r="2"></circle><path d="m21 15-3.1-3.1a2 2 0 0 0-2.8 0L6 21"></path></svg>
+                        Add step image
+                      </button>
+                    </sc-if>
+                    <sc-if value="{{ step.imgProcessing }}" hint-placeholder-val="{{ false }}">
+                      <div class="shimmer" style="border:1px solid var(--line); border-radius:10px; height:96px; display:flex; align-items:center; justify-content:center; gap:9px;">
+                        <span class="spinner sm" aria-hidden="true"></span>
+                        <span style="font-size:12.5px; color:var(--muted);">Processing…</span>
+                      </div>
+                    </sc-if>
+                    <sc-if value="{{ step.imgReady }}" hint-placeholder-val="{{ false }}">
+                      <div style="display:flex; flex-direction:column; gap:10px;">
+                        <div style="position:relative; display:inline-block; align-self:flex-start; border:1px solid var(--line); border-radius:10px; overflow:hidden;">
+                          {{ step.imgEl }}
+                          <button class="iconbtn danger" onClick="{{ step.removeImg }}" title="Remove image" style="position:absolute; top:7px; right:7px; background:var(--bg);">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg>
+                          </button>
+                        </div>
+                        <input class="field" type="text" placeholder="Alt text for this image" value="{{ step.imgAlt }}" onInput="{{ step.onImgAlt }}">
+                      </div>
+                    </sc-if>
+                  </div>
+                </div>
+              </sc-for>
+            </div>
+            <button class="ghost-btn" style="width:auto; align-self:flex-start; padding:9px 15px; font-size:13.5px;" onClick="{{ addStep }}">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+              Add step
+            </button>
+          </section>
+        </div>
+
+        <!-- ========== RAIL ========== -->
+        <aside class="rail">
+          <div style="border:1px solid var(--line); border-radius:16px; background:var(--surf); padding:18px; display:flex; flex-direction:column; gap:16px;">
+
+            <!-- autosave indicator -->
+            <div style="display:flex; align-items:center; gap:9px; min-height:20px;">
+              <sc-if value="{{ saveSaving }}" hint-placeholder-val="{{ false }}"><span class="spinner sm" aria-hidden="true"></span><span style="font-size:13px; color:var(--muted);">Saving…</span></sc-if>
+              <sc-if value="{{ saveSaved }}" hint-placeholder-val="{{ true }}"><span style="color:var(--green); display:inline-flex;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg></span><span style="font-size:13px; color:var(--muted);">{{ savedLabel }}</span></sc-if>
+              <sc-if value="{{ saveError }}" hint-placeholder-val="{{ false }}">
+                <span style="color:var(--danger); display:inline-flex;"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg></span>
+                <span style="font-size:13px; color:var(--danger);">Couldn't save</span>
+                <button class="lnk" onClick="{{ retrySave }}" style="font-size:12.5px; color:var(--accent); background:transparent; border:none; cursor:pointer; padding:0; font-weight:500; margin-left:auto;">Retry</button>
+              </sc-if>
+            </div>
+
+            <div style="height:1px; background:var(--line);"></div>
+
+            <!-- actions -->
+            <sc-if value="{{ isDraft }}" hint-placeholder-val="{{ true }}">
+              <div style="display:flex; flex-direction:column; gap:10px;">
+                <button class="primary-btn" onClick="{{ publish }}" disabled="{{ publishDisabled }}">Publish</button>
+                <button class="ghost-btn danger" onClick="{{ askDiscard }}">Discard draft</button>
+              </div>
+              <sc-if value="{{ showChecklist }}" hint-placeholder-val="{{ false }}">
+                <div style="border-top:1px solid var(--line); padding-top:14px;">
+                  <div class="seclabel" style="margin-bottom:10px;">Before publishing</div>
+                  <div style="display:flex; flex-direction:column; gap:9px;">
+                    <sc-for list="{{ checklist }}" as="c" hint-placeholder-count="6">
+                      <div style="display:flex; align-items:flex-start; gap:9px;">
+                        <span aria-hidden="true" style="flex-shrink:0; margin-top:1px; width:16px; height:16px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; border:1.5px solid {{ c.ring }}; background:{{ c.fill }}; color:{{ c.tick }}; font-size:9px;">{{ c.icon }}</span>
+                        <span style="font-size:13px; line-height:1.4; color:{{ c.color }};">{{ c.label }}</span>
+                      </div>
+                    </sc-for>
+                  </div>
+                </div>
+              </sc-if>
+            </sc-if>
+
+            <sc-if value="{{ isPublished }}" hint-placeholder-val="{{ false }}">
+              <div style="display:flex; flex-direction:column; gap:10px;">
+                <button class="primary-btn" onClick="{{ update }}">Update</button>
+                <button class="ghost-btn" onClick="{{ unpublish }}">Unpublish</button>
+              </div>
+              <div style="border-top:1px solid var(--line); padding-top:14px;">
+                <a class="lnk" href="#" onClick="{{ preview }}" style="display:inline-flex; align-items:center; gap:7px; font-size:13px; color:var(--muted);">
+                  <svg class="ic-right" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"></path><circle cx="12" cy="12" r="3"></circle></svg>
+                  View live recipe
+                </a>
+              </div>
+            </sc-if>
+          </div>
+        </aside>
+      </div>
+    </sc-if>
+  </main>
+
+  <!-- ===== FOOTER ===== -->
+  <footer style="border-top:1px solid var(--line);">
+    <div style="max-width:1080px; margin:0 auto; padding:22px clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:12px; align-items:center; justify-content:space-between;">
+      <span style="font-size:12.5px; color:var(--faint);">akli.dev admin</span>
+      <span style="font-size:12.5px; color:var(--faint);">Signed in as {{ email }}</span>
+    </div>
+  </footer>
+
+  <!-- ===== DISCARD DIALOG ===== -->
+  <sc-if value="{{ discardOpen }}" hint-placeholder-val="{{ false }}">
+    <div class="overlay" role="dialog" aria-modal="true" aria-labelledby="dc-title" onClick="{{ cancelDiscard }}">
+      <div onClick="{{ stop }}" style="width:100%; max-width:420px; background:var(--bg); border:1px solid var(--line); border-radius:18px; padding:26px; box-shadow:0 24px 60px rgba(0,0,0,0.28); animation:pop .18s ease;">
+        <h2 id="dc-title" style="font-size:18px; font-weight:600; letter-spacing:-0.02em; margin:0 0 10px;">Discard this draft?</h2>
+        <p style="font-size:14.5px; line-height:1.6; color:var(--subtle); margin:0 0 24px;">This draft and everything in it will be permanently deleted. This can't be undone.</p>
+        <div style="display:flex; justify-content:flex-end; gap:10px;">
+          <button class="ghost-btn" style="width:auto;" onClick="{{ cancelDiscard }}">Keep editing</button>
+          <button class="danger-solid" onClick="{{ confirmDiscard }}">Discard draft</button>
+        </div>
+      </div>
+    </div>
+  </sc-if>
+
+  <!-- ===== LEAVE (UNSAVED) DIALOG ===== -->
+  <sc-if value="{{ leaveOpen }}" hint-placeholder-val="{{ false }}">
+    <div class="overlay" role="dialog" aria-modal="true" aria-labelledby="lv-title" onClick="{{ cancelLeave }}">
+      <div onClick="{{ stop }}" style="width:100%; max-width:420px; background:var(--bg); border:1px solid var(--line); border-radius:18px; padding:26px; box-shadow:0 24px 60px rgba(0,0,0,0.28); animation:pop .18s ease;">
+        <h2 id="lv-title" style="font-size:18px; font-weight:600; letter-spacing:-0.02em; margin:0 0 10px;">Leave with unsaved changes?</h2>
+        <p style="font-size:14.5px; line-height:1.6; color:var(--subtle); margin:0 0 24px;">Your changes are still saving. If you leave now they might not be stored.</p>
+        <div style="display:flex; justify-content:flex-end; gap:10px;">
+          <button class="ghost-btn" style="width:auto;" onClick="{{ cancelLeave }}">Stay</button>
+          <button class="primary-btn" style="width:auto;" onClick="{{ confirmLeave }}">Leave anyway</button>
+        </div>
+      </div>
+    </div>
+  </sc-if>
+
+  <!-- ===== TOASTS ===== -->
+  <div style="position:fixed; bottom:18px; right:18px; z-index:80; display:flex; flex-direction:column; gap:10px; max-width:340px;">
+    <sc-for list="{{ toasts }}" as="t" hint-placeholder-count="0">
+      <button class="toast" type="button" aria-label="Dismiss notification" onClick="{{ t.dismiss }}" style="display:flex; align-items:center; gap:11px; width:100%; text-align:left; background:var(--bg); border:1px solid var(--line); border-radius:11px; padding:12px 15px; box-shadow:0 12px 30px rgba(0,0,0,0.16); animation:toastIn .2s ease; cursor:pointer; font-family:inherit;">
+        <span aria-hidden="true" style="width:18px; height:18px; flex-shrink:0; border-radius:50%; background:{{ t.dot }}; color:{{ t.accent }}; display:inline-flex; align-items:center; justify-content:center; font-size:11px; line-height:1;">{{ t.icon }}</span>
+        <span style="font-size:13.5px; line-height:1.45; color:var(--subtle); flex:1;">{{ t.msg }}</span>
+        <span class="toast-x" aria-hidden="true" style="flex-shrink:0; color:var(--faint); font-size:12px; line-height:1; opacity:.5; transition:opacity .18s ease, color .18s ease;">✕</span>
+      </button>
+    </sc-for>
+  </div>
+
+  <!-- preview switcher (design-time only) -->
+  <div style="position:fixed; bottom:18px; left:18px; z-index:30;">
+    <div class="seg" role="group" aria-label="Preview state">
+      <button data-on="{{ isDraftView }}" onClick="{{ vDraft }}">Draft</button>
+      <button data-on="{{ isPublished }}" onClick="{{ vPublished }}">Published</button>
+      <button data-on="{{ isLoading }}" onClick="{{ vLoading }}">Loading</button>
+      <button data-on="{{ sessionExpired }}" onClick="{{ toggleSession }}">Session</button>
+      <button data-on="{{ imageProcessingNotice }}" onClick="{{ toggleProcNotice }}">Img notice</button>
+      <button data-on="{{ saveError }}" onClick="{{ toggleSaveErr }}">Save error</button>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{}">
+class Component extends DCLogic {
+  state = {
+    theme: 'light',
+    view: 'editor',                 // editor | loading
+    status: 'draft',                // draft | published
+    recipe: {
+      title: 'Mild Thai-Style Basa & Coconut Rice',
+      slug: 'mild-thai-style-basa-coconut-rice',
+      slugEdited: false,
+      intro: 'A comforting Thai-infused rice and fish one pot. Flavour the rice with coconut and fragrant green curry paste, then steam the fish on top for tenderness.',
+      cover: { state: 'empty', url: '', alt: '' },     // empty | processing | ready
+      prep: '5', cook: '30', servings: '2',
+      tags: ['Thai', 'Fish'],
+      ingredients: [
+        { id: 1, qty: '140 g', name: 'White basmati rice' },
+        { id: 2, qty: '2', name: 'Basa fillets' },
+        { id: 3, qty: '40 g', name: 'Thai green curry paste' }
+      ],
+      steps: [
+        { id: 1, text: 'Boil a kettle. Trim and finely slice the spring onions; deseed and chop the pepper.', image: { state: 'empty', url: '', alt: '' } },
+        { id: 2, text: 'Fry the pepper and most of the spring onion with the curry paste for 2–3 min until fragrant.', image: { state: 'empty', url: '', alt: '' } }
+      ]
+    },
+    tagInput: '',
+    save: { state: 'saved', at: Date.now() - 45000 },   // saved | saving | error
+    discardOpen: false,
+    leaveOpen: false,
+    sessionExpired: false,
+    procNoticeForce: false,
+    toasts: []
+  };
+
+  email = 'akli@akli.dev';
+  allTags = ['Thai','Fish','Rice','One Pot','Coconut','Pasta','Beef','Baking','Bread','Mains','Vegetarian','Dessert','Quick','Soup','Spicy'];
+  _seq = 100; _toastSeq = 0; _timers = [];
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') this.setState({ theme: saved });
+      else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) this.setState({ theme: 'dark' });
+    } catch (e) {}
+  }
+  componentWillUnmount() { this._timers.forEach(clearTimeout); }
+  later(fn, ms) { const t = setTimeout(fn, ms); this._timers.push(t); return t; }
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  // ---- toasts ----
+  toast(type, msg) {
+    const id = ++this._toastSeq;
+    this.setState(s => ({ toasts: s.toasts.concat([{ id, type, msg }]) }));
+    this.later(() => this.dismiss(id), 3600);
+  }
+  dismiss = (id) => this.setState(s => ({ toasts: s.toasts.filter(t => t.id !== id) }));
+
+  // ---- autosave ----
+  scheduleSave() {
+    clearTimeout(this._saveT);
+    this._saveT = this.later(() => this.runSave(), 1500);
+  }
+  runSave() {
+    this.setState({ save: { state: 'saving' } });
+    clearTimeout(this._saveT2);
+    this._saveT2 = this.later(() => {
+      this.setState({ save: { state: 'saved', at: Date.now() } });
+    }, 850);
+  }
+  retrySave = () => this.runSave();
+
+  // ---- recipe mutation ----
+  patch(part) {
+    this.setState(s => ({ recipe: Object.assign({}, s.recipe, part) }));
+    this.scheduleSave();
+  }
+  patchRecipe(fn) {
+    this.setState(s => ({ recipe: fn(Object.assign({}, s.recipe)) }));
+    this.scheduleSave();
+  }
+
+  slugify(t) { return t.toLowerCase().replace(/&/g,'and').replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,''); }
+
+  onTitle = (e) => {
+    const title = e.target.value;
+    this.setState(s => {
+      const r = Object.assign({}, s.recipe, { title });
+      if (!r.slugEdited && !this.imagesExist(r)) r.slug = this.slugify(title);
+      return { recipe: r };
+    });
+    this.scheduleSave();
+  };
+  onSlug = (e) => { const v = this.slugify(e.target.value); this.patch({ slug: v, slugEdited: true }); };
+  resetSlug = () => this.patch({ slug: this.slugify(this.state.recipe.title), slugEdited: false });
+  onIntro = (e) => this.patch({ intro: e.target.value });
+  onAlt = (e) => this.patchRecipe(r => { r.cover = Object.assign({}, r.cover, { alt: e.target.value }); return r; });
+  onPrep = (e) => this.patch({ prep: e.target.value });
+  onCook = (e) => this.patch({ cook: e.target.value });
+  onServings = (e) => this.patch({ servings: e.target.value });
+
+  imagesExist(r) {
+    if (r.cover.state !== 'empty') return true;
+    return r.steps.some(s => s.image.state !== 'empty');
+  }
+
+  // ---- cover image (async simulated) ----
+  uploadCover = () => {
+    this.patchRecipe(r => { r.cover = { state: 'processing', url: '', alt: r.cover.alt || '' }; return r; });
+    this.later(() => {
+      this.patchRecipe(r => { r.cover = Object.assign({}, r.cover, { state: 'ready', url: 'https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=900&q=70' }); return r; });
+      this.toast('success', 'Cover image ready.');
+    }, 2600);
+  };
+  removeCover = () => { this.patchRecipe(r => { r.cover = { state: 'empty', url: '', alt: '' }; return r; }); };
+
+  // ---- tags ----
+  onTagInput = (e) => this.setState({ tagInput: e.target.value });
+  addTag = (label) => {
+    label = (label || '').trim();
+    if (!label) return;
+    this.setState(s => {
+      if (s.recipe.tags.some(t => t.toLowerCase() === label.toLowerCase())) return { tagInput: '' };
+      return { recipe: Object.assign({}, s.recipe, { tags: s.recipe.tags.concat([label]) }), tagInput: '' };
+    });
+    this.scheduleSave();
+  };
+  onTagKey = (e) => { if (e.key === 'Enter') { e.preventDefault(); this.addTag(this.state.tagInput); } };
+  removeTag = (label) => { this.patchRecipe(r => { r.tags = r.tags.filter(t => t !== label); return r; }); };
+
+  // ---- ingredients ----
+  addIngredient = () => this.patchRecipe(r => { r.ingredients = r.ingredients.concat([{ id: ++this._seq, qty: '', name: '' }]); return r; });
+  updIngredient = (id, part) => this.patchRecipe(r => { r.ingredients = r.ingredients.map(x => x.id === id ? Object.assign({}, x, part) : x); return r; });
+  removeIngredient = (id) => this.patchRecipe(r => { r.ingredients = r.ingredients.filter(x => x.id !== id); return r; });
+  moveIngredient = (id, dir) => this.patchRecipe(r => { r.ingredients = this.move(r.ingredients, id, dir); return r; });
+
+  // ---- steps ----
+  addStep = () => this.patchRecipe(r => { r.steps = r.steps.concat([{ id: ++this._seq, text: '', image: { state: 'empty', url: '', alt: '' } }]); return r; });
+  updStep = (id, part) => this.patchRecipe(r => { r.steps = r.steps.map(x => x.id === id ? Object.assign({}, x, part) : x); return r; });
+  removeStep = (id) => this.patchRecipe(r => { r.steps = r.steps.filter(x => x.id !== id); return r; });
+  moveStep = (id, dir) => this.patchRecipe(r => { r.steps = this.move(r.steps, id, dir); return r; });
+  addStepImg = (id) => {
+    this.patchRecipe(r => { r.steps = r.steps.map(x => x.id === id ? Object.assign({}, x, { image: { state: 'processing', url: '', alt: x.image.alt || '' } }) : x); return r; });
+    this.later(() => {
+      this.patchRecipe(r => { r.steps = r.steps.map(x => x.id === id ? Object.assign({}, x, { image: { state: 'ready', url: 'https://images.unsplash.com/photo-1455619452474-d2be8b1e70cd?w=400&q=70', alt: x.image.alt || '' } }) : x); return r; });
+    }, 2400);
+  };
+  removeStepImg = (id) => this.patchRecipe(r => { r.steps = r.steps.map(x => x.id === id ? Object.assign({}, x, { image: { state: 'empty', url: '', alt: '' } }) : x); return r; });
+  updStepImgAlt = (id, alt) => this.patchRecipe(r => { r.steps = r.steps.map(x => x.id === id ? Object.assign({}, x, { image: Object.assign({}, x.image, { alt: alt }) }) : x); return r; });
+
+  move(arr, id, dir) {
+    const i = arr.findIndex(x => x.id === id);
+    const j = dir === 'up' ? i - 1 : i + 1;
+    if (i < 0 || j < 0 || j >= arr.length) return arr;
+    const copy = arr.slice();
+    const tmp = copy[i]; copy[i] = copy[j]; copy[j] = tmp;
+    return copy;
+  }
+
+  // ---- publish flow ----
+  missing() {
+    const r = this.state.recipe;
+    const anyProcessing = r.cover.state === 'processing' || r.steps.some(s => s.image.state === 'processing');
+    const readyStepImgs = r.steps.filter(s => s.image.state === 'ready');
+    const list = [
+      { key: 'title', label: 'Add a title', done: !!r.title.trim() },
+      { key: 'intro', label: 'Write an intro', done: !!r.intro.trim() },
+      { key: 'cover', label: 'Upload a cover image', done: r.cover.state === 'ready' },
+      { key: 'alt', label: 'Add cover alt text', done: r.cover.state === 'ready' && !!r.cover.alt.trim() },
+      { key: 'ing', label: 'Add at least one ingredient', done: r.ingredients.some(x => x.name.trim()) },
+      { key: 'step', label: 'Add at least one step', done: r.steps.some(x => x.text.trim()) },
+      { key: 'proc', label: 'Wait for images to finish processing', done: !anyProcessing }
+    ];
+    if (readyStepImgs.length) {
+      list.push({ key: 'stepalt', label: 'Add alt text to every step image', done: readyStepImgs.every(s => s.image.alt.trim()) });
+    }
+    return list;
+  }
+  publish = () => { this.setState({ status: 'published' }); this.toast('success', 'Recipe published — it\u2019s now live.'); };
+  update = () => { this.runSave(); this.toast('success', 'Changes saved.'); };
+  unpublish = () => { this.setState({ status: 'draft' }); this.toast('info', 'Recipe moved back to drafts.'); };
+  preview = (e) => { if (e) e.preventDefault(); this.toast('info', 'Opening the live recipe in a new tab.'); };
+
+  askDiscard = () => this.setState({ discardOpen: true });
+  cancelDiscard = () => this.setState({ discardOpen: false });
+  confirmDiscard = () => { this.setState({ discardOpen: false }); this.toast('success', 'Draft discarded.'); };
+
+  onBack = (e) => {
+    if (e) e.preventDefault();
+    if (this.state.save.state === 'saving') this.setState({ leaveOpen: true });
+    else this.toast('info', 'Back to recipes.');
+  };
+  cancelLeave = () => this.setState({ leaveOpen: false });
+  confirmLeave = () => { this.setState({ leaveOpen: false }); this.toast('info', 'Back to recipes.'); };
+
+  relogin = () => { this.setState({ sessionExpired: false }); this.toast('info', 'Redirecting to log in…'); };
+  logout = () => this.toast('info', 'Signing out…');
+  stop = (e) => { if (e && e.stopPropagation) e.stopPropagation(); };
+
+  // ---- design-time ----
+  vDraft = () => this.setState({ view: 'editor', status: 'draft' });
+  vPublished = () => this.setState({ view: 'editor', status: 'published' });
+  vLoading = () => this.setState({ view: 'loading' });
+  toggleSession = () => this.setState(s => ({ sessionExpired: !s.sessionExpired }));
+  toggleProcNotice = () => this.setState(s => ({ procNoticeForce: !s.procNoticeForce }));
+  toggleSaveErr = () => this.setState(s => ({ save: s.save.state === 'error' ? { state: 'saved', at: Date.now() } : { state: 'error' } }));
+
+  savedLabel() {
+    const at = this.state.save.at;
+    if (!at) return 'Saved';
+    const secs = Math.floor((Date.now() - at) / 1000);
+    if (secs < 8) return 'Saved just now';
+    if (secs < 60) return 'Saved ' + secs + 's ago';
+    const d = new Date(at);
+    let h = d.getHours(); const m = String(d.getMinutes()).padStart(2, '0');
+    const ap = h >= 12 ? 'PM' : 'AM'; h = h % 12 || 12;
+    return 'Saved at ' + h + ':' + m + ' ' + ap;
+  }
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    const r = this.state.recipe;
+    const status = this.state.status;
+    const locked = this.imagesExist(r);
+    const checklist = this.missing();
+    const canPublish = checklist.every(c => c.done);
+    const anyProcessing = r.cover.state === 'processing' || r.steps.some(s => s.image.state === 'processing');
+
+    const tagsUsed = r.tags.map(label => ({ label, remove: () => this.removeTag(label) }));
+    const q = this.state.tagInput.trim().toLowerCase();
+    const suggestions = this.allTags
+      .filter(t => !r.tags.some(x => x.toLowerCase() === t.toLowerCase()))
+      .filter(t => !q || t.toLowerCase().includes(q))
+      .slice(0, 6)
+      .map(label => ({ label, add: () => this.addTag(label) }));
+
+    const ingredients = r.ingredients.map((x, i) => ({
+      qty: x.qty, name: x.name, isFirst: i === 0, isLast: i === r.ingredients.length - 1,
+      onQty: (e) => this.updIngredient(x.id, { qty: e.target.value }),
+      onName: (e) => this.updIngredient(x.id, { name: e.target.value }),
+      up: () => this.moveIngredient(x.id, 'up'), down: () => this.moveIngredient(x.id, 'down'),
+      remove: () => this.removeIngredient(x.id)
+    }));
+
+    const steps = r.steps.map((x, i) => ({
+      num: i + 1, text: x.text, isFirst: i === 0, isLast: i === r.steps.length - 1,
+      imgEmpty: x.image.state === 'empty', imgProcessing: x.image.state === 'processing', imgReady: x.image.state === 'ready', imgUrl: x.image.url,
+      imgEl: x.image.url ? React.createElement('img', { src: x.image.url, alt: '', style: { display:'block', height:'96px', width:'auto', objectFit:'cover' } }) : null,
+      onText: (e) => this.updStep(x.id, { text: e.target.value }),
+      up: () => this.moveStep(x.id, 'up'), down: () => this.moveStep(x.id, 'down'),
+      remove: () => this.removeStep(x.id),
+      addImg: () => this.addStepImg(x.id), removeImg: () => this.removeStepImg(x.id),
+      imgAlt: x.image.alt || '', onImgAlt: (e) => this.updStepImgAlt(x.id, e.target.value)
+    }));
+
+    const tStyle = { success:{accent:'var(--green)',dot:'var(--green-bg)',icon:'\u2713'}, error:{accent:'var(--danger)',dot:'var(--danger-bg)',icon:'\u2715'}, info:{accent:'var(--accent)',dot:'color-mix(in srgb, var(--accent) 14%, transparent)',icon:'\u203a'} };
+    const toasts = this.state.toasts.map(t => Object.assign({}, tStyle[t.type] || tStyle.info, { msg: t.msg, dismiss: () => this.dismiss(t.id) }));
+
+    const cl = checklist.map(c => ({
+      label: c.label, icon: c.done ? '\u2713' : '',
+      ring: c.done ? 'var(--green)' : 'var(--line)',
+      fill: c.done ? 'var(--green)' : 'transparent',
+      tick: c.done ? '#fff' : 'transparent',
+      color: c.done ? 'var(--faint)' : 'var(--subtle)'
+    }));
+
+    return {
+      theme: this.state.theme, email: this.email,
+      toggle: this.toggle, toggleIcon: isDark ? '\u2600' : '\u263e',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode',
+      logout: this.logout,
+
+      isLoading: this.state.view === 'loading',
+      isEditor: this.state.view === 'editor',
+      isDraft: status === 'draft', isPublished: status === 'published',
+      isDraftView: this.state.view === 'editor' && status === 'draft',
+
+      pageHeading: status === 'published' ? 'Edit recipe' : 'New recipe',
+      statusLabel: status === 'published' ? 'Published' : 'Draft',
+      statusBg: status === 'published' ? 'var(--green-bg)' : 'var(--amber-bg)',
+      statusFg: status === 'published' ? 'var(--green)' : 'var(--amber)',
+
+      title: r.title, slug: r.slug, slugPreview: r.slug || 'recipe-slug',
+      slugLocked: locked, slugResettable: !locked && r.slugEdited && this.slugify(r.title) !== r.slug,
+      resetSlug: this.resetSlug,
+      intro: r.intro, prep: r.prep, cook: r.cook, servings: r.servings,
+      onTitle: this.onTitle, onSlug: this.onSlug, onIntro: this.onIntro,
+      onPrep: this.onPrep, onCook: this.onCook, onServings: this.onServings,
+
+      coverEmpty: r.cover.state === 'empty', coverProcessing: r.cover.state === 'processing', coverReady: r.cover.state === 'ready',
+      coverUrl: r.cover.url, coverAlt: r.cover.alt,
+      coverImgEl: r.cover.url ? React.createElement('img', { src: r.cover.url, alt: '', style: { display:'block', width:'100%', aspectRatio:'16/9', objectFit:'cover' } }) : null,
+      uploadCover: this.uploadCover, removeCover: this.removeCover, onAlt: this.onAlt,
+
+      hasTags: tagsUsed.length > 0, tags: tagsUsed,
+      tagInput: this.state.tagInput, onTagInput: this.onTagInput, onTagKey: this.onTagKey,
+      hasSuggestions: suggestions.length > 0, suggestions,
+
+      ingredients, ingCountLabel: r.ingredients.length + (r.ingredients.length === 1 ? ' item' : ' items'),
+      addIngredient: this.addIngredient,
+      steps, stepCountLabel: r.steps.length + (r.steps.length === 1 ? ' step' : ' steps'),
+      addStep: this.addStep,
+
+      saveSaving: this.state.save.state === 'saving',
+      saveSaved: this.state.save.state === 'saved',
+      saveError: this.state.save.state === 'error',
+      savedLabel: this.savedLabel(), retrySave: this.retrySave,
+
+      publish: this.publish, publishDisabled: !canPublish,
+      showChecklist: !canPublish,
+      checklist: cl,
+      askDiscard: this.askDiscard, update: this.update, unpublish: this.unpublish, preview: this.preview,
+
+      sessionExpired: this.state.sessionExpired, relogin: this.relogin,
+      imageProcessingNotice: anyProcessing || this.state.procNoticeForce,
+
+      discardOpen: this.state.discardOpen, cancelDiscard: this.cancelDiscard, confirmDiscard: this.confirmDiscard,
+      leaveOpen: this.state.leaveOpen, cancelLeave: this.cancelLeave, confirmLeave: this.confirmLeave,
+      onBack: this.onBack, stop: this.stop,
+      toasts,
+
+      vDraft: this.vDraft, vPublished: this.vPublished, vLoading: this.vLoading,
+      toggleSession: this.toggleSession, toggleProcNotice: this.toggleProcNotice, toggleSaveErr: this.toggleSaveErr
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/Admin Recipe Preview.dc.html
+++ b/docs/design/paper/pages/Admin Recipe Preview.dc.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --surf:#F4F1EA; --hover:rgba(0,0,0,0.022); --field:#FFFFFF;
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --accent:#1F66E0;
+    --green:#1F8A5B; --green-bg:rgba(31,138,91,0.10);
+    --amber:#A66E0A; --amber-bg:rgba(194,129,12,0.12);
+    --danger:#C0392B;
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --surf:#1C1A15; --hover:rgba(255,255,255,0.04); --field:#1B1914;
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --accent:#6BA0FF;
+    --green:#62C08D; --green-bg:rgba(98,192,141,0.14);
+    --amber:#E0A93B; --amber-bg:rgba(224,169,59,0.16);
+    --danger:#E8786B;
+  }
+  .lnk { transition: color .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .lnk svg, .banner-btn svg { transition: transform .25s ease; }
+  .lnk:hover .ic-left, .banner-btn:hover .ic-left { transform: translateX(-3px); }
+  .lnk:hover .ic-upright, .banner-btn:hover .ic-upright { transform: translate(3px,-3px); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  .banner-btn { font-family:'Geist',system-ui,sans-serif; font-size:13px; font-weight:600; border-radius:9px; padding:8px 15px; cursor:pointer; white-space:nowrap; transition: opacity .2s ease, border-color .2s ease, color .2s ease, background .2s ease; text-decoration:none; display:inline-flex; align-items:center; gap:7px; }
+  .banner-solid { color:var(--btn-fg); background:var(--btn-bg); border:1px solid var(--btn-bg); }
+  .banner-solid:hover { opacity:.9; }
+  .banner-ghost { color:var(--text); background:transparent; border:1px solid var(--btn-border); }
+  .banner-ghost:hover { border-color:var(--accent); color:var(--accent); }
+  .tag-chip { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.04em; color:var(--muted); border:1px solid var(--line); background:var(--surf); padding:5px 10px; border-radius:7px; }
+  .ing { display:flex; align-items:center; gap:13px; width:100%; text-align:left; background:transparent; border:none; border-top:1px solid var(--line); padding:11px 4px; cursor:pointer; font-family:inherit; }
+  .ing:first-of-type { border-top:none; }
+  .ing-box { width:17px; height:17px; border:1.5px solid var(--btn-border); border-radius:5px; flex-shrink:0; display:flex; align-items:center; justify-content:center; color:transparent; font-size:10px; line-height:1; transition: background .18s ease, border-color .18s ease, color .18s ease; }
+  .ing-name { flex:1; font-size:15px; color:var(--text); line-height:1.35; }
+  .ing-qty { font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--muted); flex-shrink:0; }
+  .ing[data-checked="true"] .ing-box { background:var(--accent); border-color:var(--accent); color:#fff; }
+  .ing[data-checked="true"] .ing-name { text-decoration:line-through; color:var(--faint); }
+  .ing[data-checked="true"] .ing-qty { color:var(--faint); }
+  .spinner { width:26px; height:26px; border-radius:50%; border:3px solid var(--line); border-top-color:var(--accent); animation:spin .7s linear infinite; }
+  @keyframes spin { to { transform:rotate(360deg); } }
+  .seg { display:inline-flex; background:var(--surf); border:1px solid var(--line); border-radius:9px; padding:3px; gap:2px; box-shadow:0 4px 14px rgba(0,0,0,0.10); }
+  .seg button { font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--muted); background:transparent; border:none; padding:6px 10px; border-radius:6px; cursor:pointer; transition: background .18s ease, color .18s ease; }
+  .seg button[data-on="true"] { background:var(--field); color:var(--text); box-shadow:0 1px 2px rgba(0,0,0,0.05); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius:6px; }
+  .recipe-grid { display:grid; grid-template-columns:1fr; gap:clamp(36px,5vw,52px); }
+  @media (min-width:780px) { .recipe-grid { grid-template-columns:296px 1fr; gap:clamp(44px,5vw,72px); align-items:start; } .recipe-aside { position:sticky; top:96px; } }
+  @media (prefers-reduced-motion: reduce) { .spinner{animation:none;} }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased; display:flex; flex-direction:column;">
+
+  <!-- ===== STATUS BANNER ===== -->
+  <sc-if value="{{ isRecipe }}" hint-placeholder-val="{{ true }}">
+  <div role="region" aria-label="Preview status" style="position:sticky; top:0; z-index:30; background:{{ bannerBg }}; border-bottom:1px solid {{ bannerBorder }}; backdrop-filter:saturate(140%) blur(10px); -webkit-backdrop-filter:saturate(140%) blur(10px);">
+    <div style="max-width:1080px; margin:0 auto; padding:13px clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; align-items:center; gap:12px 16px; justify-content:space-between;">
+      <div style="display:flex; align-items:center; gap:14px; flex-wrap:wrap;">
+        <a class="lnk" href="#" onClick="{{ onBack }}" style="display:inline-flex; align-items:center; gap:6px; font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.03em; color:var(--muted);">
+          <svg class="ic-left" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"></path></svg>
+          Recipes
+        </a>
+        <span aria-hidden="true" style="width:1px; height:16px; background:{{ bannerBorder }};"></span>
+        <span aria-hidden="true" style="display:inline-flex; color:{{ bannerFg }};">
+          <sc-if value="{{ isPublished }}" hint-placeholder-val="{{ false }}"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"></path></svg></sc-if>
+          <sc-if value="{{ isDraft }}" hint-placeholder-val="{{ true }}"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"></path><circle cx="12" cy="12" r="3"></circle></svg></sc-if>
+        </span>
+        <span style="font-size:14px; font-weight:500; color:var(--text);">{{ bannerText }}</span>
+      </div>
+      <div style="display:flex; align-items:center; gap:9px;">
+        <a class="banner-btn banner-ghost" href="#" onClick="{{ onEdit }}">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z"></path></svg>
+          Edit
+        </a>
+        <sc-if value="{{ isDraft }}" hint-placeholder-val="{{ true }}">
+          <button class="banner-btn banner-solid" onClick="{{ onPublish }}">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"></path><path d="m5 12 7-7 7 7"></path></svg>
+            Publish
+          </button>
+        </sc-if>
+        <sc-if value="{{ isPublished }}" hint-placeholder-val="{{ false }}">
+          <a class="banner-btn banner-solid" href="https://akli.dev/recipes/mild-thai-style-basa-coconut-rice" target="_blank" rel="noopener">
+            View public page
+            <svg class="ic-upright" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7"></path><path d="M7 7h10v10"></path></svg>
+          </a>
+        </sc-if>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </div>
+    </div>
+  </div>
+  </sc-if>
+
+  <!-- ===== PUBLIC RECIPE (visitor view) ===== -->
+  <main style="flex:1;">
+
+    <!-- LOADING -->
+    <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
+      <div style="max-width:680px; margin:0 auto; padding:clamp(80px,16vw,160px) 24px; text-align:center; display:flex; flex-direction:column; align-items:center; gap:18px;">
+        <div class="spinner" aria-hidden="true"></div>
+        <p style="font-size:14px; color:var(--muted); margin:0;">Loading preview…</p>
+      </div>
+    </sc-if>
+
+    <!-- NOT FOUND -->
+    <sc-if value="{{ isNotFound }}" hint-placeholder-val="{{ false }}">
+      <div style="max-width:520px; margin:0 auto; padding:clamp(72px,13vw,140px) 24px; text-align:center; display:flex; flex-direction:column; align-items:center;">
+        <div style="width:54px; height:54px; border-radius:14px; background:var(--surf); border:1px solid var(--line); display:flex; align-items:center; justify-content:center; margin-bottom:22px; color:var(--muted);">
+          <svg width="25" height="25" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-3.5-3.5"></path><path d="M11 8v3"></path><path d="M11 14h.01"></path></svg>
+        </div>
+        <h1 style="font-size:24px; font-weight:600; letter-spacing:-0.02em; margin:0 0 10px;">Recipe not found</h1>
+        <p style="font-size:15px; line-height:1.6; color:var(--muted); margin:0 0 26px; max-width:38ch;">This recipe may have been deleted, or the link is incorrect.</p>
+        <a class="banner-btn banner-ghost" href="#" onClick="{{ onBack }}" style="font-size:14px; padding:10px 18px;">
+          <svg class="ic-left" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"></path></svg>
+          Back to recipes
+        </a>
+      </div>
+    </sc-if>
+
+    <!-- RECIPE -->
+    <sc-if value="{{ isRecipe }}" hint-placeholder-val="{{ true }}">
+      <article style="max-width:920px; margin:0 auto; padding:clamp(28px,5vw,48px) 24px clamp(64px,9vw,96px);">
+
+        <figure style="margin:0 0 36px;">
+          <img src="https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=1100&q=72" alt="One-pot Mild Thai-Style Basa &amp; Coconut Rice" style="display:block; width:100%; height:auto; aspect-ratio:16/10; object-fit:cover; border-radius:16px; border:1px solid var(--line);">
+        </figure>
+
+        <header style="max-width:680px;">
+          <h1 style="font-size:clamp(32px,5.4vw,46px); font-weight:600; line-height:1.08; letter-spacing:-0.03em; margin:0 0 18px;">Mild Thai-Style Basa &amp; Coconut Rice</h1>
+          <div style="display:flex; flex-wrap:wrap; align-items:center; gap:6px 12px; font-family:'JetBrains Mono',monospace; font-size:12.5px; letter-spacing:0.02em; color:var(--muted); margin-bottom:20px;">
+            <span>27 June 2026</span><span aria-hidden="true" style="color:var(--faint);">·</span>
+            <span>5 min prep</span><span aria-hidden="true" style="color:var(--faint);">·</span>
+            <span>30 min cook</span><span aria-hidden="true" style="color:var(--faint);">·</span>
+            <span>Serves 2</span>
+          </div>
+          <div style="display:flex; flex-wrap:wrap; gap:8px; margin-bottom:24px;">
+            <span class="tag-chip">Thai</span><span class="tag-chip">Fish</span><span class="tag-chip">Rice</span><span class="tag-chip">One Pot</span><span class="tag-chip">Coconut</span>
+          </div>
+          <p style="font-size:clamp(17px,2.6vw,19px); line-height:1.7; color:var(--subtle); margin:0;">A comforting Thai-infused rice and fish one pot. Flavour the rice with coconut and fragrant green curry paste, then steam the fish on top for tenderness.</p>
+        </header>
+
+        <div style="height:1px; background:var(--line); margin:clamp(36px,5vw,52px) 0;"></div>
+
+        <div class="recipe-grid">
+          <aside class="recipe-aside">
+            <div style="border:1px solid var(--line); border-radius:16px; background:var(--surf); padding:22px 22px 14px;">
+              <div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:6px;">
+                <h2 style="font-size:18px; font-weight:600; letter-spacing:-0.01em; margin:0;">Ingredients</h2>
+                <span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--faint);">Serves 2</span>
+              </div>
+              <p style="font-size:12px; color:var(--faint); margin:0 0 12px;">Tap to check off as you go.</p>
+              <div>
+                <sc-for list="{{ ingredients }}" as="ing" hint-placeholder-count="9">
+                  <button class="ing" type="button" data-checked="{{ ing.checked }}" onClick="{{ ing.on }}">
+                    <span class="ing-box">✓</span>
+                    <span class="ing-name">{{ ing.name }}</span>
+                    <span class="ing-qty">{{ ing.qty }}</span>
+                  </button>
+                </sc-for>
+              </div>
+            </div>
+          </aside>
+
+          <section>
+            <h2 style="font-size:clamp(22px,3vw,26px); font-weight:600; letter-spacing:-0.02em; margin:0 0 8px;">Method</h2>
+            <p style="font-size:13px; color:var(--faint); font-family:'JetBrains Mono',monospace; margin:0 0 28px;">7 steps</p>
+            <div style="display:flex; flex-direction:column; gap:28px;">
+              <sc-for list="{{ steps }}" as="step" hint-placeholder-count="7">
+                <div style="display:flex; gap:18px;">
+                  <div style="flex-shrink:0; width:34px; height:34px; border-radius:50%; background:var(--surf); border:1px solid var(--line); display:flex; align-items:center; justify-content:center; font-family:'JetBrains Mono',monospace; font-size:14px; font-weight:500; color:var(--accent);">{{ step.num }}</div>
+                  <div style="padding-top:3px; flex:1;">
+                    <sc-for list="{{ step.lines }}" as="line" hint-placeholder-count="2">
+                      <p style="font-size:16.5px; line-height:1.7; color:var(--subtle); margin:0 0 12px;">{{ line }}</p>
+                    </sc-for>
+                  </div>
+                </div>
+              </sc-for>
+            </div>
+          </section>
+        </div>
+      </article>
+    </sc-if>
+  </main>
+
+  <!-- ===== PUBLIC FOOTER ===== -->
+  <sc-if value="{{ isRecipe }}" hint-placeholder-val="{{ true }}">
+    <footer style="border-top:1px solid var(--line);">
+      <div style="max-width:1080px; margin:0 auto; padding:clamp(34px,5vw,44px) clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between;">
+        <nav aria-label="Elsewhere" style="display:flex; flex-direction:column; gap:12px;">
+          <span style="font-size:15px; font-weight:600; color:var(--text);">Elsewhere</span>
+          <div style="display:flex; flex-wrap:wrap; gap:20px; font-size:14px; color:var(--muted);">
+            <a class="lnk" href="https://github.com/vandelay87">GitHub</a>
+            <a class="lnk" href="https://www.linkedin.com/in/akli-aissat-b08119115/">LinkedIn</a>
+            <a class="lnk" href="mailto:akliaissat@outlook.com?subject=Hello">Email</a>
+          </div>
+        </nav>
+        <span style="font-size:13px; font-weight:500; color:var(--muted);">akli.dev</span>
+      </div>
+    </footer>
+  </sc-if>
+
+  <!-- preview switcher (design-time only) -->
+  <div style="position:fixed; bottom:18px; left:18px; z-index:40;">
+    <div class="seg" role="group" aria-label="Preview state">
+      <button data-on="{{ isDraftView }}" onClick="{{ vDraft }}">Unpublished</button>
+      <button data-on="{{ isPublished }}" onClick="{{ vPublished }}">Published</button>
+      <button data-on="{{ isLoading }}" onClick="{{ vLoading }}">Loading</button>
+      <button data-on="{{ isNotFound }}" onClick="{{ vNotFound }}">Not found</button>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{}">
+class Component extends DCLogic {
+  state = { theme: 'light', view: 'recipe', status: 'draft', checked: {} };
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') this.setState({ theme: saved });
+      else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) this.setState({ theme: 'dark' });
+    } catch (e) {}
+  }
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  toggleIng = (i) => this.setState(s => { const c = Object.assign({}, s.checked); c[i] = !c[i]; return { checked: c }; });
+
+  onEdit = (e) => { if (e) e.preventDefault(); };
+  onPublish = () => this.setState({ status: 'published' });
+  onBack = (e) => { if (e) e.preventDefault(); };
+
+  vDraft = () => this.setState({ view: 'recipe', status: 'draft' });
+  vPublished = () => this.setState({ view: 'recipe', status: 'published' });
+  vLoading = () => this.setState({ view: 'loading' });
+  vNotFound = () => this.setState({ view: 'notfound' });
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    const published = this.state.status === 'published';
+    const view = this.state.view;
+
+    const rawIng = [
+      { qty: '8 ml', name: 'Fish sauce' }, { qty: '1', name: 'Red pepper' },
+      { qty: '140 g', name: 'White basmati rice' }, { qty: '50 g', name: 'Solid creamed coconut' },
+      { qty: '2', name: 'Spring onions' }, { qty: '2', name: 'Basa fillets' },
+      { qty: '5 g', name: 'Thai basil' }, { qty: '15 g', name: 'Crispy onions' },
+      { qty: '40 g', name: 'Thai green curry paste' }
+    ];
+    const ingredients = rawIng.map((ing, i) => Object.assign({}, ing, { checked: !!this.state.checked[i], on: () => this.toggleIng(i) }));
+
+    const steps = [
+      { num: '1', lines: ['Boil a kettle.', 'Trim, then slice your spring onions finely.', 'Deseed your pepper and chop into large bite-sized pieces.'] },
+      { num: '2', lines: ['Heat a large, wide-based pan (preferably non-stick with a matching lid) with a drizzle of vegetable oil over a medium heat.', 'Once hot, add the chopped pepper and most of the sliced spring onion with your Thai green curry paste and cook for 2–3 min, until fragrant.'] },
+      { num: '3', lines: ['Dissolve the chopped creamed coconut and fish sauce in 300 ml boiled water.'] },
+      { num: '4', lines: ['Add your basmati rice and coconut stock to the pan with 1 tsp sugar and a generous pinch of salt, and give everything a good mix.', 'Reduce the heat to low, then cook covered for 10 min, until most of the stock has absorbed and the rice is almost cooked.'] },
+      { num: '5', lines: ['Meanwhile, chop your Thai basil finely, including the stalks.'] },
+      { num: '6', lines: ['Once the rice is almost cooked, increase the heat to medium-high and top with your basa fillets. Season with a pinch of salt and pepper.', 'Cook covered for 6–7 min, until the fish is cooked through and tender.'] },
+      { num: '7', lines: ['Transfer the cooked basa to a plate.', 'Add most of the chopped Thai basil to the pan and mix it all together.', 'Serve the basa over the one-pot Thai-style coconut rice.', 'Garnish with the remaining Thai basil and sliced spring onion, then sprinkle over your crispy onions.'] }
+    ];
+
+    return {
+      theme: this.state.theme,
+      toggle: this.toggle, toggleIcon: isDark ? '\u2600' : '\u263e',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode',
+
+      isLoading: view === 'loading', isNotFound: view === 'notfound', isRecipe: view === 'recipe',
+      isDraft: view === 'recipe' && !published,
+      isPublished: view === 'recipe' && published,
+      isDraftView: view === 'recipe' && !published,
+
+      bannerText: published ? 'This recipe is published.' : 'Preview — this recipe is not yet published.',
+      bannerBg: published ? 'color-mix(in srgb, var(--green) 13%, color-mix(in srgb, var(--bg) 78%, transparent))' : 'color-mix(in srgb, var(--amber) 14%, color-mix(in srgb, var(--bg) 78%, transparent))',
+      bannerBorder: published ? 'color-mix(in srgb, var(--green) 30%, var(--line))' : 'color-mix(in srgb, var(--amber) 30%, var(--line))',
+      bannerFg: published ? 'var(--green)' : 'var(--amber)',
+
+      onEdit: this.onEdit, onPublish: this.onPublish, onBack: this.onBack,
+      ingredients, steps,
+
+      vDraft: this.vDraft, vPublished: this.vPublished, vLoading: this.vLoading, vNotFound: this.vNotFound
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/Admin Recipes.dc.html
+++ b/docs/design/paper/pages/Admin Recipes.dc.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --surf:#F4F1EA; --hover:rgba(0,0,0,0.022); --field:#FFFFFF;
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --accent:#1F66E0;
+    --green:#1F8A5B; --green-bg:rgba(31,138,91,0.10);
+    --amber:#A66E0A; --amber-bg:rgba(194,129,12,0.12);
+    --danger:#C0392B; --danger-bg:rgba(192,57,43,0.07);
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --surf:#1C1A15; --hover:rgba(255,255,255,0.04); --field:#1B1914;
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --accent:#6BA0FF;
+    --green:#62C08D; --green-bg:rgba(98,192,141,0.12);
+    --amber:#E0A93B; --amber-bg:rgba(224,169,59,0.14);
+    --danger:#E8786B; --danger-bg:rgba(232,120,107,0.12);
+  }
+  .lnk { transition: color .25s ease, opacity .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .site-header { position: sticky; top:0; z-index:20; background: color-mix(in srgb, var(--bg) 84%, transparent); backdrop-filter: saturate(140%) blur(10px); -webkit-backdrop-filter: saturate(140%) blur(10px); border-bottom:1px solid var(--line); }
+  .navlink { font-size:14px; color:var(--muted); text-decoration:none; padding:6px 0; position:relative; transition: color .2s ease; }
+  .navlink:hover { color:var(--text); }
+  .navlink[data-active="true"] { color:var(--text); font-weight:500; }
+  .navlink[data-active="true"]::after { content:""; position:absolute; left:0; right:0; bottom:-21px; height:2px; background:var(--text); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  .ghost-btn { font-family:'Geist',system-ui,sans-serif; font-size:13.5px; font-weight:500; color:var(--subtle); background:transparent; border:1px solid var(--btn-border); border-radius:9px; padding:8px 14px; cursor:pointer; transition: border-color .2s ease, color .2s ease, background .2s ease; }
+  .ghost-btn:hover { border-color:var(--accent); color:var(--accent); background:var(--hover); }
+  .primary-btn { font-family:'Geist',system-ui,sans-serif; font-size:14px; font-weight:600; color:var(--btn-fg); background:var(--btn-bg); border:none; border-radius:10px; padding:11px 18px; cursor:pointer; display:inline-flex; align-items:center; gap:8px; transition: opacity .2s ease, transform .06s ease; }
+  .primary-btn:hover { opacity:.9; }
+  .primary-btn:active { transform:translateY(1px); }
+  .danger-btn { font-family:'Geist',system-ui,sans-serif; font-size:14px; font-weight:600; color:#fff; background:var(--danger); border:none; border-radius:10px; padding:11px 18px; cursor:pointer; transition: opacity .2s ease, transform .06s ease; }
+  [data-theme="dark"] .danger-btn { color:#1A1410; }
+  .danger-btn:hover { opacity:.9; }
+  .danger-btn:active { transform:translateY(1px); }
+  .act { font-family:'Geist',system-ui,sans-serif; font-size:13px; font-weight:500; color:var(--muted); background:transparent; border:1px solid transparent; border-radius:8px; padding:6px 10px; cursor:pointer; display:inline-flex; align-items:center; gap:6px; transition: color .18s ease, background .18s ease; }
+  .act:hover { color:var(--text); background:var(--hover); }
+  .act svg { width:15px; height:15px; }
+  .act-danger:hover { color:var(--danger); background:var(--danger-bg); }
+  .act-pub:hover { color:var(--green); background:var(--green-bg); }
+  .row { transition: background .18s ease; }
+  .row:hover { background:var(--hover); }
+  .spinner { width:26px; height:26px; border-radius:50%; border:3px solid var(--line); border-top-color:var(--accent); animation:spin .7s linear infinite; }
+  @keyframes spin { to { transform:rotate(360deg); } }
+  .seg { display:inline-flex; background:var(--surf); border:1px solid var(--line); border-radius:9px; padding:3px; gap:2px; box-shadow:0 4px 14px rgba(0,0,0,0.08); }
+  .seg button { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.02em; color:var(--muted); background:transparent; border:none; padding:6px 10px; border-radius:6px; cursor:pointer; transition: background .18s ease, color .18s ease; }
+  .seg button[data-on="true"] { background:var(--field); color:var(--text); box-shadow:0 1px 2px rgba(0,0,0,0.05); }
+  .overlay { position:fixed; inset:0; z-index:60; display:flex; align-items:center; justify-content:center; padding:24px; background:color-mix(in srgb, #000 38%, transparent); backdrop-filter:blur(2px); animation:fade .15s ease; }
+  @keyframes fade { from { opacity:0; } }
+  @keyframes pop { from { opacity:0; transform:translateY(8px) scale(.98); } }
+  @keyframes toastIn { from { opacity:0; transform:translateX(16px); } }
+  .toast:hover { border-color: color-mix(in srgb, var(--text) 18%, var(--line)); }
+  .toast:hover .toast-x { opacity:1; color:var(--muted); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius:6px; }
+  @media (prefers-reduced-motion: reduce) { .spinner{animation:none;} .overlay,.toast{animation:none;} }
+  @media (max-width:680px) { .navlink[data-active="true"]::after { bottom:-15px; } }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased; display:flex; flex-direction:column;">
+
+  <!-- ===== ADMIN SHELL HEADER ===== -->
+  <header class="site-header">
+    <div style="max-width:1080px; margin:0 auto; padding:18px clamp(20px,5vw,28px); display:flex; align-items:center; justify-content:space-between; gap:20px;">
+      <div style="display:flex; align-items:center; gap:clamp(18px,4vw,30px);">
+        <a class="lnk" href="/" style="font-size:15px; font-weight:600; letter-spacing:-0.01em;">Akli Aissat</a>
+        <nav aria-label="Admin" style="display:flex; align-items:center; gap:22px; font-size:14px; color:var(--muted);">
+          <a class="lnk" href="#" aria-current="page" style="color:var(--text); font-weight:500;">Recipes</a>
+          <a class="lnk" href="#">Users</a>
+        </nav>
+      </div>
+      <div style="display:flex; align-items:center; gap:14px;">
+        <span style="font-size:13px; color:var(--muted);">{{ email }}</span>
+        <button class="ghost-btn" style="padding:7px 13px;" onClick="{{ logout }}">Log out</button>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </div>
+    </div>
+  </header>
+
+  <!-- ===== MAIN ===== -->
+  <main style="flex:1; max-width:1080px; width:100%; margin:0 auto; padding:clamp(32px,5vw,52px) clamp(20px,5vw,28px) 64px;">
+
+    <!-- page header -->
+    <div style="display:flex; flex-wrap:wrap; gap:16px; align-items:flex-end; justify-content:space-between; margin-bottom:30px;">
+      <div>
+        <h1 style="font-size:clamp(28px,4vw,34px); font-weight:600; letter-spacing:-0.025em; margin:0 0 6px;">Recipes</h1>
+        <p style="font-size:14.5px; color:var(--muted); margin:0;">{{ subtitle }}</p>
+      </div>
+      <button class="primary-btn" onClick="{{ newRecipe }}">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+        New recipe
+      </button>
+    </div>
+
+    <!-- ===== LIST STATE ===== -->
+    <sc-if value="{{ isList }}" hint-placeholder-val="{{ true }}">
+      <div style="border:1px solid var(--line); border-radius:16px; overflow:hidden; background:var(--field);">
+        <sc-for list="{{ recipes }}" as="r" hint-placeholder-count="5">
+          <div class="row" style="display:flex; flex-wrap:wrap; gap:16px 20px; align-items:center; justify-content:space-between; padding:18px clamp(16px,2.5vw,22px); border-top:1px solid var(--line);">
+            <div style="min-width:240px; flex:1;">
+              <div style="display:flex; align-items:center; gap:11px; margin-bottom:9px;">
+                <span style="display:inline-flex; align-items:center; gap:6px; font-family:'JetBrains Mono',monospace; font-size:10.5px; letter-spacing:0.06em; text-transform:uppercase; padding:3px 9px; border-radius:999px; background:{{ r.badgeBg }}; color:{{ r.badgeFg }};"><span style="width:5px; height:5px; border-radius:50%; background:{{ r.badgeFg }};"></span>{{ r.statusLabel }}</span>
+                <h2 style="font-size:16.5px; font-weight:600; letter-spacing:-0.015em; margin:0; color:var(--text);">{{ r.title }}</h2>
+              </div>
+              <div style="display:flex; flex-wrap:wrap; align-items:center; gap:7px;">
+                <sc-for list="{{ r.tags }}" as="tag" hint-placeholder-count="3">
+                  <span style="font-family:'JetBrains Mono',monospace; font-size:10.5px; letter-spacing:0.03em; color:var(--muted); border:1px solid var(--line); background:var(--surf); padding:3px 8px; border-radius:6px;">{{ tag }}</span>
+                </sc-for>
+                <span style="font-size:12.5px; color:var(--faint); margin-left:4px;">{{ r.updatedLabel }}</span>
+              </div>
+            </div>
+            <div style="display:flex; flex-wrap:wrap; align-items:center; gap:4px;">
+              <button class="act" onClick="{{ r.onEdit }}" title="Edit">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z"></path></svg>Edit
+              </button>
+              <button class="act" onClick="{{ r.onPreview }}" title="Preview">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"></path><circle cx="12" cy="12" r="3"></circle></svg>Preview
+              </button>
+              <button class="act act-pub" onClick="{{ r.onToggle }}" title="{{ r.toggleLabel }}">
+                <sc-if value="{{ r.isPublished }}" hint-placeholder-val="{{ false }}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"></path><path d="m19 9-5 5-4-4-3 3"></path></svg></sc-if>
+                <sc-if value="{{ r.isDraft }}" hint-placeholder-val="{{ true }}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"></path><path d="m5 12 7-7 7 7"></path></svg></sc-if>
+                {{ r.toggleLabel }}
+              </button>
+              <button class="act act-danger" onClick="{{ r.onDelete }}" title="Delete">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"></path><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path></svg>Delete
+              </button>
+            </div>
+          </div>
+        </sc-for>
+      </div>
+    </sc-if>
+
+    <!-- ===== EMPTY STATE ===== -->
+    <sc-if value="{{ isEmpty }}" hint-placeholder-val="{{ false }}">
+      <div style="border:1px dashed var(--line); border-radius:16px; padding:clamp(48px,8vw,84px) 24px; text-align:center; display:flex; flex-direction:column; align-items:center;">
+        <div style="width:52px; height:52px; border-radius:14px; background:var(--surf); border:1px solid var(--line); display:flex; align-items:center; justify-content:center; margin-bottom:20px; color:var(--muted);">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"></path><path d="M14 2v5h5"></path></svg>
+        </div>
+        <h2 style="font-size:20px; font-weight:600; letter-spacing:-0.02em; margin:0 0 8px;">No recipes yet</h2>
+        <p style="font-size:14.5px; line-height:1.6; color:var(--muted); margin:0 0 24px; max-width:36ch;">Your kitchen is empty. Create your first recipe to start building the collection.</p>
+        <button class="primary-btn" onClick="{{ newRecipe }}">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+          Create your first recipe
+        </button>
+      </div>
+    </sc-if>
+
+    <!-- ===== LOADING STATE ===== -->
+    <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
+      <div style="border:1px solid var(--line); border-radius:16px; padding:clamp(56px,9vw,92px) 24px; text-align:center; display:flex; flex-direction:column; align-items:center; gap:18px;">
+        <div class="spinner" aria-hidden="true"></div>
+        <p style="font-size:14px; color:var(--muted); margin:0;">Loading recipes…</p>
+      </div>
+    </sc-if>
+
+    <!-- ===== ERROR STATE ===== -->
+    <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}">
+      <div style="border:1px solid color-mix(in srgb, var(--danger) 30%, var(--line)); background:var(--danger-bg); border-radius:16px; padding:clamp(48px,8vw,80px) 24px; text-align:center; display:flex; flex-direction:column; align-items:center;">
+        <div style="width:52px; height:52px; border-radius:14px; background:var(--field); border:1px solid color-mix(in srgb, var(--danger) 30%, var(--line)); display:flex; align-items:center; justify-content:center; margin-bottom:20px; color:var(--danger);">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
+        </div>
+        <h2 style="font-size:20px; font-weight:600; letter-spacing:-0.02em; margin:0 0 8px;">Couldn't load recipes</h2>
+        <p style="font-size:14.5px; line-height:1.6; color:var(--muted); margin:0 0 24px; max-width:38ch;">Something went wrong reaching the server. Check your connection and try again.</p>
+        <button class="ghost-btn" onClick="{{ retry }}" style="display:inline-flex; align-items:center; gap:8px;">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"></path><path d="M3 3v5h5"></path></svg>
+          Retry
+        </button>
+      </div>
+    </sc-if>
+  </main>
+
+  <!-- ===== FOOTER ===== -->
+  <footer style="border-top:1px solid var(--line);">
+    <div style="max-width:1080px; margin:0 auto; padding:22px clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:12px; align-items:center; justify-content:space-between;">
+      <span style="font-size:12.5px; color:var(--faint);">akli.dev admin</span>
+      <span style="font-size:12.5px; color:var(--faint);">Signed in as {{ email }}</span>
+    </div>
+  </footer>
+
+  <!-- ===== DELETE DIALOG ===== -->
+  <sc-if value="{{ deleteOpen }}" hint-placeholder-val="{{ false }}">
+    <div class="overlay" role="dialog" aria-modal="true" aria-labelledby="del-title" onClick="{{ cancelDelete }}">
+      <div onClick="{{ stop }}" style="width:100%; max-width:420px; background:var(--bg); border:1px solid var(--line); border-radius:18px; padding:26px; box-shadow:0 24px 60px rgba(0,0,0,0.28); animation:pop .18s ease;">
+        <div style="display:flex; align-items:center; gap:12px; margin-bottom:14px;">
+          <div style="width:38px; height:38px; flex-shrink:0; border-radius:10px; background:var(--danger-bg); display:flex; align-items:center; justify-content:center; color:var(--danger);">
+            <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"></path><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path></svg>
+          </div>
+          <h2 id="del-title" style="font-size:18px; font-weight:600; letter-spacing:-0.02em; margin:0;">Delete recipe</h2>
+        </div>
+        <p style="font-size:14.5px; line-height:1.6; color:var(--subtle); margin:0 0 24px;">Are you sure you want to delete <strong style="color:var(--text);">“{{ deleteTitle }}”</strong>? This action can't be undone.</p>
+        <div style="display:flex; justify-content:flex-end; gap:10px;">
+          <button class="ghost-btn" onClick="{{ cancelDelete }}">Cancel</button>
+          <button class="danger-btn" onClick="{{ confirmDelete }}">Delete recipe</button>
+        </div>
+      </div>
+    </div>
+  </sc-if>
+
+  <!-- ===== TOASTS ===== -->
+  <div style="position:fixed; bottom:18px; right:18px; z-index:80; display:flex; flex-direction:column; gap:10px; max-width:340px;">
+    <sc-for list="{{ toasts }}" as="t" hint-placeholder-count="0">
+      <button class="toast" type="button" aria-label="Dismiss notification" onClick="{{ t.dismiss }}" style="display:flex; align-items:center; gap:11px; width:100%; text-align:left; background:var(--bg); border:1px solid var(--line); border-radius:11px; padding:12px 15px; box-shadow:0 12px 30px rgba(0,0,0,0.16); animation:toastIn .2s ease; cursor:pointer; font-family:inherit;">
+        <span aria-hidden="true" style="width:18px; height:18px; flex-shrink:0; border-radius:50%; background:{{ t.dot }}; color:{{ t.accent }}; display:inline-flex; align-items:center; justify-content:center; font-size:11px; line-height:1;">{{ t.icon }}</span>
+        <span style="font-size:13.5px; line-height:1.45; color:var(--subtle); flex:1;">{{ t.msg }}</span>
+        <span class="toast-x" aria-hidden="true" style="flex-shrink:0; color:var(--faint); font-size:12px; line-height:1; opacity:.5; transition:opacity .18s ease, color .18s ease;">✕</span>
+      </button>
+    </sc-for>
+  </div>
+
+  <!-- preview switcher (design-time only) -->
+  <div style="position:fixed; bottom:18px; left:18px; z-index:30; display:flex; align-items:center; gap:8px;">
+    <div class="seg" role="group" aria-label="Preview state">
+      <button data-on="{{ isList }}" onClick="{{ setList }}">List</button>
+      <button data-on="{{ isEmpty }}" onClick="{{ setEmpty }}">Empty</button>
+      <button data-on="{{ isLoading }}" onClick="{{ setLoadingState }}">Loading</button>
+      <button data-on="{{ isError }}" onClick="{{ setErrorState }}">Error</button>
+    </div>
+    <button class="seg" onClick="{{ demoToast }}" style="cursor:pointer;"><span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--muted); padding:6px 10px;">Toast</span></button>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{}">
+class Component extends DCLogic {
+  state = {
+    theme: 'light',
+    view: 'list',          // list | empty | loading | error
+    recipes: [
+      { id: 1, title: 'Mild Thai-Style Basa & Coconut Rice', status: 'published', tags: ['Thai','Fish','Rice','One Pot'], updated: '2026-06-27' },
+      { id: 2, title: 'Weeknight Beef Ragù',                  status: 'published', tags: ['Pasta','Beef'],               updated: '2026-06-21' },
+      { id: 3, title: 'Rosemary Olive Oil Focaccia',          status: 'draft',     tags: ['Baking','Bread'],             updated: '2026-06-18' },
+      { id: 4, title: 'Miso Mushroom Ramen',                  status: 'published', tags: ['Mains','Vegetarian'],         updated: '2026-06-10' },
+      { id: 5, title: 'Dark Chocolate Tahini Cookies',        status: 'draft',     tags: ['Baking','Dessert'],           updated: '2026-05-30' }
+    ],
+    deleteId: null,
+    toasts: []
+  };
+
+  email = 'akli@akli.dev';
+  _toastSeq = 0;
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') this.setState({ theme: saved });
+      else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) this.setState({ theme: 'dark' });
+    } catch (e) {}
+  }
+  componentWillUnmount() { (this._timers || []).forEach(clearTimeout); }
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  // ---- toasts ----
+  pushToast(type, msg) {
+    const id = ++this._toastSeq;
+    this.setState(s => ({ toasts: s.toasts.concat([{ id, type, msg }]) }));
+    this._timers = this._timers || [];
+    this._timers.push(setTimeout(() => this.dismissToast(id), 3600));
+  }
+  dismissToast = (id) => this.setState(s => ({ toasts: s.toasts.filter(t => t.id !== id) }));
+
+  // ---- view states ----
+  setView = (view) => this.setState({ view });
+  retry = () => {
+    this.setState({ view: 'loading' });
+    this._timers = this._timers || [];
+    this._timers.push(setTimeout(() => this.setState({ view: 'list' }), 1100));
+  };
+
+  // ---- recipe actions ----
+  newRecipe = () => this.pushToast('info', 'Opening a new recipe…');
+  onEdit = (r) => this.pushToast('info', 'Opening the editor for “' + r.title + '”.');
+  onPreview = (r) => this.pushToast('info', 'Preview for “' + r.title + '” opens in a new tab.');
+  onToggle = (r) => {
+    this.setState(s => ({
+      recipes: s.recipes.map(x => x.id === r.id ? Object.assign({}, x, { status: x.status === 'published' ? 'draft' : 'published', updated: '2026-06-30' }) : x)
+    }));
+    this.pushToast('success', r.status === 'published'
+      ? '“' + r.title + '” moved to drafts.'
+      : '“' + r.title + '” is now published.');
+  };
+  askDelete = (r) => this.setState({ deleteId: r.id });
+  cancelDelete = () => this.setState({ deleteId: null });
+  confirmDelete = () => {
+    const r = this.state.recipes.find(x => x.id === this.state.deleteId);
+    this.setState(s => {
+      const recipes = s.recipes.filter(x => x.id !== s.deleteId);
+      return { recipes, deleteId: null, view: recipes.length ? s.view : 'empty' };
+    });
+    if (r) this.pushToast('success', '“' + r.title + '” was deleted.');
+  };
+  stop = (e) => { if (e && e.stopPropagation) e.stopPropagation(); };
+  logout = () => this.pushToast('info', 'Signing out…');
+  demoToast = () => this.pushToast('error', 'Access denied — admins only.');
+
+  relTime(iso) {
+    const now = new Date('2026-06-30T12:00:00');
+    const d = new Date(iso + 'T12:00:00');
+    const days = Math.round((now - d) / 86400000);
+    if (days <= 0) return 'Updated today';
+    if (days === 1) return 'Updated yesterday';
+    if (days < 7) return 'Updated ' + days + ' days ago';
+    if (days < 14) return 'Updated last week';
+    if (days < 30) return 'Updated ' + Math.floor(days / 7) + ' weeks ago';
+    const m = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+    return 'Updated ' + d.getDate() + ' ' + m[d.getMonth()] + ' ' + d.getFullYear();
+  }
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    const v = this.state.view;
+    const sorted = this.state.recipes.slice().sort((a, b) => b.updated < a.updated ? -1 : 1);
+    const recipes = sorted.map(r => {
+      const published = r.status === 'published';
+      return {
+        id: r.id, title: r.title, tags: r.tags,
+        isPublished: published, isDraft: !published,
+        statusLabel: published ? 'Published' : 'Draft',
+        badgeBg: published ? 'var(--green-bg)' : 'var(--amber-bg)',
+        badgeFg: published ? 'var(--green)' : 'var(--amber)',
+        updatedLabel: this.relTime(r.updated),
+        toggleLabel: published ? 'Unpublish' : 'Publish',
+        onEdit: () => this.onEdit(r),
+        onPreview: () => this.onPreview(r),
+        onToggle: () => this.onToggle(r),
+        onDelete: () => this.askDelete(r)
+      };
+    });
+
+    const tStyle = { success: { accent:'var(--green)', dot:'var(--green-bg)', icon:'✓' },
+                     error:   { accent:'var(--danger)', dot:'var(--danger-bg)', icon:'✕' },
+                     info:    { accent:'var(--accent)', dot:'color-mix(in srgb, var(--accent) 14%, transparent)', icon:'›' } };
+    const toasts = this.state.toasts.map(t => Object.assign({}, tStyle[t.type] || tStyle.info, { msg: t.msg, dismiss: () => this.dismissToast(t.id) }));
+
+    const delRecipe = this.state.recipes.find(x => x.id === this.state.deleteId);
+
+    return {
+      theme: this.state.theme, email: this.email,
+      toggle: this.toggle, toggleIcon: isDark ? '☀' : '☾',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode',
+      logout: this.logout,
+      subtitle: recipes.length === 1 ? '1 recipe' : recipes.length + ' recipes',
+      newRecipe: this.newRecipe,
+      isList: v === 'list', isEmpty: v === 'empty', isLoading: v === 'loading', isError: v === 'error',
+      recipes,
+      retry: this.retry,
+      deleteOpen: !!delRecipe, deleteTitle: delRecipe ? delRecipe.title : '',
+      cancelDelete: this.cancelDelete, confirmDelete: this.confirmDelete, stop: this.stop,
+      toasts,
+      setList: () => this.setView('list'), setEmpty: () => this.setView('empty'),
+      setLoadingState: () => this.setView('loading'), setErrorState: () => this.setView('error'),
+      demoToast: this.demoToast
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/Admin Users.dc.html
+++ b/docs/design/paper/pages/Admin Users.dc.html
@@ -1,0 +1,404 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --surf:#F4F1EA; --hover:rgba(0,0,0,0.022); --field:#FFFFFF;
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --accent:#1F66E0; --accent-bg:rgba(31,102,224,0.10);
+    --green:#1F8A5B; --green-bg:rgba(31,138,91,0.10);
+    --amber:#A66E0A; --amber-bg:rgba(194,129,12,0.12);
+    --danger:#C0392B; --danger-bg:rgba(192,57,43,0.07);
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --surf:#1C1A15; --hover:rgba(255,255,255,0.04); --field:#1B1914;
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --accent:#6BA0FF; --accent-bg:rgba(107,160,255,0.14);
+    --green:#62C08D; --green-bg:rgba(98,192,141,0.12);
+    --amber:#E0A93B; --amber-bg:rgba(224,169,59,0.14);
+    --danger:#E8786B; --danger-bg:rgba(232,120,107,0.12);
+  }
+  .lnk { transition: color .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .site-header { position: sticky; top:0; z-index:20; background: color-mix(in srgb, var(--bg) 84%, transparent); backdrop-filter: saturate(140%) blur(10px); -webkit-backdrop-filter: saturate(140%) blur(10px); border-bottom:1px solid var(--line); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  .field { width:100%; font-family:'Geist',system-ui,sans-serif; font-size:15px; color:var(--text); background:var(--field); border:1px solid var(--line); border-radius:10px; padding:12px 13px; outline:none; transition: border-color .18s ease, box-shadow .18s ease; }
+  .field::placeholder { color:var(--faint); }
+  .field:focus { border-color:var(--accent); box-shadow:0 0 0 3px color-mix(in srgb, var(--accent) 15%, transparent); }
+  .field.err { border-color:var(--danger); }
+  .field.err:focus { box-shadow:0 0 0 3px color-mix(in srgb, var(--danger) 18%, transparent); }
+  .primary-btn { font-family:'Geist',system-ui,sans-serif; font-size:14px; font-weight:600; color:var(--btn-fg); background:var(--btn-bg); border:none; border-radius:10px; padding:11px 18px; cursor:pointer; display:inline-flex; align-items:center; justify-content:center; gap:8px; transition: opacity .2s ease, transform .06s ease; }
+  .primary-btn:hover { opacity:.9; } .primary-btn:active { transform:translateY(1px); }
+  .primary-btn:disabled { opacity:.5; cursor:not-allowed; }
+  .ghost-btn { font-family:'Geist',system-ui,sans-serif; font-size:14px; font-weight:500; color:var(--subtle); background:transparent; border:1px solid var(--btn-border); border-radius:10px; padding:10px 16px; cursor:pointer; display:inline-flex; align-items:center; justify-content:center; gap:8px; transition: border-color .2s ease, color .2s ease, background .2s ease; }
+  .ghost-btn:hover { border-color:var(--accent); color:var(--accent); background:var(--hover); }
+  .danger-solid { font-family:'Geist',system-ui,sans-serif; font-size:14px; font-weight:600; color:#fff; background:var(--danger); border:none; border-radius:10px; padding:11px 18px; cursor:pointer; transition: opacity .2s ease; }
+  [data-theme="dark"] .danger-solid { color:#1A1410; } .danger-solid:hover { opacity:.9; }
+  .act { font-family:'Geist',system-ui,sans-serif; font-size:13px; font-weight:500; color:var(--muted); background:transparent; border:1px solid transparent; border-radius:8px; padding:6px 11px; cursor:pointer; display:inline-flex; align-items:center; gap:6px; transition: color .18s ease, background .18s ease; }
+  .act:hover { color:var(--danger); background:var(--danger-bg); }
+  .act svg { width:15px; height:15px; }
+  .row { transition: background .18s ease; }
+  .row:hover { background:var(--hover); }
+  .roleseg { display:inline-flex; background:var(--field); border:1px solid var(--line); border-radius:9px; padding:3px; gap:2px; }
+  .roleseg button { font-family:'Geist',system-ui,sans-serif; font-size:13px; font-weight:500; border:none; padding:8px 16px; border-radius:6px; cursor:pointer; }
+  .avatar { width:36px; height:36px; flex-shrink:0; border-radius:50%; background:var(--surf); border:1px solid var(--line); display:flex; align-items:center; justify-content:center; font-size:14px; font-weight:600; color:var(--muted); }
+  .spinner { width:26px; height:26px; border-radius:50%; border:3px solid var(--line); border-top-color:var(--accent); animation:spin .7s linear infinite; }
+  .spinner.sm { width:15px; height:15px; border-width:2px; }
+  @keyframes spin { to { transform:rotate(360deg); } }
+  .seg { display:inline-flex; background:var(--surf); border:1px solid var(--line); border-radius:9px; padding:3px; gap:2px; box-shadow:0 4px 14px rgba(0,0,0,0.08); }
+  .seg button { font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--muted); background:transparent; border:none; padding:6px 10px; border-radius:6px; cursor:pointer; transition: background .18s ease, color .18s ease; }
+  .seg button[data-on="true"] { background:var(--field); color:var(--text); box-shadow:0 1px 2px rgba(0,0,0,0.05); }
+  .overlay { position:fixed; inset:0; z-index:60; display:flex; align-items:center; justify-content:center; padding:24px; background:color-mix(in srgb, #000 38%, transparent); animation:fade .15s ease; }
+  @keyframes fade { from { opacity:0; } }
+  @keyframes pop { from { opacity:0; transform:translateY(8px) scale(.98); } }
+  @keyframes toastIn { from { opacity:0; transform:translateX(16px); } }
+  @keyframes slideDown { from { opacity:0; transform:translateY(-8px); } }
+  .toast:hover { border-color: color-mix(in srgb, var(--text) 18%, var(--line)); }
+  .toast:hover .toast-x { opacity:1; color:var(--muted); }
+  a:focus-visible, button:focus-visible, .field:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius:6px; }
+  @media (prefers-reduced-motion: reduce) { .spinner{animation:none;} .overlay,.toast,.invite{animation:none;} }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased; display:flex; flex-direction:column;">
+
+  <!-- ===== SHELL HEADER ===== -->
+  <header class="site-header">
+    <div style="max-width:1080px; margin:0 auto; padding:18px clamp(20px,5vw,28px); display:flex; align-items:center; justify-content:space-between; gap:20px;">
+      <div style="display:flex; align-items:center; gap:clamp(18px,4vw,30px);">
+        <a class="lnk" href="/" style="font-size:15px; font-weight:600; letter-spacing:-0.01em;">Akli Aissat</a>
+        <nav aria-label="Admin" style="display:flex; align-items:center; gap:22px; font-size:14px; color:var(--muted);">
+          <a class="lnk" href="#">Recipes</a>
+          <a class="lnk" href="#" aria-current="page" style="color:var(--text); font-weight:500;">Users</a>
+        </nav>
+      </div>
+      <div style="display:flex; align-items:center; gap:14px;">
+        <span style="font-size:13px; color:var(--muted);">{{ email }}</span>
+        <button class="ghost-btn" style="padding:7px 13px; font-size:13px;" onClick="{{ logout }}">Log out</button>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </div>
+    </div>
+  </header>
+
+  <main style="flex:1; max-width:1080px; width:100%; margin:0 auto; padding:clamp(32px,5vw,52px) clamp(20px,5vw,28px) 64px;">
+
+    <!-- page header -->
+    <div style="display:flex; flex-wrap:wrap; gap:16px; align-items:flex-end; justify-content:space-between; margin-bottom:30px;">
+      <div>
+        <h1 style="font-size:clamp(28px,4vw,34px); font-weight:600; letter-spacing:-0.025em; margin:0 0 6px;">Users</h1>
+        <p style="font-size:14.5px; color:var(--muted); margin:0;">{{ subtitle }}</p>
+      </div>
+      <sc-if value="{{ showInviteButton }}" hint-placeholder-val="{{ true }}">
+        <button class="primary-btn" onClick="{{ openInvite }}">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path><circle cx="9" cy="7" r="4"></circle><line x1="19" y1="8" x2="19" y2="14"></line><line x1="22" y1="11" x2="16" y2="11"></line></svg>
+          Invite user
+        </button>
+      </sc-if>
+    </div>
+
+    <!-- ===== INVITE FORM ===== -->
+    <sc-if value="{{ inviteOpen }}" hint-placeholder-val="{{ false }}">
+      <div class="invite" style="border:1px solid var(--line); border-radius:16px; background:var(--surf); padding:clamp(18px,3vw,24px); margin-bottom:24px; animation:slideDown .2s ease;">
+        <div style="display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:18px;">
+          <h2 style="font-size:17px; font-weight:600; letter-spacing:-0.015em; margin:0;">Invite a user</h2>
+          <button class="lnk" onClick="{{ cancelInvite }}" aria-label="Close" style="background:transparent; border:none; color:var(--faint); cursor:pointer; font-size:14px; line-height:1; padding:4px;">✕</button>
+        </div>
+        <form onSubmit="{{ sendInvite }}" novalidate="true" style="display:flex; flex-wrap:wrap; gap:16px; align-items:flex-start;">
+          <div style="flex:1; min-width:240px;">
+            <label class="flabel" for="inv-email" style="font-size:13px; font-weight:500; color:var(--subtle); display:block; margin-bottom:7px;">Email address</label>
+            <input id="inv-email" class="field {{ emailErrClass }}" type="email" autocomplete="off" placeholder="name@example.com" value="{{ inviteEmail }}" onInput="{{ onInviteEmail }}">
+            <sc-if value="{{ hasInviteError }}" hint-placeholder-val="{{ false }}">
+              <div role="alert" style="display:flex; align-items:center; gap:7px; margin-top:8px; font-size:13px; color:var(--danger);">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+                {{ inviteError }}
+              </div>
+            </sc-if>
+          </div>
+          <div>
+            <span class="flabel" style="font-size:13px; font-weight:500; color:var(--subtle); display:block; margin-bottom:7px;">Role</span>
+            <div class="roleseg" role="group" aria-label="Role">
+              <button type="button" style="background:{{ contribBg }}; color:{{ contribFg }};" onClick="{{ pickContributor }}">Contributor</button>
+              <button type="button" style="background:{{ adminBg }}; color:{{ adminFg }};" onClick="{{ pickAdmin }}">Admin</button>
+            </div>
+          </div>
+          <div style="align-self:flex-start;">
+            <span aria-hidden="true" style="display:block; font-size:13px; margin-bottom:7px; height:18px;">&nbsp;</span>
+            <div style="display:flex; gap:10px;">
+              <button class="ghost-btn" type="button" onClick="{{ cancelInvite }}">Cancel</button>
+              <button class="primary-btn" type="submit" disabled="{{ sendDisabled }}">
+                <sc-if value="{{ inviteSending }}" hint-placeholder-val="{{ false }}"><span class="spinner sm" aria-hidden="true"></span></sc-if>
+                {{ sendLabel }}
+              </button>
+            </div>
+          </div>
+        </form>
+        <p style="font-size:12.5px; color:var(--faint); margin:14px 0 0; line-height:1.5;">{{ roleHint }}</p>
+      </div>
+    </sc-if>
+
+    <!-- ===== LIST ===== -->
+    <sc-if value="{{ isList }}" hint-placeholder-val="{{ true }}">
+      <div style="border:1px solid var(--line); border-radius:16px; overflow:hidden; background:var(--field);">
+        <sc-for list="{{ users }}" as="u" hint-placeholder-count="4">
+          <div class="row" style="display:flex; flex-wrap:wrap; gap:14px 18px; align-items:center; justify-content:space-between; padding:16px clamp(16px,2.5vw,22px); border-top:1px solid var(--line);">
+            <div style="display:flex; align-items:center; gap:13px; min-width:0;">
+              <span class="avatar">{{ u.initial }}</span>
+              <div style="min-width:0;">
+                <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
+                  <span style="font-size:15px; font-weight:500; color:var(--text); word-break:break-word;">{{ u.email }}</span>
+                  <sc-if value="{{ u.isSelf }}" hint-placeholder-val="{{ false }}"><span style="font-family:'JetBrains Mono',monospace; font-size:10px; letter-spacing:0.06em; text-transform:uppercase; color:var(--muted); background:var(--surf); border:1px solid var(--line); padding:2px 7px; border-radius:5px;">You</span></sc-if>
+                </div>
+              </div>
+            </div>
+            <div style="display:flex; align-items:center; gap:10px 18px; flex-wrap:wrap;">
+              <span style="display:inline-flex; align-items:center; gap:6px; font-family:'JetBrains Mono',monospace; font-size:10.5px; letter-spacing:0.05em; text-transform:uppercase; padding:4px 10px; border-radius:999px; background:{{ u.roleBg }}; color:{{ u.roleFg }};">{{ u.role }}</span>
+              <span style="display:inline-flex; align-items:center; gap:6px; font-size:13px; color:var(--muted); min-width:96px;"><span style="width:6px; height:6px; border-radius:50%; background:{{ u.statusFg }};"></span>{{ u.status }}</span>
+              <div style="width:84px; display:flex; justify-content:flex-end;">
+                <sc-if value="{{ u.removable }}" hint-placeholder-val="{{ true }}">
+                  <button class="act" onClick="{{ u.onRemove }}" title="Remove user">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"></path><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path></svg>Remove
+                  </button>
+                </sc-if>
+              </div>
+            </div>
+          </div>
+        </sc-for>
+      </div>
+    </sc-if>
+
+    <!-- ===== LOADING ===== -->
+    <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
+      <div style="border:1px solid var(--line); border-radius:16px; padding:clamp(56px,9vw,92px) 24px; text-align:center; display:flex; flex-direction:column; align-items:center; gap:18px;">
+        <div class="spinner" aria-hidden="true"></div>
+        <p style="font-size:14px; color:var(--muted); margin:0;">Loading users…</p>
+      </div>
+    </sc-if>
+
+    <!-- ===== ERROR ===== -->
+    <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}">
+      <div style="border:1px solid color-mix(in srgb, var(--danger) 30%, var(--line)); background:var(--danger-bg); border-radius:16px; padding:clamp(48px,8vw,80px) 24px; text-align:center; display:flex; flex-direction:column; align-items:center;">
+        <div style="width:52px; height:52px; border-radius:14px; background:var(--field); border:1px solid color-mix(in srgb, var(--danger) 30%, var(--line)); display:flex; align-items:center; justify-content:center; margin-bottom:20px; color:var(--danger);">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
+        </div>
+        <h2 style="font-size:20px; font-weight:600; letter-spacing:-0.02em; margin:0 0 8px;">Couldn't load users</h2>
+        <p style="font-size:14.5px; line-height:1.6; color:var(--muted); margin:0 0 24px; max-width:38ch;">Something went wrong reaching the server. Check your connection and try again.</p>
+        <button class="ghost-btn" onClick="{{ retry }}">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"></path><path d="M3 3v5h5"></path></svg>
+          Retry
+        </button>
+      </div>
+    </sc-if>
+  </main>
+
+  <!-- ===== FOOTER ===== -->
+  <footer style="border-top:1px solid var(--line);">
+    <div style="max-width:1080px; margin:0 auto; padding:22px clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:12px; align-items:center; justify-content:space-between;">
+      <span style="font-size:12.5px; color:var(--faint);">akli.dev admin</span>
+      <span style="font-size:12.5px; color:var(--faint);">Signed in as {{ email }}</span>
+    </div>
+  </footer>
+
+  <!-- ===== REMOVE DIALOG ===== -->
+  <sc-if value="{{ removeOpen }}" hint-placeholder-val="{{ false }}">
+    <div class="overlay" role="dialog" aria-modal="true" aria-labelledby="rm-title" onClick="{{ cancelRemove }}">
+      <div onClick="{{ stop }}" style="width:100%; max-width:430px; background:var(--bg); border:1px solid var(--line); border-radius:18px; padding:26px; box-shadow:0 24px 60px rgba(0,0,0,0.28); animation:pop .18s ease;">
+        <div style="display:flex; align-items:center; gap:12px; margin-bottom:14px;">
+          <div style="width:38px; height:38px; flex-shrink:0; border-radius:10px; background:var(--danger-bg); display:flex; align-items:center; justify-content:center; color:var(--danger);">
+            <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"></path><path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"></path><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path></svg>
+          </div>
+          <h2 id="rm-title" style="font-size:18px; font-weight:600; letter-spacing:-0.02em; margin:0;">Remove user</h2>
+        </div>
+        <p style="font-size:14.5px; line-height:1.6; color:var(--subtle); margin:0 0 24px;">Remove <strong style="color:var(--text);">{{ removeEmail }}</strong>? They will lose access immediately. This can't be undone.</p>
+        <div style="display:flex; justify-content:flex-end; gap:10px;">
+          <button class="ghost-btn" onClick="{{ cancelRemove }}">Cancel</button>
+          <button class="danger-solid" onClick="{{ confirmRemove }}">Remove user</button>
+        </div>
+      </div>
+    </div>
+  </sc-if>
+
+  <!-- ===== TOASTS ===== -->
+  <div style="position:fixed; bottom:18px; right:18px; z-index:80; display:flex; flex-direction:column; gap:10px; max-width:340px;">
+    <sc-for list="{{ toasts }}" as="t" hint-placeholder-count="0">
+      <button class="toast" type="button" aria-label="Dismiss notification" onClick="{{ t.dismiss }}" style="display:flex; align-items:center; gap:11px; width:100%; text-align:left; background:var(--bg); border:1px solid var(--line); border-radius:11px; padding:12px 15px; box-shadow:0 12px 30px rgba(0,0,0,0.16); animation:toastIn .2s ease; cursor:pointer; font-family:inherit;">
+        <span aria-hidden="true" style="width:18px; height:18px; flex-shrink:0; border-radius:50%; background:{{ t.dot }}; color:{{ t.accent }}; display:inline-flex; align-items:center; justify-content:center; font-size:11px; line-height:1;">{{ t.icon }}</span>
+        <span style="font-size:13.5px; line-height:1.45; color:var(--subtle); flex:1;">{{ t.msg }}</span>
+        <span class="toast-x" aria-hidden="true" style="flex-shrink:0; color:var(--faint); font-size:12px; line-height:1; opacity:.5; transition:opacity .18s ease, color .18s ease;">✕</span>
+      </button>
+    </sc-for>
+  </div>
+
+  <!-- preview switcher (design-time only) -->
+  <div style="position:fixed; bottom:18px; left:18px; z-index:30;">
+    <div class="seg" role="group" aria-label="Preview state">
+      <button data-on="{{ isList }}" onClick="{{ vList }}">List</button>
+      <button data-on="{{ isLoading }}" onClick="{{ vLoading }}">Loading</button>
+      <button data-on="{{ isError }}" onClick="{{ vError }}">Error</button>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{}">
+class Component extends DCLogic {
+  state = {
+    theme: 'light',
+    view: 'list',              // list | loading | error
+    users: [
+      { id: 1, email: 'akli@akli.dev', role: 'Admin', status: 'Confirmed', self: true },
+      { id: 2, email: 'sam.rivera@gmail.com', role: 'Contributor', status: 'Confirmed', self: false },
+      { id: 3, email: 'j.okafor@outlook.com', role: 'Contributor', status: 'Pending', self: false },
+      { id: 4, email: 'mei.tanaka@proton.me', role: 'Admin', status: 'Confirmed', self: false }
+    ],
+    invite: { open: false, email: '', role: 'Contributor', error: '', sending: false },
+    removeId: null,
+    toasts: []
+  };
+
+  email = 'akli@akli.dev';
+  _toastSeq = 0; _timers = [];
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') this.setState({ theme: saved });
+      else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) this.setState({ theme: 'dark' });
+    } catch (e) {}
+  }
+  componentWillUnmount() { this._timers.forEach(clearTimeout); }
+  later(fn, ms) { const t = setTimeout(fn, ms); this._timers.push(t); return t; }
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  toast(type, msg) {
+    const id = ++this._toastSeq;
+    this.setState(s => ({ toasts: s.toasts.concat([{ id, type, msg }]) }));
+    this.later(() => this.dismiss(id), 3600);
+  }
+  dismiss = (id) => this.setState(s => ({ toasts: s.toasts.filter(t => t.id !== id) }));
+
+  // ---- invite ----
+  openInvite = () => this.setState({ invite: { open: true, email: '', role: 'Contributor', error: '', sending: false } });
+  cancelInvite = () => this.setState(s => ({ invite: Object.assign({}, s.invite, { open: false, sending: false }) }));
+  onInviteEmail = (e) => this.setState(s => ({ invite: Object.assign({}, s.invite, { email: e.target.value, error: '' }) }));
+  pickRole = (role) => this.setState(s => ({ invite: Object.assign({}, s.invite, { role }) }));
+
+  sendInvite = (e) => {
+    if (e && e.preventDefault) e.preventDefault();
+    const inv = this.state.invite;
+    const email = inv.email.trim();
+    const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!re.test(email)) return this.setState(s => ({ invite: Object.assign({}, s.invite, { error: 'Enter a valid email address.' }) }));
+    if (this.state.users.some(u => u.email.toLowerCase() === email.toLowerCase()))
+      return this.setState(s => ({ invite: Object.assign({}, s.invite, { error: 'A user with this email already exists.' }) }));
+
+    this.setState(s => ({ invite: Object.assign({}, s.invite, { sending: true, error: '' }) }));
+    this.later(() => {
+      this.setState(s => ({
+        users: s.users.concat([{ id: Date.now(), email, role: inv.role, status: 'Pending', self: false }]),
+        invite: { open: false, email: '', role: 'Contributor', error: '', sending: false }
+      }));
+      this.toast('success', 'Invite sent to ' + email + '.');
+    }, 1100);
+  };
+
+  // ---- remove ----
+  askRemove = (id) => this.setState({ removeId: id });
+  cancelRemove = () => this.setState({ removeId: null });
+  confirmRemove = () => {
+    const u = this.state.users.find(x => x.id === this.state.removeId);
+    this.setState(s => ({ users: s.users.filter(x => x.id !== s.removeId), removeId: null }));
+    if (u) this.toast('success', 'User ' + u.email + ' removed.');
+  };
+  stop = (e) => { if (e && e.stopPropagation) e.stopPropagation(); };
+  retry = () => { this.setState({ view: 'loading' }); this.later(() => this.setState({ view: 'list' }), 1000); };
+  logout = () => this.toast('info', 'Signing out…');
+
+  vList = () => this.setState({ view: 'list' });
+  vLoading = () => this.setState({ view: 'loading' });
+  vError = () => this.setState({ view: 'error' });
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    const view = this.state.view;
+    const inv = this.state.invite;
+
+    const users = this.state.users.map(u => ({
+      email: u.email,
+      initial: (u.email[0] || '?').toUpperCase(),
+      role: u.role, isSelf: u.self,
+      roleBg: u.role === 'Admin' ? 'var(--accent-bg)' : 'var(--surf)',
+      roleFg: u.role === 'Admin' ? 'var(--accent)' : 'var(--muted)',
+      status: u.status,
+      statusFg: u.status === 'Confirmed' ? 'var(--green)' : 'var(--amber)',
+      removable: !u.self,
+      onRemove: () => this.askRemove(u.id)
+    }));
+
+    const tStyle = { success:{accent:'var(--green)',dot:'var(--green-bg)',icon:'\u2713'}, error:{accent:'var(--danger)',dot:'var(--danger-bg)',icon:'\u2715'}, info:{accent:'var(--accent)',dot:'color-mix(in srgb, var(--accent) 14%, transparent)',icon:'\u203a'} };
+    const toasts = this.state.toasts.map(t => Object.assign({}, tStyle[t.type] || tStyle.info, { msg: t.msg, dismiss: () => this.dismiss(t.id) }));
+
+    const rmUser = this.state.users.find(x => x.id === this.state.removeId);
+    const count = this.state.users.length;
+
+    return {
+      theme: this.state.theme, email: this.email,
+      toggle: this.toggle, toggleIcon: isDark ? '\u2600' : '\u263e',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode',
+      logout: this.logout,
+
+      subtitle: count + (count === 1 ? ' person has access' : ' people have access'),
+      isList: view === 'list', isLoading: view === 'loading', isError: view === 'error',
+      showInviteButton: view === 'list' && !inv.open,
+      users,
+
+      openInvite: this.openInvite, cancelInvite: this.cancelInvite,
+      inviteOpen: inv.open && view === 'list',
+      inviteEmail: inv.email, onInviteEmail: this.onInviteEmail,
+      hasInviteError: !!inv.error, inviteError: inv.error,
+      emailErrClass: inv.error ? 'err' : '',
+      roleContributor: inv.role === 'Contributor', roleAdmin: inv.role === 'Admin',
+      contribBg: inv.role === 'Contributor' ? 'var(--accent)' : 'transparent',
+      contribFg: inv.role === 'Contributor' ? (isDark ? '#11151f' : '#fff') : 'var(--muted)',
+      adminBg: inv.role === 'Admin' ? 'var(--accent)' : 'transparent',
+      adminFg: inv.role === 'Admin' ? (isDark ? '#11151f' : '#fff') : 'var(--muted)',
+      pickContributor: () => this.pickRole('Contributor'), pickAdmin: () => this.pickRole('Admin'),
+      inviteSending: inv.sending, sendDisabled: inv.sending,
+      sendLabel: inv.sending ? 'Sending…' : 'Send invite',
+      roleHint: inv.role === 'Admin'
+        ? 'Admins can manage recipes and users, including inviting and removing people.'
+        : 'Contributors can create and manage recipes, but can\u2019t manage users.',
+      sendInvite: this.sendInvite,
+
+      removeOpen: !!rmUser, removeEmail: rmUser ? rmUser.email : '',
+      cancelRemove: this.cancelRemove, confirmRemove: this.confirmRemove, stop: this.stop,
+      retry: this.retry,
+      toasts,
+
+      vList: this.vList, vLoading: this.vLoading, vError: this.vError
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/Apps.dc.html
+++ b/docs/design/paper/pages/Apps.dc.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --surf:#F4F1EA; --hover:rgba(0,0,0,0.022);
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --ring:rgba(0,0,0,0.06);
+    --accent:#1F66E0;
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --surf:#1C1A15; --hover:rgba(255,255,255,0.04);
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --ring:rgba(255,255,255,0.08);
+    --accent:#6BA0FF;
+  }
+  .lnk { transition: color .25s ease, opacity .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .btn { transition: background .22s ease, color .22s ease, border-color .22s ease; text-decoration:none; }
+  .btn-solid:hover { background: var(--accent); color:#fff; }
+  .btn-outline:hover { border-color: var(--accent); color: var(--accent); background: var(--hover); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius:6px; }
+  [data-sticky="true"] .site-header {
+    position: sticky; top:0; z-index:20;
+    background: color-mix(in srgb, var(--bg) 82%, transparent);
+    backdrop-filter: saturate(140%) blur(10px);
+    -webkit-backdrop-filter: saturate(140%) blur(10px);
+  }
+  .skip { position:absolute; left:-9999px; top:0; background:var(--btn-bg); color:var(--btn-fg); padding:10px 16px; border-radius:8px; z-index:50; }
+  .skip:focus { left:16px; top:16px; }
+  .app-card { display:flex; flex-direction:column; text-decoration:none; color:inherit; background:var(--bg); border:1px solid var(--line); border-radius:18px; overflow:hidden; transition: transform .35s cubic-bezier(.2,.7,.2,1), box-shadow .35s ease, border-color .35s ease; }
+  .app-card:hover { transform: translateY(-5px); box-shadow: 0 18px 44px rgba(0,0,0,0.10); border-color: color-mix(in srgb, var(--accent) 35%, var(--line)); }
+  .app-prev { transition: transform .55s cubic-bezier(.2,.7,.2,1); }
+  .app-card:hover .app-prev { transform: scale(1.035); }
+  .app-arrow { display:inline-block; transition: transform .3s ease; }
+  .app-card:hover .app-arrow { transform: translate(3px,-3px); }
+  .arrowx { display:inline-block; transition: transform .25s ease; }
+  .arrowx-host:hover .arrowx { transform: translateX(3px); }
+  @keyframes riseIn { from { transform: translateY(12px); opacity:0; } to { transform:none; opacity:1; } }
+  .rise { animation: riseIn .6s cubic-bezier(.2,.7,.2,1) both; }
+  @media (prefers-reduced-motion: reduce) { .rise{animation:none;} .app-card,.app-prev{transition:none;} .app-card:hover{transform:none;} .app-card:hover .app-prev{transform:none;} html{scroll-behavior:auto;} }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" data-sticky="{{ sticky }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased;">
+  <a class="skip" href="#main">Skip to content</a>
+
+  <!-- ===== HEADER ===== -->
+  <header class="site-header">
+    <div style="max-width:1080px; margin:0 auto; padding:22px clamp(20px,5vw,28px); display:flex; align-items:center; justify-content:space-between;">
+      <a class="lnk" href="/" style="font-size:15px; font-weight:600; letter-spacing:-0.01em;">Akli Aissat</a>
+      <nav aria-label="Primary" style="display:flex; align-items:center; gap:clamp(18px,4vw,28px); font-size:14px; color:var(--muted);">
+        <a class="lnk" href="https://akli.dev/apps" style="color:var(--text); font-weight:500;">Apps</a>
+        <a class="lnk" href="https://akli.dev/recipes">Recipes</a>
+        <a class="lnk" href="https://akli.dev/blog">Blog</a>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <!-- ===== HERO ===== -->
+    <section style="max-width:720px; margin:0 auto; padding:clamp(64px,11vw,108px) 24px clamp(40px,6vw,60px);">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.16em; color:var(--faint); text-transform:uppercase; margin-bottom:22px;">Apps &amp; Experiments</div>
+      <h1 style="font-size:clamp(40px,7vw,56px); font-weight:600; line-height:1.04; letter-spacing:-0.03em; margin:0 0 22px;">Things I built to<br>figure something out.</h1>
+      <p style="font-size:clamp(17px,2.6vw,19px); line-height:1.65; color:var(--muted); margin:0; max-width:54ch;">A collection of interactive experiments and side projects. Most of these started as a way to learn something new — or to answer a question I had about how things actually work.</p>
+    </section>
+
+    <!-- ===== APPS GRID ===== -->
+    <section style="max-width:1080px; margin:0 auto; padding:clamp(20px,4vw,36px) 24px clamp(72px,10vw,108px);">
+      <div style="display:flex; align-items:baseline; gap:12px; margin-bottom:26px; font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.06em; color:var(--faint);">
+        <span>{{ countLabel }}</span>
+        <span style="flex:1; height:1px; background:var(--line);"></span>
+      </div>
+      <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(320px, 1fr)); gap:clamp(20px,3vw,28px);">
+        <sc-for list="{{ apps }}" as="app" hint-placeholder-count="2">
+          <a class="app-card" href="{{ app.href }}">
+            <div style="position:relative; aspect-ratio:16/10; overflow:hidden; background:var(--surf); border-bottom:1px solid var(--line);">
+              <div class="app-prev" style="position:absolute; inset:0; opacity:0.09; color:var(--text); background-image:{{ app.preview }}; background-size:18px 18px;"></div>
+              <div style="position:absolute; inset:0; display:flex; align-items:center; justify-content:center;">
+                <span style="font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.14em; text-transform:uppercase; color:var(--faint); background:color-mix(in srgb, var(--bg) 86%, transparent); padding:7px 12px; border-radius:999px; border:1px solid var(--line);">{{ app.shot }}</span>
+              </div>
+              <div style="position:absolute; top:14px; left:14px; font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.1em; color:var(--muted); background:color-mix(in srgb, var(--bg) 80%, transparent); padding:5px 10px; border-radius:7px;">{{ app.tag }}</div>
+            </div>
+            <div style="padding:24px 26px 28px; display:flex; flex-direction:column; flex:1;">
+              <div style="display:flex; align-items:baseline; justify-content:space-between; gap:14px; margin-bottom:10px;">
+                <span style="font-size:23px; font-weight:600; letter-spacing:-0.02em; line-height:1.2;">{{ app.title }}</span>
+                <span class="app-arrow" style="font-size:18px; color:var(--accent); flex-shrink:0;">↗</span>
+              </div>
+              <p style="font-size:15px; line-height:1.6; color:var(--muted); margin:0 0 20px;">{{ app.desc }}</p>
+              <div style="margin-top:auto; display:flex; align-items:center; gap:8px; font-size:13px; font-weight:600; color:var(--accent);">
+                <span>Open app</span>
+              </div>
+            </div>
+          </a>
+        </sc-for>
+      </div>
+
+      <!-- ===== MORE SOON ===== -->
+      <div style="margin-top:clamp(28px,4vw,40px); border:1px dashed var(--btn-border); border-radius:18px; padding:clamp(28px,5vw,40px); text-align:center;">
+        <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.12em; text-transform:uppercase; color:var(--faint); margin-bottom:10px;">In progress</div>
+        <p style="font-size:16px; line-height:1.6; color:var(--muted); margin:0 auto 18px; max-width:46ch;">More experiments are in the works. If you want to follow along, I usually write up the interesting ones on the blog.</p>
+        <a class="lnk arrowx-host" href="https://akli.dev/blog" style="display:inline-flex; align-items:center; gap:7px; font-size:14px; font-weight:600; color:var(--accent);">Read the blog <span class="arrowx">→</span></a>
+      </div>
+    </section>
+  </main>
+
+  <!-- ===== FOOTER ===== -->
+  <footer style="border-top:1px solid var(--line);">
+    <div style="max-width:1080px; margin:0 auto; padding:clamp(34px,5vw,44px) clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between;">
+      <nav aria-label="Elsewhere" style="display:flex; flex-direction:column; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:var(--text);">Elsewhere</span>
+        <div style="display:flex; flex-wrap:wrap; gap:20px; font-size:14px; color:var(--muted);">
+          <a class="lnk" href="https://github.com/vandelay87">GitHub</a>
+          <a class="lnk" href="https://www.linkedin.com/in/akli-aissat-b08119115/">LinkedIn</a>
+          <a class="lnk" href="mailto:akliaissat@outlook.com?subject=Hello">Email</a>
+        </div>
+      </nav>
+      <span style="font-size:13px; font-weight:500; color:var(--muted);">akli.dev</span>
+    </div>
+  </footer>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{
+  &quot;stickyNav&quot;: { &quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: true, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;Layout&quot; }
+}">
+class Component extends DCLogic {
+  state = { theme: 'light' };
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') {
+        this.setState({ theme: saved });
+      } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        this.setState({ theme: 'dark' });
+      }
+    } catch (e) {}
+  }
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    const dots = 'radial-gradient(currentColor 1.1px, transparent 1.1px)';
+    const stripe = 'repeating-linear-gradient(135deg, currentColor 0 1px, transparent 1px 9px)';
+    const apps = [
+      {
+        title: 'Pokédex',
+        desc: 'A searchable encyclopedia of Gen 1 Pokémon, styled after the classic Game Boy Color Pokédex.',
+        href: 'https://akli.dev/apps/pokedex',
+        tag: 'React · AWS',
+        shot: 'screenshot — pokédex',
+        preview: 'radial-gradient(currentColor 1.2px, transparent 1.2px)'
+      },
+      {
+        title: 'Sand box',
+        desc: 'A real-time particle physics simulation of falling sand grains on a black canvas.',
+        href: 'https://akli.dev/apps/sand-box',
+        tag: 'Canvas · Physics',
+        shot: 'screenshot — sand box',
+        preview: 'repeating-linear-gradient(135deg, currentColor 0 1px, transparent 1px 9px)'
+      }
+    ];
+    return {
+      apps,
+      countLabel: apps.length + (apps.length === 1 ? ' experiment' : ' experiments'),
+      theme: this.state.theme,
+      sticky: String(this.props.stickyNav ?? true),
+      toggle: this.toggle,
+      toggleIcon: isDark ? '☀' : '☾',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode'
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/Blog Post.dc.html
+++ b/docs/design/paper/pages/Blog Post.dc.html
@@ -1,0 +1,451 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --surf:#F4F1EA; --hover:rgba(0,0,0,0.022);
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --ring:rgba(0,0,0,0.06); --accent:#1F66E0;
+    --code-bg:#F7F4ED; --code-head:#EFEADF; --code-fg:#33302A;
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --surf:#1C1A15; --hover:rgba(255,255,255,0.04);
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --ring:rgba(255,255,255,0.08); --accent:#6BA0FF;
+    --code-bg:#1A1813; --code-head:#221F18; --code-fg:#D7D1C5;
+  }
+  .lnk { transition: color .25s ease, opacity .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius:6px; }
+  [data-sticky="true"] .site-header {
+    position: sticky; top:0; z-index:20;
+    background: color-mix(in srgb, var(--bg) 82%, transparent);
+    backdrop-filter: saturate(140%) blur(10px);
+    -webkit-backdrop-filter: saturate(140%) blur(10px);
+  }
+  .skip { position:absolute; left:-9999px; top:0; background:var(--btn-bg); color:var(--btn-fg); padding:10px 16px; border-radius:8px; z-index:50; }
+  .skip:focus { left:16px; top:16px; }
+  .arrowx { display:inline-block; transition: transform .25s ease; }
+  .back-link:hover .arrowx { transform: translateX(-3px); }
+  .tag-chip { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.04em; color:var(--muted); border:1px solid var(--line); background:var(--surf); padding:5px 10px; border-radius:7px; text-decoration:none; transition: color .2s ease, border-color .2s ease; }
+  .tag-chip:hover { border-color: var(--accent); color: var(--accent); }
+  .prose p { font-size:18px; line-height:1.75; color:var(--subtle); margin:0 0 22px; }
+  .prose h2 { font-size:clamp(23px,3.2vw,27px); font-weight:600; letter-spacing:-0.02em; line-height:1.25; color:var(--text); margin:54px 0 18px; }
+  .prose strong { color:var(--text); font-weight:600; }
+  .prose a { color:var(--accent); text-decoration:none; }
+  .prose a:hover { text-decoration:underline; }
+  .code { margin:28px 0; border:1px solid var(--line); border-radius:12px; overflow:hidden; background:var(--code-bg); }
+  .code-head { font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.02em; color:var(--muted); padding:8px 10px 8px 16px; border-bottom:1px solid var(--line); background:var(--code-head); display:flex; align-items:center; justify-content:space-between; gap:12px; }
+  .code-copy { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.04em; color:var(--muted); background:transparent; border:1px solid var(--line); padding:3px 9px; border-radius:6px; cursor:pointer; flex-shrink:0; transition: color .2s ease, border-color .2s ease, background .2s ease; }
+  .code-copy:hover { color:var(--accent); border-color:var(--accent); background:var(--hover); }
+  .code-copy.copied { color:var(--accent); border-color:var(--accent); }
+  .code pre { margin:0; padding:18px 16px; overflow-x:auto; font-family:'JetBrains Mono',monospace; font-size:13px; line-height:1.7; color:var(--code-fg); white-space:pre; -webkit-font-smoothing:auto; }
+  .callout { margin:30px 0; border:1px solid var(--line); background:var(--surf); border-radius:12px; padding:18px 20px; display:flex; gap:14px; align-items:flex-start; }
+  .callout-emoji { font-size:17px; line-height:1.5; flex-shrink:0; }
+  .callout-label { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.14em; text-transform:uppercase; margin-bottom:7px; }
+  .callout[data-type="tip"] { background: color-mix(in srgb, #1F8A5B 6%, var(--surf)); border-color: color-mix(in srgb, #1F8A5B 24%, var(--line)); }
+  .callout[data-type="tip"] .callout-label { color:#1F8A5B; }
+  [data-theme="dark"] .callout[data-type="tip"] .callout-label { color:#62C08D; }
+  .callout[data-type="warning"] { background: color-mix(in srgb, #C2810C 7%, var(--surf)); border-color: color-mix(in srgb, #C2810C 26%, var(--line)); }
+  .callout[data-type="warning"] .callout-label { color:#A66E0A; }
+  [data-theme="dark"] .callout[data-type="warning"] .callout-label { color:#E0A93B; }
+  .callout[data-type="info"] { background: color-mix(in srgb, var(--accent) 6%, var(--surf)); border-color: color-mix(in srgb, var(--accent) 24%, var(--line)); }
+  .callout[data-type="info"] .callout-label { color:var(--accent); }
+  .share-btn { display:inline-flex; align-items:center; gap:8px; font-size:13.5px; font-weight:500; color:var(--text); text-decoration:none; border:1px solid var(--btn-border); padding:9px 16px; border-radius:999px; transition: border-color .2s ease, color .2s ease, background .2s ease; }
+  .share-btn:hover { border-color: var(--accent); color: var(--accent); background: var(--hover); }
+  .rel:hover .rel-title { color: var(--accent); }
+  .rel-title { transition: color .25s ease; }
+  @media (prefers-reduced-motion: reduce) { html{scroll-behavior:auto;} *{transition:none !important;} }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" data-sticky="{{ sticky }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased;">
+  <a class="skip" href="#main">Skip to content</a>
+
+  <!-- ===== HEADER ===== -->
+  <header class="site-header">
+    <div style="max-width:1080px; margin:0 auto; padding:22px clamp(20px,5vw,28px); display:flex; align-items:center; justify-content:space-between;">
+      <a class="lnk" href="/" style="font-size:15px; font-weight:600; letter-spacing:-0.01em;">Akli Aissat</a>
+      <nav aria-label="Primary" style="display:flex; align-items:center; gap:clamp(18px,4vw,28px); font-size:14px; color:var(--muted);">
+        <a class="lnk" href="https://akli.dev/apps">Apps</a>
+        <a class="lnk" href="https://akli.dev/recipes">Recipes</a>
+        <a class="lnk" href="https://akli.dev/blog" style="color:var(--text); font-weight:500;">Blog</a>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <article style="max-width:680px; margin:0 auto; padding:clamp(40px,7vw,72px) 24px clamp(64px,9vw,96px);">
+
+      <!-- back -->
+      <a class="lnk back-link" href="https://akli.dev/blog" style="display:inline-flex; align-items:center; gap:7px; font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.04em; color:var(--muted); margin-bottom:36px;"><span class="arrowx">←</span> All posts</a>
+
+      <!-- header -->
+      <header>
+        <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.04em; color:var(--faint); margin-bottom:18px;">7 April 2026 · 4 min read</div>
+        <h1 style="font-size:clamp(32px,5.6vw,46px); font-weight:600; line-height:1.08; letter-spacing:-0.03em; margin:0 0 24px;">Building a Pokédex with React and AWS</h1>
+        <div style="display:flex; flex-wrap:wrap; gap:8px;">
+          <a class="tag-chip" href="https://akli.dev/blog?tag=react">react</a>
+          <a class="tag-chip" href="https://akli.dev/blog?tag=aws">aws</a>
+          <a class="tag-chip" href="https://akli.dev/blog?tag=cdk">cdk</a>
+          <a class="tag-chip" href="https://akli.dev/blog?tag=dynamodb">dynamodb</a>
+          <a class="tag-chip" href="https://akli.dev/blog?tag=lambda">lambda</a>
+          <a class="tag-chip" href="https://akli.dev/blog?tag=typescript">typescript</a>
+        </div>
+      </header>
+
+      <!-- hero image -->
+      <figure style="margin:40px 0 8px;">
+        <img src="https://akli.dev/images/blog/pokedex-desktop.webp" alt="Pokédex app showing the Pokémon list and detail panel" loading="eager" style="display:block; width:100%; height:auto; border-radius:14px; border:1px solid var(--line);">
+        <figcaption style="text-align:center; font-size:14px; font-style:italic; color:var(--faint); margin-top:14px;">The finished Pokédex, running on akli.dev</figcaption>
+      </figure>
+
+      <div class="prose">
+        <p>I built a full-stack Pokédex as a portfolio project. It runs on AWS, costs almost nothing to host, and looks like a Game Boy Color screen. The frontend is React 19 with TypeScript. The backend is API Gateway, Lambda, and DynamoDB, all defined in CDK.</p>
+        <p>You can try it at <a href="https://akli.dev/apps/pokedex">akli.dev/apps/pokedex</a>.</p>
+
+        <h2>The CDK stacks</h2>
+        <p>The infrastructure lives in a separate repo from the frontend. The Pokédex spans three of the four stacks because each has different deployment constraints.</p>
+
+        <!-- file tree -->
+        <div class="code">
+          <div class="code-head">akli-infrastructure/</div>
+          <pre>bin/
+  akli-infrastructure.ts
+lib/
+  certificate-stack.ts
+  pokedex-stack.ts
+  api-stack.ts
+lambda/
+  pokedex-handler.ts
+  seed-pokemon.ts
+data/
+  pokemon.json</pre>
+        </div>
+
+        <!-- architecture diagram -->
+        <div data-om-raster="1" style="margin:32px 0; display:grid; grid-template-columns:repeat(auto-fit, minmax(200px,1fr)); gap:14px;">
+          <div style="border:1px solid var(--line); border-radius:12px; background:var(--surf); padding:16px; display:flex; flex-direction:column; gap:12px;">
+            <div>
+              <div style="font-size:14px; font-weight:600; letter-spacing:-0.01em;">CertificateStack</div>
+              <div style="font-family:'JetBrains Mono',monospace; font-size:10.5px; color:var(--accent); margin-top:3px;">us-east-1</div>
+            </div>
+            <div style="display:flex; flex-direction:column; gap:8px;">
+              <div style="font-size:12.5px; color:var(--muted); line-height:1.4;">Route 53 hosted zone</div>
+              <div style="font-size:12.5px; color:var(--muted); line-height:1.4;">ACM cert · akli.dev</div>
+              <div style="font-size:12.5px; color:var(--muted); line-height:1.4;">ACM cert · api.akli.dev</div>
+            </div>
+          </div>
+          <div style="border:1px solid var(--line); border-radius:12px; background:var(--surf); padding:16px; display:flex; flex-direction:column; gap:12px;">
+            <div>
+              <div style="font-size:14px; font-weight:600; letter-spacing:-0.01em;">PokedexStack</div>
+              <div style="font-family:'JetBrains Mono',monospace; font-size:10.5px; color:var(--accent); margin-top:3px;">eu-west-2</div>
+            </div>
+            <div style="display:flex; flex-direction:column; gap:8px;">
+              <div style="font-size:12.5px; color:var(--muted); line-height:1.4;">DynamoDB · pokedex-pokemon</div>
+              <div style="font-size:12.5px; color:var(--muted); line-height:1.4;">Lambda handler · Node 22</div>
+              <div style="font-size:12.5px; color:var(--muted); line-height:1.4;">Seeder Lambda · custom resource</div>
+              <div style="font-size:12.5px; color:var(--muted); line-height:1.4;">HTTP API Gateway v2</div>
+            </div>
+          </div>
+          <div style="border:1px solid var(--line); border-radius:12px; background:var(--surf); padding:16px; display:flex; flex-direction:column; gap:12px;">
+            <div>
+              <div style="font-size:14px; font-weight:600; letter-spacing:-0.01em;">ApiStack</div>
+              <div style="font-family:'JetBrains Mono',monospace; font-size:10.5px; color:var(--accent); margin-top:3px;">eu-west-2</div>
+            </div>
+            <div style="display:flex; flex-direction:column; gap:8px;">
+              <div style="font-size:12.5px; color:var(--muted); line-height:1.4;">CloudFront · api.akli.dev</div>
+              <div style="font-size:12.5px; color:var(--muted); line-height:1.4;">Route 53 record · api.akli.dev</div>
+            </div>
+          </div>
+        </div>
+
+        <p><strong>CertificateStack</strong> deploys to <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">us-east-1</code>. CloudFront requires certificates in that region, so this stack owns the Route 53 hosted zone and ACM certificates. The other stacks consume its outputs through CDK's cross-region references.</p>
+        <p><strong>PokedexStack</strong> deploys to <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">eu-west-2</code>. It creates the DynamoDB table, the Lambda handler, and the HTTP API Gateway. It also seeds the database automatically on every deploy.</p>
+        <p><strong>ApiStack</strong>, also in <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">eu-west-2</code>, puts a CloudFront distribution in front of the API Gateway, with a custom domain at <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">api.akli.dev</code>. This stack exists so I can add future APIs as additional cache behaviours on the same distribution.</p>
+        <p>The stacks reference each other through props. The CDK app wires them together:</p>
+
+        <div class="code">
+          <div class="code-head"><span>bin/akli-infrastructure.ts</span><button class="code-copy" type="button" aria-label="Copy code">Copy</button></div>
+          <pre>const pokedexStack = new PokedexStack(app, 'PokedexStack', {
+  env: { account, region: 'eu-west-2' },
+})
+
+new ApiStack(app, 'ApiStack', {
+  env: { account, region: 'eu-west-2' },
+  crossRegionReferences: true,
+  apiCertificate: certStack.apiCertificate,
+  hostedZone: certStack.hostedZone,
+  pokedexApiUrl: pokedexStack.httpApi.apiEndpoint,
+})</pre>
+        </div>
+
+        <p>CDK stack dependencies are just TypeScript props. No SSM parameter lookups, no hardcoded ARNs.</p>
+
+        <h2>One Lambda, two routes</h2>
+        <p>The API uses HTTP API Gateway v2, which is cheaper and simpler for a read-only service like this. A single Lambda function handles both routes. API Gateway v2 passes a <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">routeKey</code> string, so the handler just matches against it:</p>
+
+        <div class="code">
+          <div class="code-head"><span>lambda/pokedex-handler.ts</span><button class="code-copy" type="button" aria-label="Copy code">Copy</button></div>
+          <pre>const ROUTE_LIST = 'GET /pokedex/pokemon'
+const ROUTE_DETAIL = 'GET /pokedex/pokemon/{id}'
+
+export const handler = async (
+  event: APIGatewayProxyEventV2,
+): Promise&lt;APIGatewayProxyStructuredResultV2&gt; =&gt; {
+  const routeKey = event.routeKey
+
+  if (routeKey === ROUTE_LIST) {
+    const result = await client.send(new ScanCommand({
+      TableName: TABLE_NAME,
+      ProjectionExpression: 'id, #n, types, sprite',
+      ExpressionAttributeNames: { '#n': 'name' },
+    }))
+    const items = (result.Items || []).map(item =&gt; unmarshall(item))
+    return jsonResponse(200, { pokemon: items, count: items.length, nextToken: null })
+  }
+
+  if (routeKey === ROUTE_DETAIL) {
+    const id = Number(event.pathParameters?.id)
+    if (isNaN(id)) {
+      return jsonResponse(404, { error: 'Pokemon not found' })
+    }
+
+    const result = await client.send(new GetItemCommand({
+      TableName: TABLE_NAME,
+      Key: { id: { N: String(id) } },
+    }))
+
+    if (!result.Item) {
+      return jsonResponse(404, { error: 'Pokemon not found' })
+    }
+
+    return jsonResponse(200, unmarshall(result.Item))
+  }
+}</pre>
+        </div>
+
+        <p>The list endpoint uses a <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">ProjectionExpression</code> to return only the fields the list view needs: id, name, types, and sprite URL. The detail endpoint returns the full item. This keeps the list payload small.</p>
+
+        <h2>Automated data seeding</h2>
+        <p>The Pokédex data comes from a static JSON file checked into the infrastructure repo. I didn't want a manual “run this script after deploying” step, so I used a CDK Custom Resource to seed DynamoDB automatically.</p>
+        <p>The interesting part is change detection. CDK computes an MD5 hash of <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">pokemon.json</code> at synth time and passes it as a property on the Custom Resource:</p>
+
+        <div class="code">
+          <div class="code-head"><span>lib/pokedex-stack.ts</span><button class="code-copy" type="button" aria-label="Copy code">Copy</button></div>
+          <pre>const pokemonDataHash = crypto
+  .createHash('md5')
+  .update(fs.readFileSync(pokemonDataPath, 'utf-8'))
+  .digest('hex')
+
+new CustomResource(this, 'SeedPokemonResource', {
+  serviceToken: seedProvider.serviceToken,
+  properties: {
+    DataHash: pokemonDataHash,
+  },
+})</pre>
+        </div>
+
+        <p>When the hash changes, CloudFormation treats it as a resource update and invokes the seeder Lambda. When the hash stays the same, nothing happens. The seeder uses <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">BatchWriteItem</code> with exponential backoff, splitting the data into batches of 25 — DynamoDB's limit per request.</p>
+
+        <!-- callout — type can be tip | warning | info -->
+        <div class="callout" data-type="tip">
+          <span class="callout-emoji" aria-hidden="true">💡</span>
+          <div>
+            <div class="callout-label">Tip</div>
+            <p style="font-size:15.5px; line-height:1.65; color:var(--subtle); margin:0;">CDK Custom Resources are great for one-time setup tasks. The <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--bg); padding:2px 6px; border-radius:5px;">properties</code> trick gives you free change detection.</p>
+          </div>
+        </div>
+
+        <h2>Frontend caching with useRef</h2>
+        <p>The frontend uses two hooks for data fetching. <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">usePokemonList</code> fetches all summaries on mount. <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">usePokemonDetail</code> fetches a single Pokémon's full data when the user selects one.</p>
+        <p>The detail hook caches responses in a <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">useRef</code> so clicking a previously viewed Pokémon is instant:</p>
+
+        <div class="code">
+          <div class="code-head"><span>src/hooks/usePokemonDetail.ts</span><button class="code-copy" type="button" aria-label="Copy code">Copy</button></div>
+          <pre>export const usePokemonDetail = (id: number | null) =&gt; {
+  const [detail, setDetail] = useState&lt;PokemonDetail | null&gt;(null)
+  const [loading, setLoading] = useState(false)
+  const cache = useRef&lt;Record&lt;number, PokemonDetail&gt;&gt;({})
+
+  useEffect(() =&gt; {
+    if (id === null) return
+
+    if (cache.current[id]) {
+      setDetail(cache.current[id])
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+
+    const load = async () =&gt; {
+      const data = await fetchPokemonDetail(id)
+      if (!cancelled) {
+        cache.current[id] = data
+        setDetail(data)
+        setLoading(false)
+      }
+    }
+
+    load()
+    return () =&gt; { cancelled = true }
+  }, [id])
+
+  return { detail, loading }
+}</pre>
+        </div>
+
+        <p><code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">useRef</code> survives re-renders without triggering them. The <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">cancelled</code> flag prevents state updates on unmounted components.</p>
+
+        <h2>The Game Boy Color look</h2>
+        <p>I wanted the app to feel like a handheld console, not a typical web app. A few CSS decisions carry most of the weight.</p>
+        <p>The pixel font is <strong>Press Start 2P</strong>, loaded as a local woff2 file. Every label, stat name, and Pokémon name uses it. The body text falls back to <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">Courier New</code> for readability.</p>
+        <p>Pokémon sprites use <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">image-rendering: pixelated</code> so they stay crisp at any size instead of getting blurry from bilinear filtering. Each Pokémon type gets its own colour token, with text colours precomputed to meet WCAG AA contrast against their backgrounds.</p>
+        <p>Stat bars animate in with a staggered delay. Each bar receives its index as a CSS custom property, and the animation delay is computed from it:</p>
+
+        <div class="code">
+          <div class="code-head"><span>src/components/StatBar/StatBar.module.css</span><button class="code-copy" type="button" aria-label="Copy code">Copy</button></div>
+          <pre>.fill {
+  width: var(--stat-width);
+  animation: fillBar 300ms ease-out forwards;
+  animation-delay: calc(var(--stat-index, 0) * 75ms);
+}</pre>
+        </div>
+
+        <p>The result: HP fills first, then Attack, then Defense, cascading down the list. The animation also respects <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">prefers-reduced-motion</code>.</p>
+
+        <h2>What I'd do differently</h2>
+        <p><strong>Pagination.</strong> The list endpoint does a full table scan. With 151 Pokémon that's fine. With 1000+ it wouldn't be. The response already includes a <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">nextToken</code> field (always <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">null</code> for now), so adding cursor-based pagination with DynamoDB's <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">LastEvaluatedKey</code> would be backwards-compatible.</p>
+        <p><strong>Shared types.</strong> The frontend and infrastructure repos define the same <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">Pokemon</code> interface independently. A shared package or a generated OpenAPI spec would keep them in sync.</p>
+        <p><strong>End-to-end CDK tests.</strong> I unit-tested the Lambda handlers and the stack synthesis, but I didn't test the Custom Resource seeder against a real DynamoDB table. A CDK integration test using <code style="font-family:'JetBrains Mono',monospace; font-size:0.88em; background:var(--surf); padding:2px 6px; border-radius:5px;">integ-runner</code> would catch issues that unit tests miss.</p>
+        <p>You can try the Pokédex at <a href="https://akli.dev/apps/pokedex">akli.dev/apps/pokedex</a>.</p>
+      </div>
+
+      <!-- share -->
+      <div style="margin-top:56px; padding-top:32px; border-top:1px solid var(--line);">
+        <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.06em; color:var(--faint); margin-bottom:16px;">Share this post</div>
+        <div style="display:flex; flex-wrap:wrap; gap:10px;">
+          <a class="share-btn" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fakli.dev%2Fblog%2Fbuilding-a-pokedex&text=Building%20a%20Pokedex%20with%20React%20and%20AWS" target="_blank" rel="noopener">Share on X</a>
+          <a class="share-btn" href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fakli.dev%2Fblog%2Fbuilding-a-pokedex" target="_blank" rel="noopener">Share on LinkedIn</a>
+        </div>
+      </div>
+
+      <!-- related -->
+      <div style="margin-top:48px;">
+        <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.06em; color:var(--faint); margin-bottom:16px;">Related posts</div>
+        <a class="rel lnk" href="https://akli.dev/blog/from-draft-to-published-recipe" style="display:block; border:1px solid var(--line); border-radius:14px; padding:22px 24px;">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--faint); margin-bottom:8px;">27 June 2026 · 7 min read</div>
+          <div class="rel-title" style="font-size:19px; font-weight:600; letter-spacing:-0.02em; color:var(--text);">From an Empty Draft to a Published Recipe</div>
+        </a>
+      </div>
+
+    </article>
+  </main>
+
+  <!-- ===== FOOTER ===== -->
+  <footer style="border-top:1px solid var(--line);">
+    <div style="max-width:1080px; margin:0 auto; padding:clamp(34px,5vw,44px) clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between;">
+      <nav aria-label="Elsewhere" style="display:flex; flex-direction:column; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:var(--text);">Elsewhere</span>
+        <div style="display:flex; flex-wrap:wrap; gap:20px; font-size:14px; color:var(--muted);">
+          <a class="lnk" href="https://github.com/vandelay87">GitHub</a>
+          <a class="lnk" href="https://www.linkedin.com/in/akli-aissat-b08119115/">LinkedIn</a>
+          <a class="lnk" href="mailto:akliaissat@outlook.com?subject=Hello">Email</a>
+        </div>
+      </nav>
+      <span style="font-size:13px; font-weight:500; color:var(--muted);">akli.dev</span>
+    </div>
+  </footer>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{
+  &quot;stickyNav&quot;: { &quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: true, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;Layout&quot; }
+}">
+class Component extends DCLogic {
+  state = { theme: 'light' };
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') {
+        this.setState({ theme: saved });
+      } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        this.setState({ theme: 'dark' });
+      }
+    } catch (e) {}
+
+    this._onCopy = (e) => {
+      const btn = e.target.closest && e.target.closest('.code-copy');
+      if (!btn) return;
+      const block = btn.closest('.code');
+      const pre = block && block.querySelector('pre');
+      if (!pre) return;
+      const text = pre.innerText;
+      const done = () => {
+        btn.textContent = 'Copied';
+        btn.classList.add('copied');
+        clearTimeout(btn._t);
+        btn._t = setTimeout(() => { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 1600);
+      };
+      const fallback = () => {
+        try {
+          const ta = document.createElement('textarea');
+          ta.value = text; ta.style.position = 'fixed'; ta.style.top = '0'; ta.style.opacity = '0';
+          document.body.appendChild(ta); ta.focus(); ta.select(); document.execCommand('copy');
+          document.body.removeChild(ta); done();
+        } catch (err) {}
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done).catch(fallback);
+      } else {
+        fallback();
+      }
+    };
+    document.addEventListener('click', this._onCopy);
+  }
+
+  componentWillUnmount() {
+    if (this._onCopy) document.removeEventListener('click', this._onCopy);
+  }
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    return {
+      theme: this.state.theme,
+      sticky: String(this.props.stickyNav ?? true),
+      toggle: this.toggle,
+      toggleIcon: isDark ? '☀' : '☾',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode'
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/Blog.dc.html
+++ b/docs/design/paper/pages/Blog.dc.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --surf:#F4F1EA; --hover:rgba(0,0,0,0.022);
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --ring:rgba(0,0,0,0.06);
+    --accent:#1F66E0;
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --surf:#1C1A15; --hover:rgba(255,255,255,0.04);
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --ring:rgba(255,255,255,0.08);
+    --accent:#6BA0FF;
+  }
+  .lnk { transition: color .25s ease, opacity .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius:6px; }
+  [data-sticky="true"] .site-header {
+    position: sticky; top:0; z-index:20;
+    background: color-mix(in srgb, var(--bg) 82%, transparent);
+    backdrop-filter: saturate(140%) blur(10px);
+    -webkit-backdrop-filter: saturate(140%) blur(10px);
+  }
+  .skip { position:absolute; left:-9999px; top:0; background:var(--btn-bg); color:var(--btn-fg); padding:10px 16px; border-radius:8px; z-index:50; }
+  .skip:focus { left:16px; top:16px; }
+  .arrowx { display:inline-block; transition: transform .25s ease; }
+  .post { display:block; text-decoration:none; color:inherit; padding:clamp(30px,4vw,40px) clamp(14px,2vw,20px); margin:0 calc(-1 * clamp(14px,2vw,20px)); border-radius:14px; transition: background .25s ease; }
+  .post:hover { background: var(--hover); }
+  .post-title { transition: color .25s ease; }
+  .post:hover .post-title { color: var(--accent); }
+  .post:hover .arrowx { transform: translate(3px,-3px); }
+  .tag-chip { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.04em; color:var(--muted); border:1px solid var(--line); background:var(--surf); padding:5px 10px; border-radius:7px; cursor:pointer; transition: color .2s ease, border-color .2s ease, background .2s ease; }
+  .tag-chip:hover { border-color: var(--accent); color: var(--accent); }
+  .tag-chip[data-active="true"] { background: var(--accent); border-color: var(--accent); color:#fff; }
+  .clear-btn { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.04em; color:var(--muted); background:var(--surf); border:1px solid var(--line); padding:4px 10px; border-radius:7px; cursor:pointer; transition: color .2s ease, border-color .2s ease, background .2s ease; }
+  .clear-btn:hover { color:var(--accent); border-color:var(--accent); background:var(--hover); }
+  @media (prefers-reduced-motion: reduce) { html{scroll-behavior:auto;} .post,.post-title,.arrowx,.tag-chip{transition:none;} }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" data-sticky="{{ sticky }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased;">
+  <a class="skip" href="#main">Skip to content</a>
+
+  <!-- ===== HEADER ===== -->
+  <header class="site-header">
+    <div style="max-width:1080px; margin:0 auto; padding:22px clamp(20px,5vw,28px); display:flex; align-items:center; justify-content:space-between;">
+      <a class="lnk" href="/" style="font-size:15px; font-weight:600; letter-spacing:-0.01em;">Akli Aissat</a>
+      <nav aria-label="Primary" style="display:flex; align-items:center; gap:clamp(18px,4vw,28px); font-size:14px; color:var(--muted);">
+        <a class="lnk" href="https://akli.dev/apps">Apps</a>
+        <a class="lnk" href="https://akli.dev/recipes">Recipes</a>
+        <a class="lnk" href="https://akli.dev/blog" style="color:var(--text); font-weight:500;">Blog</a>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <!-- ===== HERO ===== -->
+    <section style="max-width:720px; margin:0 auto; padding:clamp(64px,11vw,108px) 24px clamp(36px,5vw,52px);">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.16em; color:var(--faint); text-transform:uppercase; margin-bottom:22px;">The Blog</div>
+      <h1 style="font-size:clamp(40px,7vw,56px); font-weight:600; line-height:1.04; letter-spacing:-0.03em; margin:0 0 22px;">Notes on building<br>things, and why.</h1>
+      <p style="font-size:clamp(17px,2.6vw,19px); line-height:1.65; color:var(--muted); margin:0; max-width:54ch;">Thoughts on building things, technical deep-dives, and the lessons you only learn the hard way. I write these mostly to document how I solved a problem, in case it's useful to someone hitting the same wall — or to me, six months from now.</p>
+    </section>
+
+    <!-- ===== POSTS ===== -->
+    <section style="max-width:720px; margin:0 auto; padding:0 24px clamp(64px,9vw,96px);">
+      <div style="display:flex; align-items:baseline; gap:12px; margin-bottom:18px; font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.06em; color:var(--faint);">
+        <span>{{ countLabel }}</span>
+        <sc-if value="{{ isFiltered }}" hint-placeholder-val="{{ false }}">
+          <span style="color:var(--accent);">{{ activeTag }}</span>
+          <button class="clear-btn" onClick="{{ clear }}">✕ clear</button>
+        </sc-if>
+        <span style="flex:1; height:1px; background:var(--line);"></span>
+      </div>
+
+      <!-- filter bar -->
+      <div role="group" aria-label="Filter posts by tag" style="display:flex; flex-wrap:wrap; gap:8px; margin-bottom:34px;">
+        <button class="tag-chip" data-active="{{ allActive }}" onClick="{{ clear }}">all</button>
+        <sc-for list="{{ allTags }}" as="tag" hint-placeholder-count="6">
+          <button class="tag-chip" data-active="{{ tag.active }}" onClick="{{ tag.on }}">{{ tag.label }}</button>
+        </sc-for>
+      </div>
+
+      <sc-for list="{{ posts }}" as="post" hint-placeholder-count="2">
+        <div class="post" style="border-bottom:1px solid var(--line);">
+          <a class="lnk" href="{{ post.href }}" style="display:block;">
+            <div style="display:flex; align-items:center; gap:10px; font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.04em; color:var(--faint); margin-bottom:14px;">
+              <span>{{ post.date }}</span>
+              <span aria-hidden="true">·</span>
+              <span>{{ post.read }}</span>
+            </div>
+            <div style="display:flex; align-items:flex-start; justify-content:space-between; gap:18px;">
+              <h2 class="post-title" style="font-size:clamp(24px,3.6vw,29px); font-weight:600; letter-spacing:-0.022em; line-height:1.18; margin:0; color:var(--text);">{{ post.title }}</h2>
+              <span class="arrowx" style="font-size:18px; color:var(--accent); flex-shrink:0; line-height:1.6;">↗</span>
+            </div>
+            <p style="font-size:16px; line-height:1.65; color:var(--muted); margin:14px 0 0; max-width:60ch;">{{ post.desc }}</p>
+          </a>
+          <div style="display:flex; flex-wrap:wrap; gap:8px; margin-top:20px;">
+            <sc-for list="{{ post.tags }}" as="tag" hint-placeholder-count="4">
+              <button class="tag-chip" data-active="{{ tag.active }}" onClick="{{ tag.on }}">{{ tag.label }}</button>
+            </sc-for>
+          </div>
+        </div>
+      </sc-for>
+
+      <sc-if value="{{ noResults }}" hint-placeholder-val="{{ false }}">
+        <div style="text-align:center; padding:clamp(48px,8vw,72px) 24px; color:var(--muted);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:13px; margin-bottom:10px;">No posts tagged <span style="color:var(--text);">{{ activeTag }}</span> yet.</div>
+          <button class="lnk" onClick="{{ clear }}" style="font-size:14px; font-weight:600; color:var(--accent); background:transparent; border:none; cursor:pointer;">Show all posts</button>
+        </div>
+      </sc-if>
+    </section>
+  </main>
+
+  <!-- ===== FOOTER ===== -->
+  <footer style="border-top:1px solid var(--line);">
+    <div style="max-width:1080px; margin:0 auto; padding:clamp(34px,5vw,44px) clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between;">
+      <nav aria-label="Elsewhere" style="display:flex; flex-direction:column; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:var(--text);">Elsewhere</span>
+        <div style="display:flex; flex-wrap:wrap; gap:20px; font-size:14px; color:var(--muted);">
+          <a class="lnk" href="https://github.com/vandelay87">GitHub</a>
+          <a class="lnk" href="https://www.linkedin.com/in/akli-aissat-b08119115/">LinkedIn</a>
+          <a class="lnk" href="mailto:akliaissat@outlook.com?subject=Hello">Email</a>
+        </div>
+      </nav>
+      <span style="font-size:13px; font-weight:500; color:var(--muted);">akli.dev</span>
+    </div>
+  </footer>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{
+  &quot;stickyNav&quot;: { &quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: true, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;Layout&quot; }
+}">
+class Component extends DCLogic {
+  state = { theme: 'light', activeTag: null };
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') {
+        this.setState({ theme: saved });
+      } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        this.setState({ theme: 'dark' });
+      }
+    } catch (e) {}
+    try {
+      const t = new URLSearchParams(window.location.search).get('tag');
+      if (t) this.setState({ activeTag: t });
+    } catch (e) {}
+  }
+
+  syncUrl(activeTag) {
+    try {
+      const url = new URL(window.location.href);
+      if (activeTag) url.searchParams.set('tag', activeTag);
+      else url.searchParams.delete('tag');
+      window.history.replaceState(null, '', url);
+    } catch (e) {}
+  }
+
+  setTag = (tag) => {
+    this.setState(s => {
+      const activeTag = s.activeTag === tag ? null : tag;
+      this.syncUrl(activeTag);
+      return { activeTag };
+    });
+  };
+
+  clearTag = () => {
+    this.syncUrl(null);
+    this.setState({ activeTag: null });
+  };
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    const active = this.state.activeTag;
+    const rawPosts = [
+      {
+        title: 'From an Empty Draft to a Published Recipe',
+        href: 'https://akli.dev/blog/from-draft-to-published-recipe',
+        date: '27 June 2026',
+        read: '7 min read',
+        desc: 'A walk through my recipe app by following one recipe from the moment I click “New” to the moment a visitor reads it — across React, Lambda, DynamoDB, and S3.',
+        tags: ['react', 'aws', 'lambda', 'dynamodb', 's3', 'cognito', 'typescript']
+      },
+      {
+        title: 'Building a Pokédex with React and AWS',
+        href: 'https://akli.dev/blog/building-a-pokedex',
+        date: '7 April 2026',
+        read: '4 min read',
+        desc: 'How I built a full-stack Pokédex app with React 19, AWS CDK, DynamoDB, Lambda, and a Game Boy Color aesthetic.',
+        tags: ['react', 'aws', 'cdk', 'dynamodb', 'lambda', 'typescript']
+      }
+    ];
+
+    const seen = new Set();
+    const allLabels = [];
+    rawPosts.forEach(p => p.tags.forEach(t => { if (!seen.has(t)) { seen.add(t); allLabels.push(t); } }));
+    const mkChip = (label) => ({ label, active: active === label, on: () => this.setTag(label) });
+
+    const filtered = active ? rawPosts.filter(p => p.tags.includes(active)) : rawPosts;
+    const posts = filtered.map(p => Object.assign({}, p, { tags: p.tags.map(mkChip) }));
+    const isFiltered = !!active;
+    const countLabel = isFiltered
+      ? (posts.length + (posts.length === 1 ? ' post' : ' posts') + ' tagged')
+      : (rawPosts.length + ' posts');
+
+    return {
+      posts,
+      allTags: allLabels.map(mkChip),
+      countLabel,
+      isFiltered,
+      allActive: !isFiltered,
+      noResults: posts.length === 0,
+      activeTag: active || '',
+      clear: this.clearTag,
+      theme: this.state.theme,
+      sticky: String(this.props.stickyNav ?? true),
+      toggle: this.toggle,
+      toggleIcon: isDark ? '☀' : '☾',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode'
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/Home.dc.html
+++ b/docs/design/paper/pages/Home.dc.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --hover:rgba(0,0,0,0.022);
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --ring:rgba(0,0,0,0.06);
+    --accent:#1F66E0;
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --hover:rgba(255,255,255,0.04);
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --ring:rgba(255,255,255,0.08);
+    --accent:#6BA0FF;
+  }
+  .lnk { transition: color .25s ease, opacity .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .row-link { transition: background .25s ease; border-radius:10px; text-decoration:none; color:inherit; display:block; }
+  .row-link:hover { background: var(--hover); }
+  .arrowx { display:inline-block; transition: transform .25s ease; }
+  .arrowx-host:hover .arrowx { transform: translateX(3px); }
+  .arrowx-up:hover .arrowx { transform: translate(2px,-2px); }
+  .btn { transition: background .22s ease, color .22s ease, border-color .22s ease; text-decoration:none; }
+  .btn-solid:hover { background: var(--accent); color:#fff; }
+  .btn-outline:hover { border-color: var(--accent); color: var(--accent); background: var(--hover); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius:6px; }
+  [data-sticky="true"] .site-header {
+    position: sticky; top:0; z-index:20;
+    background: color-mix(in srgb, var(--bg) 82%, transparent);
+    backdrop-filter: saturate(140%) blur(10px);
+    -webkit-backdrop-filter: saturate(140%) blur(10px);
+    border-bottom: 1px solid transparent;
+  }
+  .skip { position:absolute; left:-9999px; top:0; background:var(--btn-bg); color:var(--btn-fg); padding:10px 16px; border-radius:8px; z-index:50; }
+  .skip:focus { left:16px; top:16px; }
+  /* RecipeCard (inlined) */
+  .rc { display:block; text-decoration:none; color:inherit; background:var(--bg); border:1px solid var(--line); border-radius:16px; overflow:hidden; transition: transform .3s cubic-bezier(.2,.7,.2,1), box-shadow .3s ease; }
+  .rc:hover { transform: translateY(-4px); box-shadow: 0 14px 34px rgba(0,0,0,0.10); }
+  .rc-shot { transition: transform .5s cubic-bezier(.2,.7,.2,1); }
+  .rc:hover .rc-shot { transform: scale(1.04); }
+  /* LinkSection (inlined) */
+  .ls-all { text-decoration:none; transition: color .25s ease; }
+  .ls-allarrow { display:inline-block; transition: transform .25s ease; }
+  .ls-all:hover .ls-allarrow { transform: translateX(3px); }
+  .ls-row { text-decoration:none; color:inherit; display:flex; align-items:baseline; justify-content:space-between; gap:20px; padding:20px 14px; border-radius:10px; transition: background .25s ease; }
+  .ls-row:hover { background: var(--hover); }
+  .ls-arrow { display:inline-block; transition: transform .25s ease; flex-shrink:0; }
+  .ls-row:hover .ls-arrow { transform: translate(2px,-2px); }
+  @keyframes riseIn { from { transform: translateY(10px); } to { transform: none; } }
+  .rise { animation: riseIn .6s cubic-bezier(.2,.7,.2,1) both; }
+  @media (prefers-reduced-motion: reduce) { .rise { animation:none; } .btn:hover { transform:none; } html{scroll-behavior:auto;} }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" data-sticky="{{ sticky }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased;">
+  <a class="skip" href="#main">Skip to content</a>
+
+  <!-- ===== HEADER ===== -->
+  <header class="site-header">
+    <div style="max-width:1080px; margin:0 auto; padding:22px clamp(20px,5vw,28px); display:flex; align-items:center; justify-content:space-between;">
+      <a class="lnk" href="/" style="font-size:15px; font-weight:600; letter-spacing:-0.01em;">Akli Aissat</a>
+      <nav aria-label="Primary" style="display:flex; align-items:center; gap:clamp(18px,4vw,28px); font-size:14px; color:var(--muted);">
+        <a class="lnk" href="https://akli.dev/apps">Apps</a>
+        <a class="lnk" href="https://akli.dev/recipes">Recipes</a>
+        <a class="lnk" href="https://akli.dev/blog">Blog</a>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <!-- ===== HERO ===== -->
+    <section class="rise" style="max-width:640px; margin:0 auto; padding:clamp(72px,12vw,124px) 24px clamp(64px,9vw,104px); text-align:center;">
+      <sc-if value="{{ showPhoto }}" hint-placeholder-val="{{ true }}">
+        <img src="https://akli.dev/assets/profile-CW56JYP1.webp" alt="Portrait of Akli Aissat" width="200" height="200" loading="eager" style="width:clamp(150px,24vw,200px); height:clamp(150px,24vw,200px); border-radius:50%; object-fit:cover; object-position:50% 10%; margin:0 auto 40px; display:block; box-shadow:0 0 0 1px var(--ring), 0 12px 34px rgba(0,0,0,0.12);">
+      </sc-if>
+      <h1 style="font-size:clamp(40px,7vw,56px); font-weight:600; line-height:1.06; letter-spacing:-0.03em; margin:0 0 18px;">Akli Aissat</h1>
+      <p style="font-size:clamp(18px,3.4vw,21px); line-height:1.5; color:var(--subtle); margin:0 0 22px; font-weight:500;">Full-stack engineer</p>
+      <p style="font-size:16px; line-height:1.72; color:var(--muted); margin:0 auto; max-width:46ch;">I build beautiful, responsive web applications with React, TypeScript, and modern web technologies — with a focus on accessible, user-friendly experiences.</p>
+      <div style="display:flex; flex-wrap:wrap; gap:12px; justify-content:center; margin-top:38px;">
+        <a class="btn btn-solid" href="mailto:akliaissat@outlook.com?subject=Hello" style="font-size:14px; font-weight:600; color:var(--btn-fg); background:var(--btn-bg); padding:12px 24px; border-radius:999px;">Email me</a>
+        <a class="btn btn-outline" href="https://akli.dev/cv" style="font-size:14px; font-weight:500; color:var(--text); border:1px solid var(--btn-border); padding:12px 24px; border-radius:999px;">Download CV</a>
+      </div>
+    </section>
+
+    <div style="max-width:640px; margin:0 auto; padding:0 24px;"><div style="height:1px; background:var(--line);"></div></div>
+
+    <!-- ===== APPS ===== -->
+    <section style="max-width:640px; margin:0 auto; padding:clamp(56px,8vw,72px) 24px;">
+      <div style="display:flex; align-items:baseline; justify-content:space-between; gap:16px; margin-bottom:30px;">
+        <h2 style="font-size:13px; font-weight:600; letter-spacing:0.05em; color:var(--muted); text-transform:uppercase; margin:0;">Apps &amp; Experiments</h2>
+        <a class="ls-all" href="https://akli.dev/apps" style="font-size:14px; color:var(--accent); font-weight:600;">All <span class="ls-allarrow">→</span></a>
+      </div>
+      <sc-for list="{{ appsItems }}" as="item" hint-placeholder-count="2">
+        <sc-if value="{{ item.divider }}" hint-placeholder-val="{{ false }}">
+          <div style="height:1px; background:var(--line); margin:0 14px;"></div>
+        </sc-if>
+        <a class="ls-row" href="{{ item.href }}">
+          <span style="display:block;">
+            <span style="display:block; font-size:18px; font-weight:600; letter-spacing:-0.01em; line-height:1.3; margin-bottom:4px; color:var(--text);">{{ item.title }}</span>
+            <span style="display:block; font-size:14px; line-height:1.55; color:var(--muted);">{{ item.sub }}</span>
+          </span>
+          <span class="ls-arrow" style="font-size:15px; color:var(--accent);">↗</span>
+        </a>
+      </sc-for>
+    </section>
+
+    <div style="max-width:640px; margin:0 auto; padding:0 24px;"><div style="height:1px; background:var(--line);"></div></div>
+
+    <!-- ===== RECIPES CTA ===== -->
+    <section style="max-width:1080px; margin:0 auto; padding:clamp(72px,10vw,104px) 24px clamp(76px,11vw,108px);">
+      <div style="text-align:center; max-width:46ch; margin:0 auto clamp(40px,6vw,56px);">
+        <div style="font-size:13px; font-weight:600; letter-spacing:0.05em; color:var(--muted); text-transform:uppercase; margin-bottom:18px;">From the Kitchen</div>
+        <h2 style="font-size:clamp(28px,5vw,34px); font-weight:600; letter-spacing:-0.02em; margin:0 0 14px;">Lately I’ve been cooking.</h2>
+        <p style="font-size:16px; line-height:1.7; color:var(--muted); margin:0;">A small, growing collection of recipes I keep coming back to — written down so they're easy to make again.</p>
+      </div>
+
+      <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(220px, 1fr)); gap:clamp(16px,2.6vw,24px);">
+        <sc-for list="{{ recipesItems }}" as="recipe" hint-placeholder-count="3">
+          <a class="rc" href="{{ recipe.href }}">
+            <div style="overflow:hidden;">
+              <img class="rc-shot" src="{{ recipe.img }}" alt="" loading="lazy" style="display:block; width:100%; height:168px; object-fit:cover;">
+            </div>
+            <div style="padding:18px 18px 20px;">
+              <div style="font-size:17px; font-weight:600; letter-spacing:-0.01em; line-height:1.3; margin-bottom:6px; color:var(--text);">{{ recipe.title }}</div>
+              <div style="font-size:13.5px; color:var(--muted); line-height:1.5; margin-bottom:14px;">{{ recipe.desc }}</div>
+              <div style="font-size:12.5px; color:var(--faint); display:flex; flex-wrap:wrap; gap:7px;"><span>Prep: {{ recipe.prep }}</span><span aria-hidden="true">·</span><span>Cook: {{ recipe.cook }}</span><span aria-hidden="true">·</span><span>Serves: {{ recipe.serves }}</span></div>
+            </div>
+          </a>
+        </sc-for>
+      </div>
+
+      <div style="text-align:center; margin-top:clamp(36px,5vw,48px);">
+        <a class="btn btn-solid arrowx-host" href="https://akli.dev/recipes" style="display:inline-flex; align-items:center; gap:8px; font-size:14px; font-weight:600; color:var(--btn-fg); background:var(--btn-bg); padding:12px 26px; border-radius:999px;">Browse all recipes <span class="arrowx">→</span></a>
+      </div>
+    </section>
+
+    <div style="max-width:640px; margin:0 auto; padding:0 24px;"><div style="height:1px; background:var(--line);"></div></div>
+
+    <!-- ===== BLOG ===== -->
+    <section style="max-width:640px; margin:0 auto; padding:clamp(56px,8vw,72px) 24px;">
+      <div style="display:flex; align-items:baseline; justify-content:space-between; gap:16px; margin-bottom:30px;">
+        <h2 style="font-size:13px; font-weight:600; letter-spacing:0.05em; color:var(--muted); text-transform:uppercase; margin:0;">The blog</h2>
+        <a class="ls-all" href="https://akli.dev/blog" style="font-size:14px; color:var(--accent); font-weight:600;">All <span class="ls-allarrow">→</span></a>
+      </div>
+      <sc-for list="{{ blogItems }}" as="item" hint-placeholder-count="2">
+        <sc-if value="{{ item.divider }}" hint-placeholder-val="{{ false }}">
+          <div style="height:1px; background:var(--line); margin:0 14px;"></div>
+        </sc-if>
+        <a class="ls-row" href="{{ item.href }}">
+          <span style="display:block;">
+            <span style="display:block; font-size:18px; font-weight:600; letter-spacing:-0.01em; line-height:1.3; margin-bottom:4px; color:var(--text);">{{ item.title }}</span>
+            <span style="display:block; font-size:14px; line-height:1.55; color:var(--muted);">{{ item.sub }}</span>
+          </span>
+          <span class="ls-arrow" style="font-size:15px; color:var(--accent);">↗</span>
+        </a>
+      </sc-for>
+    </section>
+  </main>
+
+  <!-- ===== FOOTER ===== -->
+  <footer style="border-top:1px solid var(--line);">
+    <div style="max-width:1080px; margin:0 auto; padding:clamp(34px,5vw,44px) clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between;">
+      <nav aria-label="Elsewhere" style="display:flex; flex-direction:column; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:var(--text);">Elsewhere<br></span>
+        <div style="display:flex; flex-wrap:wrap; gap:20px; font-size:14px; color:var(--muted);">
+          <a class="lnk" href="https://github.com/vandelay87">GitHub</a>
+          <a class="lnk" href="https://www.linkedin.com/in/akli-aissat-b08119115/">LinkedIn</a>
+          <a class="lnk" href="mailto:akliaissat@outlook.com?subject=Hello">Email</a>
+        </div>
+      </nav>
+      <span style="font-size:13px; font-weight:500; color:var(--muted);">akli.dev</span>
+    </div>
+  </footer>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{
+  &quot;showPhoto&quot;: { &quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: true, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;Layout&quot; },
+  &quot;stickyNav&quot;: { &quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: true, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;Layout&quot; }
+}">
+class Component extends DCLogic {
+  state = { theme: 'light' };
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') {
+        this.setState({ theme: saved });
+      } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        this.setState({ theme: 'dark' });
+      }
+    } catch (e) {}
+  }
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    const appsItems = [
+      { title: 'Pokédex', sub: 'A searchable encyclopedia of Gen 1 Pokémon, styled after the classic Game Boy Color Pokédex.', href: 'https://akli.dev/apps/pokedex', divider: false },
+      { title: 'Sand box', sub: 'A real-time particle physics simulation of falling sand grains on a black canvas.', href: 'https://akli.dev/apps/sand-box', divider: true }
+    ];
+    const blogItems = [
+      { title: 'From an Empty Draft to a Published Recipe', sub: 'Jun ’26 · 7 min', href: 'https://akli.dev/blog/from-draft-to-published-recipe', divider: false },
+      { title: 'Building a Pokédex with React and AWS', sub: 'Apr ’26 · 4 min', href: 'https://akli.dev/blog/building-a-pokedex', divider: true }
+    ];
+    const recipesItems = [
+      { title: 'Recipe one', desc: 'A short, tempting one-line description of the dish.', img: 'https://images.unsplash.com/photo-1499636136210-6f4ee915583e?w=640&q=70', href: 'https://akli.dev/recipes', prep: '5 min', cook: '30 min', serves: '2' },
+      { title: 'Recipe two', desc: 'A short, tempting one-line description of the dish.', img: 'https://images.unsplash.com/photo-1473093295043-cdd812d0e601?w=640&q=70', href: 'https://akli.dev/recipes', prep: '10 min', cook: '25 min', serves: '4' },
+      { title: 'Recipe three', desc: 'A short, tempting one-line description of the dish.', img: 'https://images.unsplash.com/photo-1565299624946-b28f40a0ae38?w=640&q=70', href: 'https://akli.dev/recipes', prep: '15 min', cook: '40 min', serves: '2' }
+    ];
+    return {
+      appsItems,
+      blogItems,
+      recipesItems,
+      theme: this.state.theme,
+      sticky: String(this.props.stickyNav ?? true),
+      showPhoto: this.props.showPhoto ?? true,
+      toggle: this.toggle,
+      toggleIcon: isDark ? '☀' : '☾',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode'
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/Recipe.dc.html
+++ b/docs/design/paper/pages/Recipe.dc.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --surf:#F4F1EA; --hover:rgba(0,0,0,0.022);
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --ring:rgba(0,0,0,0.06); --accent:#1F66E0;
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --surf:#1C1A15; --hover:rgba(255,255,255,0.04);
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --ring:rgba(255,255,255,0.08); --accent:#6BA0FF;
+  }
+  .lnk { transition: color .25s ease, opacity .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius:6px; }
+  [data-sticky="true"] .site-header {
+    position: sticky; top:0; z-index:20;
+    background: color-mix(in srgb, var(--bg) 82%, transparent);
+    backdrop-filter: saturate(140%) blur(10px);
+    -webkit-backdrop-filter: saturate(140%) blur(10px);
+  }
+  .skip { position:absolute; left:-9999px; top:0; background:var(--btn-bg); color:var(--btn-fg); padding:10px 16px; border-radius:8px; z-index:50; }
+  .skip:focus { left:16px; top:16px; }
+  .arrowx { display:inline-block; transition: transform .25s ease; }
+  .back-link:hover .arrowx { transform: translateX(-3px); }
+  .tag-chip { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.04em; color:var(--muted); border:1px solid var(--line); background:var(--surf); padding:5px 10px; border-radius:7px; text-decoration:none; transition: color .2s ease, border-color .2s ease; }
+  .tag-chip:hover { border-color: var(--accent); color: var(--accent); }
+  .recipe-grid { display:grid; grid-template-columns:1fr; gap:clamp(36px,5vw,52px); }
+  @media (min-width:780px) {
+    .recipe-grid { grid-template-columns:296px 1fr; gap:clamp(44px,5vw,72px); align-items:start; }
+    .recipe-aside { position:sticky; top:92px; }
+  }
+  .ing { display:flex; align-items:center; gap:13px; width:100%; text-align:left; background:transparent; border:none; border-top:1px solid var(--line); padding:11px 4px; cursor:pointer; font-family:inherit; }
+  .ing:first-of-type { border-top:none; }
+  .ing-box { width:17px; height:17px; border:1.5px solid var(--btn-border); border-radius:5px; flex-shrink:0; display:flex; align-items:center; justify-content:center; color:transparent; font-size:10px; line-height:1; transition: background .18s ease, border-color .18s ease, color .18s ease; }
+  .ing-name { flex:1; font-size:15px; color:var(--text); line-height:1.35; }
+  .ing-qty { font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--muted); flex-shrink:0; }
+  .ing[data-checked="true"] .ing-box { background:var(--accent); border-color:var(--accent); color:#fff; }
+  .ing[data-checked="true"] .ing-name { text-decoration:line-through; color:var(--faint); }
+  .ing[data-checked="true"] .ing-qty { color:var(--faint); }
+  @media (prefers-reduced-motion: reduce) { html{scroll-behavior:auto;} *{transition:none !important;} }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" data-sticky="{{ sticky }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased;">
+  <a class="skip" href="#main">Skip to content</a>
+
+  <!-- ===== HEADER ===== -->
+  <header class="site-header">
+    <div style="max-width:1080px; margin:0 auto; padding:22px clamp(20px,5vw,28px); display:flex; align-items:center; justify-content:space-between;">
+      <a class="lnk" href="/" style="font-size:15px; font-weight:600; letter-spacing:-0.01em;">Akli Aissat</a>
+      <nav aria-label="Primary" style="display:flex; align-items:center; gap:clamp(18px,4vw,28px); font-size:14px; color:var(--muted);">
+        <a class="lnk" href="https://akli.dev/apps">Apps</a>
+        <a class="lnk" href="https://akli.dev/recipes" style="color:var(--text); font-weight:500;">Recipes</a>
+        <a class="lnk" href="https://akli.dev/blog">Blog</a>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <article style="max-width:920px; margin:0 auto; padding:clamp(28px,5vw,48px) 24px clamp(64px,9vw,96px);">
+
+      <!-- back -->
+      <a class="lnk back-link" href="https://akli.dev/recipes" style="display:inline-flex; align-items:center; gap:7px; font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.04em; color:var(--muted); margin-bottom:28px;"><span class="arrowx">←</span> All recipes</a>
+
+      <!-- hero -->
+      <figure style="margin:0 0 36px;">
+        <img src="https://images.akli.dev/recipes/mild-thai-basa-coconut-rice/cover-medium.webp" alt="One-pot Mild Thai-Style Basa &amp; Coconut Rice" loading="eager" style="display:block; width:100%; height:auto; aspect-ratio:16/10; object-fit:cover; border-radius:16px; border:1px solid var(--line);">
+      </figure>
+
+      <!-- header -->
+      <header style="max-width:680px;">
+        <h1 style="font-size:clamp(32px,5.4vw,46px); font-weight:600; line-height:1.08; letter-spacing:-0.03em; margin:0 0 18px;">Mild Thai-Style Basa &amp; Coconut Rice</h1>
+        <div style="display:flex; flex-wrap:wrap; align-items:center; gap:6px 12px; font-family:'JetBrains Mono',monospace; font-size:12.5px; letter-spacing:0.02em; color:var(--muted); margin-bottom:20px;">
+          <span>27 June 2026</span><span aria-hidden="true" style="color:var(--faint);">·</span>
+          <span>5 min prep</span><span aria-hidden="true" style="color:var(--faint);">·</span>
+          <span>30 min cook</span><span aria-hidden="true" style="color:var(--faint);">·</span>
+          <span>Serves 2</span>
+        </div>
+        <div style="display:flex; flex-wrap:wrap; gap:8px; margin-bottom:24px;">
+          <a class="tag-chip" href="https://akli.dev/recipes?tag=Thai">Thai</a>
+          <a class="tag-chip" href="https://akli.dev/recipes?tag=Fish">Fish</a>
+          <a class="tag-chip" href="https://akli.dev/recipes?tag=Rice">Rice</a>
+          <a class="tag-chip" href="https://akli.dev/recipes?tag=One+Pot">One Pot</a>
+          <a class="tag-chip" href="https://akli.dev/recipes?tag=Coconut">Coconut</a>
+        </div>
+        <p style="font-size:clamp(17px,2.6vw,19px); line-height:1.7; color:var(--subtle); margin:0;">A comforting Thai-infused rice and fish one pot. Flavour the rice with coconut and fragrant green curry paste, then steam the fish on top for tenderness.</p>
+      </header>
+
+      <div style="height:1px; background:var(--line); margin:clamp(36px,5vw,52px) 0;"></div>
+
+      <!-- ingredients + method -->
+      <div class="recipe-grid">
+
+        <!-- ingredients -->
+        <aside class="recipe-aside">
+          <div style="border:1px solid var(--line); border-radius:16px; background:var(--surf); padding:22px 22px 14px;">
+            <div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:6px;">
+              <h2 style="font-size:18px; font-weight:600; letter-spacing:-0.01em; margin:0;">Ingredients</h2>
+              <span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--faint);">{{ servesLabel }}</span>
+            </div>
+            <p style="font-size:12px; color:var(--faint); margin:0 0 12px;">Tap to check off as you go.</p>
+            <div>
+              <sc-for list="{{ ingredients }}" as="ing" hint-placeholder-count="9">
+                <button class="ing" type="button" data-checked="{{ ing.checked }}" onClick="{{ ing.on }}">
+                  <span class="ing-box">✓</span>
+                  <span class="ing-name">{{ ing.name }}</span>
+                  <span class="ing-qty">{{ ing.qty }}</span>
+                </button>
+              </sc-for>
+            </div>
+          </div>
+        </aside>
+
+        <!-- method -->
+        <section>
+          <h2 style="font-size:clamp(22px,3vw,26px); font-weight:600; letter-spacing:-0.02em; margin:0 0 8px;">Method</h2>
+          <p style="font-size:13px; color:var(--faint); font-family:'JetBrains Mono',monospace; margin:0 0 28px;">{{ stepsLabel }}</p>
+          <div style="display:flex; flex-direction:column; gap:28px;">
+            <sc-for list="{{ steps }}" as="step" hint-placeholder-count="7">
+              <div style="display:flex; gap:18px;">
+                <div style="flex-shrink:0; width:34px; height:34px; border-radius:50%; background:var(--surf); border:1px solid var(--line); display:flex; align-items:center; justify-content:center; font-family:'JetBrains Mono',monospace; font-size:14px; font-weight:500; color:var(--accent);">{{ step.num }}</div>
+                <div style="padding-top:3px; flex:1;">
+                  <sc-for list="{{ step.lines }}" as="line" hint-placeholder-count="2">
+                    <p style="font-size:16.5px; line-height:1.7; color:var(--subtle); margin:0 0 12px;">{{ line }}</p>
+                  </sc-for>
+                </div>
+              </div>
+            </sc-for>
+          </div>
+        </section>
+
+      </div>
+    </article>
+  </main>
+
+  <!-- ===== FOOTER ===== -->
+  <footer style="border-top:1px solid var(--line);">
+    <div style="max-width:1080px; margin:0 auto; padding:clamp(34px,5vw,44px) clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between;">
+      <nav aria-label="Elsewhere" style="display:flex; flex-direction:column; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:var(--text);">Elsewhere</span>
+        <div style="display:flex; flex-wrap:wrap; gap:20px; font-size:14px; color:var(--muted);">
+          <a class="lnk" href="https://github.com/vandelay87">GitHub</a>
+          <a class="lnk" href="https://www.linkedin.com/in/akli-aissat-b08119115/">LinkedIn</a>
+          <a class="lnk" href="mailto:akliaissat@outlook.com?subject=Hello">Email</a>
+        </div>
+      </nav>
+      <span style="font-size:13px; font-weight:500; color:var(--muted);">akli.dev</span>
+    </div>
+  </footer>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{
+  &quot;stickyNav&quot;: { &quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: true, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;Layout&quot; }
+}">
+class Component extends DCLogic {
+  state = { theme: 'light', checked: {} };
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') {
+        this.setState({ theme: saved });
+      } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        this.setState({ theme: 'dark' });
+      }
+    } catch (e) {}
+  }
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  toggleIng = (i) => {
+    this.setState(s => {
+      const checked = Object.assign({}, s.checked);
+      checked[i] = !checked[i];
+      return { checked };
+    });
+  };
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    const rawIng = [
+      { qty: '8 ml', name: 'Fish sauce' },
+      { qty: '1', name: 'Red pepper' },
+      { qty: '140 g', name: 'White basmati rice' },
+      { qty: '50 g', name: 'Solid creamed coconut' },
+      { qty: '2', name: 'Spring onions' },
+      { qty: '2', name: 'Basa fillets' },
+      { qty: '5 g', name: 'Thai basil' },
+      { qty: '15 g', name: 'Crispy onions' },
+      { qty: '40 g', name: 'Thai green curry paste' }
+    ];
+    const ingredients = rawIng.map((ing, i) => Object.assign({}, ing, {
+      checked: !!this.state.checked[i],
+      on: () => this.toggleIng(i)
+    }));
+
+    const steps = [
+      { num: '1', lines: ['Boil a kettle.', 'Trim, then slice your spring onions finely.', 'Deseed your pepper and chop into large bite-sized pieces.'] },
+      { num: '2', lines: ['Heat a large, wide-based pan (preferably non-stick with a matching lid) with a drizzle of vegetable oil over a medium heat.', 'Once hot, add the chopped pepper and most of the sliced spring onion (save the rest for garnish!) with your Thai green curry paste and cook for 2–3 min, until fragrant.'] },
+      { num: '3', lines: ['Dissolve the chopped creamed coconut and fish sauce in 300 ml boiled water.'] },
+      { num: '4', lines: ['Add your basmati rice and coconut stock to the pan with 1 tsp sugar and a generous pinch of salt, and give everything a good mix.', 'Reduce the heat to low, then cook covered for 10 min, until most of the stock has absorbed and the rice is almost cooked.'] },
+      { num: '5', lines: ['Meanwhile, chop your Thai basil finely, including the stalks.'] },
+      { num: '6', lines: ['Once the rice is almost cooked, increase the heat to medium-high and top with your basa fillets. Season with a pinch of salt and pepper.', 'Cook covered for 6–7 min, until the fish is cooked through and tender.'] },
+      { num: '7', lines: ['Transfer the cooked basa to a plate.', 'Add most of the chopped Thai basil (save the rest for garnish!) to the pan and mix it all together.', 'Serve the basa over the one-pot Thai-style coconut rice.', 'Garnish with the remaining Thai basil and sliced spring onion, then sprinkle over your crispy onions.'] }
+    ];
+
+    return {
+      ingredients,
+      steps,
+      servesLabel: 'Serves 2',
+      stepsLabel: steps.length + ' steps',
+      theme: this.state.theme,
+      sticky: String(this.props.stickyNav ?? true),
+      toggle: this.toggle,
+      toggleIcon: isDark ? '☀' : '☾',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode'
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/Recipes.dc.html
+++ b/docs/design/paper/pages/Recipes.dc.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body { margin: 0; }
+  :root {
+    --bg:#FBFAF7; --text:#1C1A16; --subtle:#3a3631; --muted:#6F6961; --faint:#9a938a;
+    --line:#ECE6DA; --surf:#F4F1EA; --hover:rgba(0,0,0,0.022);
+    --btn-bg:#1C1A16; --btn-fg:#FBFAF7; --btn-border:#E0DACE;
+    --ring:rgba(0,0,0,0.06); --accent:#1F66E0;
+  }
+  [data-theme="dark"] {
+    --bg:#141310; --text:#F3F0E8; --subtle:#CFC9BD; --muted:#A6A093; --faint:#6E685E;
+    --line:#2A2823; --surf:#1C1A15; --hover:rgba(255,255,255,0.04);
+    --btn-bg:#F3F0E8; --btn-fg:#141310; --btn-border:#36342C;
+    --ring:rgba(255,255,255,0.08); --accent:#6BA0FF;
+  }
+  .lnk { transition: color .25s ease, opacity .25s ease; text-decoration:none; color:inherit; }
+  .lnk:hover { color: var(--accent); }
+  .toggle-btn { transition: background .2s ease, border-color .2s ease, color .2s ease; cursor:pointer; background:transparent; }
+  .toggle-btn:hover { border-color: var(--btn-border); background: color-mix(in srgb, var(--text) 6%, transparent); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius:6px; }
+  [data-sticky="true"] .site-header {
+    position: sticky; top:0; z-index:20;
+    background: color-mix(in srgb, var(--bg) 82%, transparent);
+    backdrop-filter: saturate(140%) blur(10px);
+    -webkit-backdrop-filter: saturate(140%) blur(10px);
+  }
+  .skip { position:absolute; left:-9999px; top:0; background:var(--btn-bg); color:var(--btn-fg); padding:10px 16px; border-radius:8px; z-index:50; }
+  .skip:focus { left:16px; top:16px; }
+  .cat-chip { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.04em; color:var(--muted); border:1px solid var(--line); background:var(--surf); padding:6px 12px; border-radius:7px; cursor:pointer; transition: color .2s ease, border-color .2s ease, background .2s ease; }
+  .cat-chip:hover { border-color: var(--accent); color: var(--accent); }
+  .cat-chip[data-active="true"] { background: var(--accent); border-color: var(--accent); color:#fff; }
+  .search-input { width:100%; font-family:'Geist',system-ui,sans-serif; font-size:15px; color:var(--text); background:var(--surf); border:1px solid var(--line); border-radius:999px; padding:12px 40px 12px 42px; outline:none; transition: border-color .2s ease, background .2s ease; }
+  .search-input::placeholder { color:var(--faint); }
+  .search-input:focus { border-color:var(--accent); background:var(--bg); }
+  .search-clear { position:absolute; right:8px; top:50%; transform:translateY(-50%); display:inline-flex; align-items:center; justify-content:center; width:26px; height:26px; border-radius:50%; border:none; background:transparent; color:var(--muted); cursor:pointer; transition: color .2s ease, background .2s ease; }
+  .search-clear:hover { color:var(--accent); background:var(--hover); }
+  .clear-btn { font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:0.04em; color:var(--muted); background:var(--surf); border:1px solid var(--line); padding:4px 10px; border-radius:7px; cursor:pointer; transition: color .2s ease, border-color .2s ease, background .2s ease; }
+  .clear-btn:hover { color:var(--accent); border-color:var(--accent); background:var(--hover); }
+  .rc { display:block; text-decoration:none; color:inherit; background:var(--bg); border:1px solid var(--line); border-radius:16px; overflow:hidden; transition: transform .3s cubic-bezier(.2,.7,.2,1), box-shadow .3s ease; }
+  .rc:hover { transform: translateY(-4px); box-shadow: 0 14px 34px rgba(0,0,0,0.10); }
+  .rc-shot { transition: transform .5s cubic-bezier(.2,.7,.2,1); }
+  .rc:hover .rc-shot { transform: scale(1.04); }
+  @media (prefers-reduced-motion: reduce) { html{scroll-behavior:auto;} .cat-chip,.search-input,.search-clear{transition:none;} }
+</style>
+</helmet>
+
+<div data-theme="{{ theme }}" data-sticky="{{ sticky }}" style="background:var(--bg); color:var(--text); min-height:100vh; font-family:'Geist',system-ui,sans-serif; -webkit-font-smoothing:antialiased;">
+  <a class="skip" href="#main">Skip to content</a>
+
+  <!-- ===== HEADER ===== -->
+  <header class="site-header">
+    <div style="max-width:1080px; margin:0 auto; padding:22px clamp(20px,5vw,28px); display:flex; align-items:center; justify-content:space-between;">
+      <a class="lnk" href="/" style="font-size:15px; font-weight:600; letter-spacing:-0.01em;">Akli Aissat</a>
+      <nav aria-label="Primary" style="display:flex; align-items:center; gap:clamp(18px,4vw,28px); font-size:14px; color:var(--muted);">
+        <a class="lnk" href="https://akli.dev/apps">Apps</a>
+        <a class="lnk" href="https://akli.dev/recipes" style="color:var(--text); font-weight:500;">Recipes</a>
+        <a class="lnk" href="https://akli.dev/blog">Blog</a>
+        <button class="toggle-btn" onClick="{{ toggle }}" aria-label="{{ toggleLabel }}" title="{{ toggleLabel }}" style="display:inline-flex; width:32px; height:32px; align-items:center; justify-content:center; font-size:13px; color:var(--text); border:1px solid var(--btn-border); border-radius:50%;">{{ toggleIcon }}</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <!-- ===== HERO ===== -->
+    <section style="max-width:720px; margin:0 auto; padding:clamp(64px,11vw,108px) 24px clamp(36px,5vw,52px);">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.16em; color:var(--faint); text-transform:uppercase; margin-bottom:22px;">From the Kitchen</div>
+      <h1 style="font-size:clamp(40px,7vw,56px); font-weight:600; line-height:1.04; letter-spacing:-0.03em; margin:0 0 22px;">Things I keep<br>coming back to.</h1>
+      <p style="font-size:clamp(17px,2.6vw,19px); line-height:1.65; color:var(--muted); margin:0; max-width:54ch;">A small, growing collection of recipes I cook on repeat — written down so they're easy to make again. Tried, refined, and worth the effort.</p>
+    </section>
+
+    <!-- ===== RECIPES ===== -->
+    <section style="max-width:1080px; margin:0 auto; padding:clamp(12px,3vw,28px) 24px clamp(72px,10vw,108px);">
+      <div style="display:flex; align-items:baseline; gap:12px; margin-bottom:18px; font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:0.06em; color:var(--faint);">
+        <span>{{ countLabel }}</span>
+        <span style="flex:1; height:1px; background:var(--line);"></span>
+      </div>
+
+      <!-- search + category filter -->
+      <div style="display:flex; flex-wrap:wrap; align-items:center; gap:14px 12px; margin-bottom:34px;">
+        <div style="position:relative; flex:1 1 280px; max-width:420px;">
+          <span style="position:absolute; left:15px; top:50%; transform:translateY(-50%); display:flex; color:var(--faint); pointer-events:none;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.5" y2="16.5"></line></svg>
+          </span>
+          <input class="search-input" type="text" value="{{ query }}" onChange="{{ onSearch }}" placeholder="Search recipes…" aria-label="Search recipes">
+          <sc-if value="{{ hasQuery }}" hint-placeholder-val="{{ false }}">
+            <button class="search-clear" type="button" aria-label="Clear search" onClick="{{ clearQuery }}">✕</button>
+          </sc-if>
+        </div>
+        <div role="group" aria-label="Filter recipes by category" style="display:flex; flex-wrap:wrap; gap:8px;">
+          <button class="cat-chip" data-active="{{ allActive }}" onClick="{{ clear }}">all</button>
+          <sc-for list="{{ categories }}" as="cat" hint-placeholder-count="4">
+            <button class="cat-chip" data-active="{{ cat.active }}" onClick="{{ cat.on }}">{{ cat.label }}</button>
+          </sc-for>
+        </div>
+      </div>
+
+      <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(258px, 1fr)); gap:clamp(18px,2.6vw,26px);">
+        <sc-for list="{{ recipes }}" as="recipe" hint-placeholder-count="6">
+          <a class="rc" href="{{ recipe.href }}">
+            <div style="overflow:hidden;">
+              <img class="rc-shot" src="{{ recipe.img }}" alt="" loading="lazy" style="display:block; width:100%; height:168px; object-fit:cover;">
+            </div>
+            <div style="padding:18px 18px 20px;">
+              <div style="font-size:17px; font-weight:600; letter-spacing:-0.01em; line-height:1.3; margin-bottom:6px; color:var(--text);">{{ recipe.title }}</div>
+              <div style="font-size:13.5px; color:var(--muted); line-height:1.5; margin-bottom:14px;">{{ recipe.desc }}</div>
+              <div style="font-size:12.5px; color:var(--faint); display:flex; flex-wrap:wrap; gap:7px;"><span>Prep: {{ recipe.prep }}</span><span aria-hidden="true">·</span><span>Cook: {{ recipe.cook }}</span><span aria-hidden="true">·</span><span>Serves: {{ recipe.serves }}</span></div>
+            </div>
+          </a>
+        </sc-for>
+      </div>
+
+      <sc-if value="{{ noResults }}" hint-placeholder-val="{{ false }}">
+        <div style="text-align:center; padding:clamp(48px,8vw,76px) 24px; color:var(--muted);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:13px; line-height:1.6; margin-bottom:12px;">Nothing in the kitchen matches that.</div>
+          <button class="clear-btn" onClick="{{ resetAll }}">✕ clear filters</button>
+        </div>
+      </sc-if>
+    </section>
+  </main>
+
+  <!-- ===== FOOTER ===== -->
+  <footer style="border-top:1px solid var(--line);">
+    <div style="max-width:1080px; margin:0 auto; padding:clamp(34px,5vw,44px) clamp(20px,5vw,28px); display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between;">
+      <nav aria-label="Elsewhere" style="display:flex; flex-direction:column; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:var(--text);">Elsewhere</span>
+        <div style="display:flex; flex-wrap:wrap; gap:20px; font-size:14px; color:var(--muted);">
+          <a class="lnk" href="https://github.com/vandelay87">GitHub</a>
+          <a class="lnk" href="https://www.linkedin.com/in/akli-aissat-b08119115/">LinkedIn</a>
+          <a class="lnk" href="mailto:akliaissat@outlook.com?subject=Hello">Email</a>
+        </div>
+      </nav>
+      <span style="font-size:13px; font-weight:500; color:var(--muted);">akli.dev</span>
+    </div>
+  </footer>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{
+  &quot;stickyNav&quot;: { &quot;editor&quot;: &quot;boolean&quot;, &quot;default&quot;: true, &quot;tsType&quot;: &quot;boolean&quot;, &quot;section&quot;: &quot;Layout&quot; }
+}">
+class Component extends DCLogic {
+  state = { theme: 'light', cat: null, query: '' };
+
+  componentDidMount() {
+    try {
+      const saved = localStorage.getItem('akli-theme');
+      if (saved === 'light' || saved === 'dark') {
+        this.setState({ theme: saved });
+      } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        this.setState({ theme: 'dark' });
+      }
+    } catch (e) {}
+    try {
+      const c = new URLSearchParams(window.location.search).get('category');
+      if (c) this.setState({ cat: c });
+    } catch (e) {}
+  }
+
+  toggle = () => {
+    this.setState(s => {
+      const theme = s.theme === 'dark' ? 'light' : 'dark';
+      try { localStorage.setItem('akli-theme', theme); } catch (e) {}
+      return { theme };
+    });
+  };
+
+  syncUrl(cat) {
+    try {
+      const url = new URL(window.location.href);
+      if (cat) url.searchParams.set('category', cat);
+      else url.searchParams.delete('category');
+      window.history.replaceState(null, '', url);
+    } catch (e) {}
+  }
+
+  setCat = (cat) => {
+    this.setState(s => {
+      const next = s.cat === cat ? null : cat;
+      this.syncUrl(next);
+      return { cat: next };
+    });
+  };
+
+  clearCat = () => {
+    this.syncUrl(null);
+    this.setState({ cat: null });
+  };
+
+  onSearch = (e) => {
+    const query = e.target.value;
+    this.setState({ query });
+  };
+
+  clearQuery = () => this.setState({ query: '' });
+
+  resetAll = () => {
+    this.syncUrl(null);
+    this.setState({ cat: null, query: '' });
+  };
+
+  renderVals() {
+    const isDark = this.state.theme === 'dark';
+    const cat = this.state.cat;
+    const all = [
+      { title: 'Weeknight Beef Ragù', desc: 'Slow-simmered beef and pork over wide pappardelle. Forgiving and freezer-friendly.', category: 'Pasta', href: 'https://akli.dev/recipes', img: 'https://images.unsplash.com/photo-1473093295043-cdd812d0e601?w=720&q=70', prep: '20 min', cook: '3 hr', serves: '4' },
+      { title: 'Lemon & Garlic Roast Chicken', desc: 'One pan, crisp skin, soft potatoes underneath soaking up the juices.', category: 'Mains', href: 'https://akli.dev/recipes', img: 'https://images.unsplash.com/photo-1598103442097-8b74394b95c6?w=720&q=70', prep: '20 min', cook: '1 hr 20', serves: '4' },
+      { title: 'Weekend Shakshuka', desc: 'Eggs poached in a spiced tomato and pepper sauce. Best with bread for mopping.', category: 'Quick', href: 'https://akli.dev/recipes', img: 'https://images.unsplash.com/photo-1590412200988-a436970781fa?w=720&q=70', prep: '10 min', cook: '25 min', serves: '2' },
+      { title: 'Miso Mushroom Ramen', desc: 'A deep, savoury broth in half an hour using miso and dried mushrooms.', category: 'Mains', href: 'https://akli.dev/recipes', img: 'https://images.unsplash.com/photo-1569718212165-3a8278d5f624?w=720&q=70', prep: '15 min', cook: '30 min', serves: '2' },
+      { title: 'Rosemary Olive Oil Focaccia', desc: 'A high-hydration dough with a dimpled, golden crust. Mostly waiting.', category: 'Baking', href: 'https://akli.dev/recipes', img: 'https://images.unsplash.com/photo-1509440159596-0249088772ff?w=720&q=70', prep: '20 min', cook: '25 min', serves: '8' },
+      { title: 'Dark Chocolate Tahini Cookies', desc: 'Fudgy centres, crisp edges, and just enough salt to keep you reaching back.', category: 'Baking', href: 'https://akli.dev/recipes', img: 'https://images.unsplash.com/photo-1499636136210-6f4ee915583e?w=720&q=70', prep: '15 min', cook: '12 min', serves: '12' }
+    ];
+
+    const seen = new Set();
+    const labels = [];
+    all.forEach(r => { if (!seen.has(r.category)) { seen.add(r.category); labels.push(r.category); } });
+    const mkChip = (label) => ({ label, active: cat === label, on: () => this.setCat(label) });
+
+    const q = (this.state.query || '').trim().toLowerCase();
+    const recipes = all.filter(r => {
+      if (cat && r.category !== cat) return false;
+      if (q && !(r.title + ' ' + r.desc + ' ' + r.category).toLowerCase().includes(q)) return false;
+      return true;
+    });
+    const isFiltered = !!cat || !!q;
+
+    return {
+      recipes,
+      categories: labels.map(mkChip),
+      allActive: !cat,
+      query: this.state.query,
+      hasQuery: !!this.state.query,
+      noResults: recipes.length === 0,
+      countLabel: isFiltered
+        ? (recipes.length + (recipes.length === 1 ? ' recipe' : ' recipes'))
+        : (all.length + ' recipes'),
+      clear: this.clearCat,
+      clearQuery: this.clearQuery,
+      onSearch: this.onSearch,
+      resetAll: this.resetAll,
+      theme: this.state.theme,
+      sticky: String(this.props.stickyNav ?? true),
+      toggle: this.toggle,
+      toggleIcon: isDark ? '☀' : '☾',
+      toggleLabel: isDark ? 'Switch to light mode' : 'Switch to dark mode'
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/paper/pages/support.js
+++ b/docs/design/paper/pages/support.js
@@ -1,0 +1,1658 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+      const raw = t ? parseDcText(t) : null;
+      if (raw?.template) runtime.updateHtml(rootName, raw.template);
+    }).catch(() => {
+    });
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || el.getAttribute("src") || el.getAttribute("import") || "";
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const kids = hasContent ? walkChildren(el, host) : [];
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...kids.map((b, j) => b(vals, ctx, j)));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = BABEL_URL;
+        s.integrity = BABEL_SRI;
+        s.crossOrigin = "anonymous";
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => fetch(url)).then((r) => {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.text();
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          doc.documentElement.dataset.theme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const sel = pseudo === "before" || pseudo === "after" ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(sel + "{" + css + "}", el.sheet.cssRules.length);
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      fetch(url).then((res) => {
+        if (!res.ok) {
+          console.error(
+            "[dc-runtime] sibling fetch for <" + name + "/> failed:",
+            url,
+            "returned",
+            res.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res.text();
+      }).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            "[dc-runtime] sibling fetch for <" + name + "/>:",
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          "[dc-runtime] sibling fetch for <" + name + "/> threw:",
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/index.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      s.integrity = integrity;
+      s.crossOrigin = "anonymous";
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    return Promise.all([
+      loadScript(REACT_URL, REACT_SRI),
+      loadScript(REACT_DOM_URL, REACT_DOM_SRI)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const api = {
+      __dcUpdate: (name, kind, content, streaming) => {
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`<sc-comp>`,
+       *  `sc-camel-*` attrs); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/docs/prds/paper-redesign.md
+++ b/docs/prds/paper-redesign.md
@@ -1,0 +1,214 @@
+# PRD: akli.dev Warm Editorial "Paper" Redesign
+
+> Canonical design source of truth: `docs/design/paper/` (`README.md` + `design_system/`). This supersedes `docs/prds/redesign.md` (old neo-brutalist direction — now deprecated).
+
+## Overview
+
+Re-implement every screen and shared primitive of akli.dev against the `docs/design/paper/` design system, moving the fully-built app from its current **neo-brutalist** look to a **warm editorial "paper"** aesthetic. Adopt the new tokens, self-hosted fonts, soft-elevation visual language, and the design's signature interactions (icon-nudge, card lift, filter/search, autosave, toasts, dialogs, URL query sync). Simultaneously upgrade the DOM from prototype div-soup to semantic HTML5 and bring every page to **WCAG 2.2 AA**. The design is the source of truth for how the app **looks and behaves** — visual architecture, spacing, color, layout, and interaction — but it is **not a code spec.** Claude Code owns every code decision and applies clean-code / best-practice judgment: free to add, remove, rename, or restructure components, props, hooks, and tokens wherever that is genuinely cleaner. The only thing to avoid is **gratuitous churn** — don't rename or re-architect working code *merely* to mirror the prototype's names when there's no engineering benefit (e.g. renaming the `theme` storage key to `akli-theme`). We restructure DOM freely for semantics, accessibility, and SEO.
+
+This is a **re-skin + interaction-adoption + accessibility/semantics overhaul** of an already-built app — not a greenfield build and not a feature project.
+
+## Problem Statement
+
+The site (akli.dev) is fully built — React 19 + TS + Vite 7 + CSS Modules + React Router v7, ~38 components, 12 routes (6 public + 5 admin + 404), SSR-capable. It currently ships a neo-brutalist system (pure-white bg, `#000` 2px hard borders, hard-offset shadows, `--radius-none`, system fonts). That direction has been superseded by the `docs/design/paper/` redesign, and the two are mutually exclusive — radii, borders, shadows, fonts, accent, and text hierarchy all differ.
+
+- The design prototypes are inline-styled `.dc.html` files with div-soup, `role="button"` divs, visual-only state (`data-checked`, `data-active`), missing `aria-live` regions, no admin skip links, and `alt=""` on meaningful images — none of which should ship as-is.
+- Behaviors the design specifies (blog `?tag=` filter, recipes search + tag filter, ingredient check-off, publish checklist, autosave states, toasts, confirm dialogs) already exist in the codebase in varying completeness. They are **restyled** to the design's look/UX — kept as-is where the code is sound, refactored where that's genuinely cleaner, but not churned merely to match the prototype's internal naming.
+
+## Goals
+
+1. Every one of the 12 routes and all shared primitives match the `docs/design/paper/` spec in both light and dark themes.
+2. A single tokens layer (`src/styles/tokens.css`) replaces the neo-brutalist tokens with the paper system (semantic `--color-*` + short aliases), consumed by all CSS Modules.
+3. Geist + JetBrains Mono are **self-hosted** (woff2, `font-display: swap`), no third-party font requests.
+4. Light/dark theming looks correct in both themes on every screen, with **no theme flash on load**. Keep the existing `localStorage('theme')` key (no gratuitous rename) and `data-theme` on the root; the toggle is restyled to the design's icon button.
+5. Every page passes automated a11y checks (`vitest-axe` in tests + `eslint-plugin-jsx-a11y` at lint time) and meets WCAG 2.2 AA: semantic landmarks, heading order, focus management, `aria-live` for async status, real dialog semantics, labelled controls.
+6. The existing Vitest suite stays green; new behavior/a11y tests cover the adopted interactions.
+7. `CLAUDE.md` is updated to describe the new system (removing the neo-brutalist / `--radius-none` mandate and stale facts).
+
+## Non-Goals
+
+- **No new product features** beyond what the design shows. Adopting design-specified interactions is in scope; inventing capability is not.
+- **No API/contract changes.** Auth (Cognito), recipes/users/image APIs, routes, and data models are unchanged. Any design behavior with no backing endpoint is flagged as a follow-up, not stubbed into product.
+- **No _gratuitous_ churn to mirror the prototype.** Don't rename working identifiers or re-architect sound code *merely* because Claude Design named/built it differently — e.g. keep the `theme` localStorage key and the existing `?tag=` filter param (used by **both** blog and recipes today; the design's `?category=` is not adopted). (Claude Code remains free to change props, components, hooks, or structure wherever it yields cleaner code — see Design & UX. This is a ban on pointless churn, not on improvement.)
+- **No pixel/visual-regression testing** (no Playwright screenshots in CI this iteration).
+- **No shipping** of the `.dc.html` prototypes, `pages/support.js`, or any design-time affordance (the bottom preview "state switchers", `data-props` toggles).
+- **No migration off CSS Modules** or React Router; **no design-system tooling** (Storybook) added.
+- Not building a real architecture-diagram renderer beyond the existing MDX/Mermaid pipeline. (Ingredient check-off **is** persisted — see Resolved Decisions.)
+
+## User Stories
+
+- As a **visitor**, I want a calm, legible, fast site in my preferred light/dark theme so that reading blog posts and recipes is pleasant on any device.
+- As a **keyboard / screen-reader user**, I want proper landmarks, focus management, and announced status changes so that I can navigate, filter, and operate every control without a mouse.
+- As a **reader**, I want to filter the blog by tag and search/filter recipes so that I can find content quickly, with the active tag reflected in a shareable URL.
+- As the **admin (Akli)**, I want the recipe editor's autosave, slug locking, image processing, and publish checklist to keep behaving correctly (restyled to the new look) so that I can author recipes confidently without a manual save button.
+- As the **admin**, I want a clear, accessible preview of how a recipe will look published so that I can verify before publishing.
+
+## Design & UX
+
+**Source of truth:** `docs/design/paper/README.md` (screen-by-screen intent) and `docs/design/paper/design_system/` (tokens, component contracts `<Name>.d.ts`, usage `<Name>.prompt.md`, `_helpers.css`, `ui_kits/`, `guidelines/`). Where they disagree **on visuals, layout, or UX, the design wins.** The design is **not** a code spec: Claude Code owns implementation (naming, storage keys, URL params, prop APIs, hooks, structure) and applies clean-code judgment — change what's genuinely cleaner, keep what's sound, and don't churn working code *merely* to mirror the prototype. The design's `<Name>.d.ts` prop contracts show *what states/variants must exist visually*, not a prop API to adopt verbatim.
+
+### Visual language (from `design_system/readme.md`)
+
+Warm paper (never pure white), generous whitespace, narrow reading columns (1080 shell / 720 index / 680 article / ~54ch hero), quiet 1px hairlines, soft blurred low-opacity shadows reserved for toasts/dropdowns/dialogs, single blue accent used sparingly, 4-step ink-on-paper text hierarchy. Dark mode is a true warm near-black (`#141310`, not blue-black). Restrained motion (`.18–.25s ease`), spinner + shimmer for async, blur only on the sticky header. **All motion respects `prefers-reduced-motion`.** First-person, plain, dry copy; sentence case except mono uppercase eyebrows; `·` mid-dot meta separators; emoji only in the 3 Callout glyphs.
+
+### Design tokens → `src/styles/tokens.css` (full replacement)
+
+Two layers per the spec: semantic `--color-*` (light on `:root`, dark under `[data-theme="dark"]`) **and** short aliases (`--bg`, `--surf`, `--field`, `--text`→text-strong, `--subtle`→text, `--muted`, `--faint`, `--line`, `--accent`, `--btn-bg/-fg`, `--green/-bg`, `--amber/-bg`, `--danger/-bg`). Copy exact values from `design_system/tokens/`. Key migration deltas (old → new):
+
+| Aspect | Old (neo-brutalist) | New (paper) |
+|---|---|---|
+| bg | `#FFFFFF` | `#FBFAF7` (dark `#141310`) |
+| surface | `#FFFFFF` | `#F4F1EA` (dark `#1C1A15`) |
+| text | 1 muted step | 4 steps: strong `#1C1A16` / body `#3A3631` / muted `#6F6961` / faint `#767066` (AA-adjusted from design `#9A938A`) |
+| border | `#000` 2px | `#ECE6DA` 1px hairline (+ `-strong #E0DACE`) |
+| accent | `#2563EB` | `#1F66E0` (dark `#6BA0FF`) |
+| shadow | hard offset `4px 4px 0` | soft: `sm 0 1px 2px/.05` · `md 0 4px 14px/.08` · `lg 0 12px 30px/.16` · `xl 0 24px 60px/.28` |
+| radius | `0` / `2px` | `sm 6 · md 10 · lg 12 · xl 16 · 2xl 18 · full 999` |
+| fonts | system stacks | Geist (sans) + JetBrains Mono (mono) |
+
+Also net-new vs old: `--color-field`, `--color-hover`, `--color-*-bg` status tints, `--btn-*`, fluid `--font-display-hero/-title/-h2` (`clamp()`), fixed 11→56px size scale, tracking tokens (`--tracking-eyebrow .16em`, `-meta .04em`, `-tight -.03em`, `-snug -.02em`), line-heights (1.08→1.75), `--ring` focus token, `--max-w-reading/-article/-prose`, `--z-overlay/-toast`, `--duration-fast 180 / -base 250`. Import order per `styles.css`: fonts → colors → typography → spacing → helpers.
+
+The `_helpers.css` `.ds-*` interaction utilities (link nudge, card lift+zoom, field focus ring, tag/suggest/upload/danger chip hovers, toggle hover, sticky-header blur, spinner, shimmer, reduced-motion block) encode the design's _behaviors_, but do **not** ship the global `.ds-*` class contract into this CSS-Modules codebase — global classes force `:global()`/string refs that break module scoping and `composes` (and the css-engineer conventions forbid gratuitous `:global`). **Port the behaviors into the relevant component `.module.css` files.** While porting, fix two source issues: drop the `!important` on `.ds-field:focus`, and use **`:focus-visible`** (not `:focus`) for the ring. **The reduced-motion handling is mandatory** and must cover per-module transitions too (see a11y notes), not only the shared spinner/shimmer.
+
+**Alias footgun:** `--text` resolves to `text-strong` (strongest ink) while `--subtle` resolves to `--color-text` (body). Components today consume `--color-text` for body — an engineer reaching for `--text` gets the strongest ink by mistake. Prefer the semantic `--color-*` names in consumers, or add a lint note.
+
+### Fonts (self-hosted)
+
+Replace the design's `fonts.css` Google-Fonts `@import` with self-hosted woff2. **Manual self-host, deliberately not Fontsource** — no font npm dependency; commit the `.woff2` files to the repo (keeps `package.json` lean). Place files in `src/assets/fonts/` (**`.woff2` only**, only the weights used) and declare `@font-face` in a plain CSS file (`src/styles/fonts.css`) using **relative `url("../assets/fonts/*.woff2")`** — Vite's CSS asset pipeline hashes/fingerprints them automatically; no JS-side import needed. Faces: Geist 400/500/600/700 + JetBrains Mono 400/500, `font-display: swap`. Ship the official **latin** files (no manual subsetting). **Include each font's `OFL.txt`** in `src/assets/fonts/` (both are SIL Open Font License — the license must travel with the redistributed font). `--font-sans`/`--font-mono` reference the family names with the existing system-stack fallbacks. No `<link>` to fonts.googleapis.com.
+
+**FOUT/CLS mitigation (required — `swap` guarantees a flash otherwise):** (a) `<link rel="preload" as="font" type="font/woff2" crossorigin>` the critical faces (Geist 400/500) in the document `<head>`; (b) add a metric-matched fallback `@font-face` (`size-adjust`/`ascent-override`/`descent-override`) so the system fallback holds layout and CLS ≈ 0. `unicode-range` only helps if we generate subsets — omit it unless we commit to subsetting.
+
+### Theming
+
+- **No theme flash on load is in scope** (a quality goal; the approach is Claude Code's call). Recommended: a tiny blocking inline script in the document `<head>` that reads the persisted theme with a `prefers-color-scheme` fallback (wrapped in `try/catch`) and sets `data-theme` on `<html>` **before first paint**. Keep `data-theme` on `document.documentElement`.
+- **Keep the existing `localStorage('theme')` key** — don't rename it to the prototype's `akli-theme` (a migration with no benefit that would drop users' saved preference). Whether the toggle stays self-contained or moves behind a small `useTheme`/context is Claude Code's call — pick the cleaner option. If theme-dependent SSR markup risks a hydration mismatch, resolve it cleanly (read from `data-theme`, or mount-gate the toggle's stateful attributes).
+- **Restyle the toggle's markup** to the design's 32px round icon button (☾/☀, `aria-label`), replacing the current checkbox-switch.
+- **Filter state:** derive `activeTag` from `useSearchParams` on every render — do **not** mirror the URL into `useState` (desyncs on back/forward). Both `Blog.tsx` and `Recipes.tsx` already read `?tag=` correctly (recipes filter on `recipe.tags`); preserve the pattern and the shared `?tag=` param name.
+
+### Shared shell & primitives (component mapping)
+
+Reuse existing folders where names match; add/rename/delete per the design. Representative mapping (design component → repo action):
+
+- **Header** (`navigation/Header`): rebuild as one component, `variant: 'public' | 'admin'`, sticky translucent blur, `<nav aria-label>`, active link `aria-current="page"` (public headers currently lack it). Renders the existing self-contained `ThemeToggle`; absorbs repo `Navigation` + `Header` wiring. Public: brand + Apps/Recipes/Blog + toggle. Admin: brand + Recipes/Users + email + Log out + toggle. **Login uses a third "logged-out" header** (brand + "Admin" + toggle, no nav/logout).
+- **Footer**: new small shared component (public: `<nav aria-label="Elsewhere">` GitHub/LinkedIn/Email as `<ul><li>` + "akli.dev"; admin: two spans). Reuse the existing links from `SocialCard`: GitHub `https://github.com/vandelay87`, LinkedIn `https://www.linkedin.com/in/akli-aissat-b08119115/`, Email `mailto:akliaissat@outlook.com`. Currently footer is ad hoc.
+- **Core:** `Button` — extend/refactor the API to cleanly express the design's visual variants the app needs (a destructive style, an outline style, a pill vs default shape, optional `loading` and leading/trailing icon). Choosing the cleanest variant naming is Claude Code's call — rename `primary`/`secondary` to something like `solid|outline|danger` if that's genuinely cleaner, or keep and extend them; don't force new visuals into an ill-fitting existing shape, and update all callers whichever way you go. `Card`, `Link` (add `tone`, `nudge`, `icon`), `Tag` (new component — chip/filter `as span|button`, `active` → `aria-pressed`, `removable`), `StatusBadge` (extend to the design's tones + dot).
+- **Forms:** `Input` (add `prefixIcon`/`suffix`, `invalid`→`aria-invalid`), `Textarea`, `TagInput` — restyle to the design's chips + suggestions; keep the existing API (`tags`/`onChange`/`existingTags`) unless a change is genuinely cleaner (don't rename to the prototype's props just to match). `ImageUpload` (three visual states `empty|processing|ready`; **cover dropzone must be a real `<button>` or `<label>`+hidden file input**, not a `role="button"` div; wire collected alt → `<img alt>` — keep the existing upload/S3 logic; refine props only if cleaner).
+- **Feedback:** `AutosaveStatus` (`saving|saved|error`+retry, wrap in `aria-live="polite"`), `Callout` (tip/warning/info, emoji `aria-hidden`, `role="note"`), `Loading`, `ProcessingPlaceholder`, `Toast` (bottom-right, whole pill dismiss, **container needs an `aria-live` region** — one `ToastProvider`; note the design `Toast.jsx` `✕` literal is a bug to fix).
+- **Overlays:** `ConfirmDialog` — one accessible dialog used by Delete/Remove/Discard/Leave. **Use native `<dialog>` + `showModal()`** (focus trap, Escape, top-layer, focus-restore for free; call `showModal()` in an effect, never `open` during SSR; scrim-close via a `target === dialogEl` check), `danger` variant. Add a jsdom `showModal`/`close` polyfill in `tests/setup.ts`.
+- **Content:** `CodeBlock` — **enhance the existing Shiki MDX `CodeBlock`** with the design's filename header + Copy→"Copied" (keep its existing Shiki rendering/pipeline; add `aria-live` on the copy state). `RecipeCard` (lift + cover zoom; **real alt text**, meta as `<ul>`/`<dl>`).
+- **Icons:** **no icon library** — keep the existing hand-inlined SVG approach. Add new outline icons as inline SVG (`stroke="currentColor"`, Lucide-grade paths), always `aria-hidden` with a text label on the control. GitHub/LinkedIn brand glyphs stay as their existing SVGs. Glyph stand-ins (`☾/☀ ✓ ✕ · ↗ ←`) kept where the design uses them.
+- **Delete/verify:** components with no design counterpart (e.g. `FullPageHeader` neo-brutalist hero, `Grid`, `SocialCard`, `AppsCta`/`RecipesCta`/`CVDownload` as-composed) — restructure or remove as the new Home/Apps layouts dictate; the implementer has authority to delete/rename with tests updated.
+
+### Per-page specs
+
+Each page: adopt the design layout; upgrade to the listed semantics; implement the interactions/states; meet the a11y notes.
+
+**Public**
+
+1. **Home** `/` — hero (eyebrow + h1 + role + bio + Email me/Download CV CTAs; **keep the profile photo**, restyled) → "Apps & Experiments" link-section → "From the Kitchen" RecipeCard rail → "The blog" link-section. **Rewrite the hero bio to the design's plain/dry voice** (current copy is too hype-y). Upgrade: link lists → `<ul><li>`, row title → `<h3>`, dividers `aria-hidden`, recipe imgs get real alt. Section eyebrows are `<h2>`.
+2. **Apps** `/apps` — hero → responsive app-card grid (`<ul><li>`, card title `<h2>/<h3>`, decorative preview `aria-hidden`) → "In progress" `<aside>`. Count label pluralizes.
+3. **Blog** `/blog` — hero → count row + tag filter bar (`role="group"`, chips are `<button>` + `aria-pressed`) → post list (`<article>` per post, `<h2>` title link + separate tag `<ul>` of filter buttons — **do not wrap whole card in an anchor**). Interactions: tag filter preserving the **existing** `?tag=` `useSearchParams` sync (existing param name kept; derive from the URL), empty state, `aria-live` result count.
+4. **Blog Post** `/blog/:slug` — `<main><article>`, back link, `<header>` (h1 + meta + tag `<a>` links), hero `<figure>/<figcaption>`, MDX prose (existing MDX pipeline: Callout/CodeBlock/FileTree/Image/Link/Typography), Copy-to-clipboard with `aria-live`, Share row, Related `<section>`. Architecture diagram (existing Mermaid) needs a text alt.
+5. **Recipes** `/recipes` — hero → search (`<form role="search">`, `<input aria-label>`, magnifier `aria-hidden`, clear button) + **dynamic tag-filter chips** (`role="group"`, `aria-pressed`) → RecipeCard grid (`<ul><li>`, real alt) → empty state. **Keep the existing filter behavior — restyle only:** chips come from the live `/recipes/tags` endpoint (`fetchTags()` → all tags, data-driven). The design's curated "category" chips are a *visual look*, not a new taxonomy — do **not** hardcode a category list or add a `category` field. Search is client-only; only the tag filter syncs to `?tag=` (same param as Blog). The `(count)` label is a minor visual detail (the design omits it — keep or drop as looks best). `aria-live` result count.
+6. **Recipe** `/recipes/:slug` — `<main><article>`, back link, hero `<figure>`, `<header>` (h1 + mono meta + tag `<a>` links + intro), two-column: sticky `<aside>` Ingredients + `<section>` Method. **Ingredients → `<ul><li>` with real checkbox semantics** (`<input type=checkbox>` or `role="checkbox" aria-checked`; strikethrough not the only signal — note the design's "don't transition ingredient-name color" caveat). **Steps → `<ol><li>`** (number from list). **Persist checked ingredients per recipe in `localStorage`** (survives reload/navigation). Reuse as shared **`RecipeView`** (also used by Preview).
+
+**Admin** (shell = admin Header/Footer; add skip link + `<main id="main">` to all — currently missing)
+
+7. **Login** `/admin/login` — logged-out header; centered auth `<main id=main>` card; `<form novalidate>` two modes (`login` | `setPassword` from Cognito `NEW_PASSWORD_REQUIRED`); wrapping `<label>`s, correct `autocomplete`, `role="alert"` error, submit spinner/disabled. On mode switch move focus to first new field + announce heading. **Drop the bottom-right preview switcher.**
+8. **Admin Recipes** `/admin/recipes` — admin header (`aria-current` active), page header (h1 + count + "New recipe" → route, prefer `<a>`), states `list | empty | loading | error` (retry). List → `<ul><li>` rows: StatusBadge + title (`<h2/h3>`) + tags + relative "Updated…" + actions (Edit/Preview/Publish-Unpublish/Delete, icons `aria-hidden` + text labels). Delete → shared ConfirmDialog. **Toast container = `aria-live`** (polite success/info, assertive error). **Drop preview switcher + standalone Toast trigger.**
+9. **Admin Users** `/admin/users` (`requiredRole="admin"`) — page header (h1 + count + Invite), inline invite panel (`<form novalidate>`: email `<input>`+`<label>`, **role segmented control → `<fieldset><legend>Role` + `aria-pressed`**, Send spinner, `role="alert"` error + `aria-invalid`/`aria-describedby`), user list (`<ul><li>` or `<table>`; avatar `aria-hidden`; role pill; status dot+text; Remove hidden for self "You"). Remove → ConfirmDialog (danger). Toasts `aria-live`. **Drop preview switcher.**
+10. **Admin Recipe Editor** `/admin/recipes/new` & `/:id/edit` — largest. Back link; conditional banners (session-expired `role="alert"`, image-processing `role="status"`); title bar (h1 + status pill); two-column: left **single `<form>`** of `<section>`/`<fieldset>` groups (Basics: title, **URL slug** live `akli.dev/recipes/[slug]` preview + "Reset to title" + **locked** state once images exist; intro; Cover image upload+alt; Timing/servings; **TagInput**; Ingredients rows +reorder; **Steps `<ol>`** each with own image+alt), right sticky `<aside>` rail (**autosave `aria-live`**, state-aware actions, **"Before publishing" checklist** as `<ul>` with text status not color-only). Interactions: keep the existing autosave (`useAutosave`) and restyle its indicator (the prototype's ~1.5s timing isn't a mandate — change only if genuinely cleaner); slug auto/lock, image `empty→processing→ready`, publish gating (`missing()` checklist incl. all ready images have alt + none processing), Discard + Leave(unsaved-changes) dialogs, toasts. **Every `.seclabel` → real heading/legend; cover dropzone → real button/file input; wire alt → `<img alt>`; focus follows reordered item. Drop the 6-way preview switcher.**
+11. **Admin Recipe Preview** `/admin/recipes/:id/preview` — sticky status banner (amber draft / green published; back link, status text carries state, Edit + Publish(draft)|View public(published) + toggle) wrapping the shared **`RecipeView`**; states `draft | published | loading | notfound`. Reuse public `<main id=main>` + skip link + ingredient/steps semantics. **Drop preview switcher.**
+
+### States (every page)
+
+Empty, loading, error(+retry), success/toast, disabled — as enumerated per admin page above. Public pages are mostly static except Blog/Recipes (filter empty states) and BlogPost/Recipe (no async states beyond MDX/route load).
+
+## Technical Considerations
+
+- **Stack (verified):** React 19, TypeScript, Vite 7.3, react-router-dom 7.1.5, CSS Modules, Vitest 4.1 + Testing Library, SSR via `entry-server.tsx` + `lambda-handler.ts`, MDX (`@mdx-js/rollup` + Shiki dual-theme + Mermaid). pnpm only. Path aliases: `@api @components @contexts @hooks @pages @models` — **note `@models` (→`src/types`), there is NO `@types` alias** (CLAUDE.md is wrong).
+- **Conventions (keep):** `src/components/<Name>/<Name>.tsx` + `index.ts` barrel + co-located `.module.css` + `.test.tsx`; const arrow functions (`func-style: expression` ESLint); run `pnpm exec eslint --fix` on changed TSX; use the `frontend-design` skill for CSS/visual work; run `/simplify` before PRs.
+- **Tokens are a remap + deletion, NOT a clean 1:1 value swap** (correction from review). Many current tokens have **no new-system counterpart** and must be migrated by hand across `src/**/*.module.css`, e.g. `--radius-none` (~30 refs → new soft radii), `--border-width`/`-thick` (~37 refs; new system keeps the name but flips 2px→1px, a **meaning change**), `--color-bg-subtle` (~15), `--easing-default` (~12), `--color-border-subtle` (~8), `--color-link-hover` (~6), `--color-primary-hover` (~3), the `--max-w-xs/sm/md/lg/2xl` set, and the hard-shadow scale. The new system has **no hover-color tokens** (helpers just switch to `--color-primary`) and a different radius/shadow/max-width naming set. **Deliverable: an explicit old→new mapping table (including deletions) authored before the swap.** Also scope the **hardcoded** brutalist values in `src/index.css` (Mermaid `4px 4px 0 #000`, `invert(1) hue-rotate`, `--radius-none`, base body styles) — the token AC won't catch literals. Add a greppable AC: no module references a removed token.
+- **Token-value accessibility (resolved):** the design's `--color-text-faint #9A938A` on `--color-bg #FBFAF7` is only ≈2.9:1 (fails AA). **Override it to `#767066`** (~4.5:1, AA-safe for eyebrow/caption/meta text); `--color-text-muted #6F6961` (≈5.2:1) already passes. Verify the dark-mode faint `#6E685E` on `#141310` and darken if needed. axe (via `vitest-axe`) can't catch contrast under jsdom (see Testing) — this is a manual/token-level check.
+- **New dependencies:** `vitest-axe` (the Vitest-native axe-core matcher — same engine as jest-axe/Lighthouse, but ships its own types so no `@types` shim) for runtime a11y tests, and **`eslint-plugin-jsx-a11y`** for static a11y linting — the repo has *neither* today. **No icon library** — icons stay hand-inlined SVG. Self-hosted font files in `src/assets/fonts/`.
+- **Theming:** no theme flash on load is in scope (see Design). Keep the `theme` localStorage key (no gratuitous rename to `akli-theme`); whether to add a `useTheme`/context or keep the toggle self-contained is Claude Code's call. Main changes: restyle the toggle + apply `data-theme` before first paint; update the toggle test for the new markup.
+- **Accessibility (WCAG 2.2 AA) cross-cutting must-fixes** (from prototype analysis): (1) `aria-live` regions for toasts + autosave; (2) real focus-trap/Escape/**restore** dialogs; (3) checkbox semantics for ingredient toggles; (4) `aria-pressed` on filter/role toggles; (5) real button/file-input for cover dropzone; (6) admin forms wrapped in `<form>`/`<fieldset>`/`<legend>` with real headings; (7) skip link + `id="main"` on all admin pages; (8) real alt on content images + editor-collected alt wired to `<img>`; (9) `<ul>/<ol>/<li>` for grids/rows/ingredients/steps; (10) strip all design-time preview switchers/`data-props`.
+- **Additional WCAG 2.2 items not in the prototypes:** (11) **Focus management on client route change (SC 2.4.3)** — nothing currently moves focus to `<main>`/`<h1>` after navigation (`ScrollToTop` only scrolls); add a focus reset keyed on `useLocation().pathname` to the skip target. (12) **Focus Not Obscured (SC 2.4.11)** — the sticky blurred header can cover a focused element; add `scroll-margin-top`/anchor handling. (13) **Forced-colors / Windows High Contrast** — the `--ring` is `box-shadow`-only and vanishes when box-shadows are stripped; pair it with `outline: 2px solid transparent` and adopt `:focus-visible`. (14) **`@supports` fallbacks** for `color-mix()` (used in `--ring` — no support ⇒ invisible focus, an a11y regression) and `backdrop-filter` (sticky header degrades to a translucent bg with text bleed-through ⇒ provide a solid fallback).
+- **Existing `ConfirmDialog` gaps (the actual work):** it already has `role="dialog"`/`aria-modal`/Escape/Tab-trap, but lacks initial-focus-on-open, `document.activeElement` **save/restore**, and scrim-click close — those three are the adds. Native `<dialog>` + `showModal()` gives trap/Escape/top-layer/focus-restore for free (call `showModal()` in an effect, never `open` during SSR; scrim-close needs a manual `target === dialogEl` check), **but jsdom does not implement `showModal()`** — if we go native, add a jsdom polyfill in `tests/setup.ts`, else keep `role="dialog" aria-modal` so tests run.
+- **SEO:** semantic landmarks (`<main>/<nav>/<article>/<header>/<footer>`), one `<h1>` per page + ordered headings, existing `meta.ts`/sitemap plugin preserved, tag links crawlable as `<a>`. Confirm `meta.ts` titles/descriptions still apply per route.
+- **Testing:** TDD is **not** mandated for visual work (per decision). Bar = `vitest-axe` + Testing Library behavior/a11y tests, backed by `eslint-plugin-jsx-a11y` at lint time. Extend `expect` with vitest-axe's matchers (`toHaveNoViolations`) in `tests/setup.ts` (foundation gate — `vitest-axe` must land in issue 0 or downstream a11y tests can't import). Known jsdom limits to design around:
+  - **axe under jsdom (via `vitest-axe`) cannot run `color-contrast`** (no layout/paint) — it reports "incomplete", so "zero violations" does **not** cover the faint/muted contrast risk. Contrast is a **manual/token-level** check, not an axe assertion.
+  - **`aria-live` cannot be asserted as "announced"** (no AT in jsdom) — assert the live region exists with the right `aria-live` and that its text content updates after the action. Reword ACs accordingly.
+  - **Timer-driven behaviors** (autosave cadence, toast auto-dismiss ~3.6s, Copy→"Copied" 1.6s) use `vi.useFakeTimers()` + `advanceTimersByTime`; configure `userEvent.setup({ advanceTimers })` or clicks hang. (`tests/setup.ts` already shims `jest.advanceTimersByTime` so `waitFor` works under fake timers.)
+  - **`MockIntersectionObserver` fires `isIntersecting:true` synchronously on observe** — image/RecipeCard tests see images immediately loaded (good for asserting `<img alt>`), so testing the pre-intersection placeholder/`ProcessingPlaceholder` state needs a per-test non-firing IO mock.
+  - **URL-sync tests** seed `MemoryRouter initialEntries={['/blog?tag=x']}` and assert the search string via a location probe (not just "chip has aria-pressed").
+- **A shared `renderWithProviders` (MemoryRouter, + existing `AuthProvider` for admin) is worth adding** to cut boilerplate in router/auth-dependent tests (add a theme provider to it only if Claude Code introduces one).
+- **"Keep existing suite green" means _update_, not _preserve untouched_.** The `theme` key and URL params are preserved; some component APIs may change where genuinely cleaner (e.g. `Button` variants) — update those tests too. The bigger churn is markup/structure: `ThemeToggle.test.tsx` (checkbox+"Dark Mode" → icon button changes its role/name; the `theme` logic stays) and tests affected by merging `Navigation` into `Header`. Update to the new markup/APIs **without reducing coverage**; suite green **after** update.
+- **Much of the interaction logic already exists — restyle + a11y, do NOT rebuild:** `useBlocker(dirty)` + `beforeunload` (unsaved-changes) are in `RecipeEditor.tsx`; `useSearchParams` `?tag=` sync is in both `Blog.tsx` and `Recipes.tsx`; `ConfirmDialog`, `AutosaveStatus`, `ImageUpload`, `TagInput`, `useAutosave` all exist. ACs below are phrased as "preserve behavior, restyle + add the a11y gap", not greenfield.
+- **Autosave: keep the existing `useAutosave` (interval-based, 2000ms)** unless Claude Code judges a change genuinely cleaner. The design's "~1.5s debounce" is a prototype detail, not a mandate. Restyle the indicator.
+- **Docs:** update `CLAUDE.md` (remove neo-brutalist + `--radius-none` mandate; document paper tokens, Geist/JetBrains self-host, the a11y-test bar (`vitest-axe` + `eslint-plugin-jsx-a11y`); fix `@types`→`@models` and Vite 6→7). Keep the `theme` key in docs; update the toggle/theme description to match whatever's implemented. Mark `docs/prds/redesign.md` deprecated (superseded by this).
+- **Suggested sequencing** (mega-PRD, one epic; matches the stacked-issue milestone workflow — no per-issue PRs, one green epic→main PR): (0) tokens + fonts + theme no-flash + `_helpers` port + vitest-axe & jsx-a11y setup → (1) shared shell + primitives (Header/Footer/Button/Link/Card/Tag/StatusBadge/Input/Textarea/Toast/ConfirmDialog/ThemeToggle) → (2) public pages Home→Apps→Blog→BlogPost→Recipes→Recipe (+ shared RecipeView) → (3) admin Login→RecipeList→Editor(largest)→Preview→Users → (4) CLAUDE.md + cleanup + `/simplify`.
+
+## Acceptance Criteria
+
+**Foundation**
+
+- [ ] `src/styles/tokens.css` defines the full paper token set (semantic `--color-*` light on `:root` + dark under `[data-theme="dark"]`, short aliases, typography/spacing/radius/shadow/focus/layout/motion) with values matching `docs/design/paper/design_system/tokens/`. No neo-brutalist tokens remain.
+- [ ] **(greppable)** No `src/**` file references a removed token (`--radius-none`, `--color-bg-subtle`, `--easing-default`, hard-shadow scale, old `--max-w-*`, etc.), and no `.module.css`/`index.css` contains hardcoded brutalist literals (`4px 4px 0`, `#000` borders, `invert(1)`); a grep in CI/verification returns nothing.
+- [ ] An old→new token mapping table (incl. deletions + the `--border-width` 2px→1px meaning flip) exists and every consumer is migrated per it.
+- [ ] `--color-text-faint` is `#767066` (~4.5:1 on paper); every muted/faint text token meets WCAG AA against its background in both themes (manual/token-level contrast check; dark-mode faint verified/darkened as needed).
+- [ ] Geist (400/500/600/700) + JetBrains Mono (400/500) are self-hosted woff2 with `font-display: swap`; no request to `fonts.googleapis.com`; `--font-sans`/`--font-mono` resolve to them with system fallbacks.
+- [ ] **No theme flash on load:** the persisted / `prefers-color-scheme` theme is applied to `data-theme` before first paint (verified in the SSR/prod build), with no hydration-mismatch warning.
+- [ ] `ThemeToggle` is restyled to the design's round icon button (☾/☀, `aria-label`); the existing `localStorage('theme')` key is kept (no rename to `akli-theme`). The internal approach (self-contained vs `useTheme`/context) is the implementer's choice.
+- [ ] Interaction behaviors (nudge/lift/zoom/focus-ring/chip-hovers/spinner/shimmer) ship in the component modules, and `prefers-reduced-motion: reduce` disables **all** transform/opacity motion — both the shared spinner/shimmer/nudge/lift **and** per-module card/tag/toggle/header transitions.
+- [ ] Focus ring uses `:focus-visible`, includes a forced-colors fallback (`outline: 2px solid transparent`), and has `@supports` fallbacks for `color-mix()` and `backdrop-filter`.
+- [ ] Critical fonts (Geist 400/500) are `<link rel="preload">`ed and a metric-matched fallback `@font-face` is present (CLS from `swap` held); no request to `fonts.googleapis.com`.
+- [ ] `vitest-axe` is installed and its matchers (`toHaveNoViolations`) are extended in `tests/setup.ts` (+ a native-`<dialog>` `showModal` polyfill); `eslint-plugin-jsx-a11y` is added to `eslint.config.js` (flat config) and passes. No icon library added — icons stay hand-inlined SVG.
+
+**Per screen (each of the 12 routes)**
+
+- [ ] **(manual)** Visual sign-off against the `docs/design/paper/` prototype in **both** light and dark (no automated visual-regression this iteration — this is a manual AC, not CI-gated).
+- [ ] **(greppable)** No hardcoded hex/px colors or radii outside the token layer in the page's modules.
+- [ ] Uses correct landmarks (`<main id="main">` + skip link on every page incl. all admin), a single `<h1>`, and non-skipped heading order.
+- [ ] On client route change, focus moves to `<main>`/`<h1>` (SC 2.4.3), and a focused element is never obscured by the sticky header (SC 2.4.11).
+- [ ] Card grids/rows/ingredients/steps use `<ul>/<ol>/<li>`; interactive elements are real `<button>`/`<a>` (no `role="button"` divs); content images have meaningful `alt`.
+- [ ] `axe` reports **zero violations for the rules runnable in jsdom** (roles/names/aria/landmarks/heading-order); `color-contrast` is out of jsdom scope and covered by the manual contrast + Lighthouse pass.
+
+**Interactions (adopt design behavior; keep sound APIs, change where cleaner)**
+
+- [ ] Blog: tag chips are `<button aria-pressed>`; clicking filters the list, updates the pluralized count via an `aria-live` region, and preserves the **existing** `?tag=` sync (existing param name, derived from URL); empty state + clear work.
+- [ ] Recipes: `<form role="search">` filters client-side (title/desc/tags); **dynamic** tag-filter chips (from `/recipes/tags`, not a hardcoded set) with `aria-pressed` sync `?tag=` (same param as Blog, on the existing `recipe.tags`); search does **not** touch the URL; empty state + clear-filters work; count announced.
+- [ ] Recipe/Preview: ingredients are real checkboxes announcing checked state and **persisting per recipe in `localStorage`** across reloads; steps render as an `<ol>`; `RecipeView` is shared between public Recipe and admin Preview.
+- [ ] Editor: the **existing** autosave (`useAutosave`, interval-based) is preserved; its indicator renders an `aria-live="polite"` region whose text updates on each transition saving→saved(relative time)→error+Retry (tested with fake timers); slug auto-derives until edited/locked; images `empty→processing→ready`; Publish disabled until the checklist passes (incl. every ready image has alt + none processing); existing `useBlocker` unsaved-changes(Leave) + Discard dialogs preserved and restyled; collected alt is wired to the `<img alt>`.
+- [ ] Header active link sets `aria-current="page"`; the ThemeToggle flips theme + persists via the existing `theme` key.
+- [ ] Toasts render through one `aria-live` container (assertive for errors), auto-dismiss ~3.6s, dismiss on click.
+- [ ] All ConfirmDialog usages (Delete/Remove/Discard/Leave) set initial focus on open, trap focus, close on Escape and scrim click, **restore focus to the triggering element on close** (the current custom dialog does not), and use the `danger` variant where destructive.
+- [ ] No design-time affordance ships (no preview "state switcher", no `data-props` toggles, no `.dc.html`/`support.js`).
+
+**Tests & docs**
+
+- [ ] Existing tests are **updated** where markup/structure or a component API changed (e.g. `ThemeToggle` icon-button restyle, `Navigation`→`Header` merge, any `Button` variant change) without reducing coverage; the suite is green after update. (The `theme` key and URL params are preserved.) A shared `renderWithProviders` (MemoryRouter, + `AuthProvider` for admin) is available for router/auth-dependent tests.
+- [ ] New tests cover the adopted interactions (filter/search/URL-sync via `initialEntries`, ingredient check state, autosave transitions under fake timers, publish gating, dialog focus-trap/restore, toast auto-dismiss, `aria-pressed`/`aria-current`) using Testing Library role/text queries.
+- [ ] `CLAUDE.md` updated (paper system, fonts, a11y-test bar = `vitest-axe` + `eslint-plugin-jsx-a11y`; `@models` not `@types`; Vite 7; existing `theme` key/toggle left intact); `docs/prds/redesign.md` marked deprecated.
+
+## Resolved Decisions
+
+All open questions were resolved on 2026-07-01:
+
+1. **Footer links** — reuse the existing three from `SocialCard`: GitHub `https://github.com/vandelay87`, LinkedIn `https://www.linkedin.com/in/akli-aissat-b08119115/`, Email `mailto:akliaissat@outlook.com`.
+2. **Home hero** — **keep the profile photo** (restyled to the paper look); **rewrite the bio** to the design's plain/dry voice (current copy is too hype-y); CTAs = Email me + Download CV.
+3. **Ingredient check-off** — **persist checked state per recipe in `localStorage`** across reloads (a deliberate improvement over the prototype, which doesn't persist).
+4. **Icons** — **no icon library**; keep hand-inlined outline SVG (Lucide-grade paths, `aria-hidden` + text label). GitHub/LinkedIn brand glyphs stay as their existing SVGs.
+5. **Button variants** — add destructive/outline styles + pill shape under whatever variant naming is cleanest (Claude Code's call at implementation); update all callers.
+6. **`--color-text-faint`** — **darken to `#767066`** (~4.5:1 on paper, AA-safe); verify/darken the dark-mode faint `#6E685E` on `#141310` too.
+7. **Dialogs** — use **native `<dialog>` + `showModal()`** (focus-trap/Escape/restore/top-layer for free); add a jsdom `showModal` polyfill in `tests/setup.ts`.
+8. **Warning token** — the `#A66E0A` text vs `#C2810C` Callout-tint split is intentional in the design; use the design's values verbatim.
+9. **Recipes filter chips** — **keep dynamic** (all tags from `/recipes/tags`, restyled to the paper look); do **not** adopt the design's curated "category" chips as a taxonomy or hardcode a category list. `(count)` label optional. (A real `category` field would be separate, out-of-scope backend work.)
+10. **Fonts** — **manual self-host** (commit `.woff2`, no Fontsource dependency); latin-only, weights used only, `OFL.txt` included. (See Design & UX → Fonts.)
+
+## Verification (post-implementation)
+
+- `pnpm test` green; `pnpm exec eslint` clean on changed files.
+- `pnpm build` + SSR run: load each route, hard-reload in each theme, confirm **no theme flash** and no hydration warning; toggle theme (dev image upload needs `VITE_S3_BUCKET_HOST`).
+- Manual axe/Lighthouse pass per route (both themes); keyboard-only walkthrough of dialogs, filters, editor.
+- Visually diff against `docs/design/paper/` prototypes (open `.dc.html` in browser) for layout/spacing fidelity.

--- a/docs/prds/redesign.md
+++ b/docs/prds/redesign.md
@@ -1,5 +1,7 @@
 # PRD: Site Redesign — Modern Minimal Brutalist
 
+> ⚠️ **DEPRECATED (2026-07-01).** This neo-brutalist direction has been superseded by the warm editorial "paper" redesign. See [`paper-redesign.md`](./paper-redesign.md) and the design source of truth at `docs/design/paper/`. Kept for historical context only — do not implement from this document.
+
 ## Overview
 
 Redesign akli.dev with a modern neo-brutalist aesthetic. The site was recently migrated from Tailwind to CSS Modules, but the visual result drifted from the original without a clear design direction. This PRD defines that direction: clean, minimal, blocky, with generous whitespace and zero decorative animation. The goal is a portfolio that looks intentional and distinctive — not generic, not cluttered.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ import vitest from 'eslint-plugin-vitest'
 import globals from 'globals'
 
 export default [
-  { ignores: ['dist', 'coverage/**'] },
+  { ignores: ['dist', 'coverage/**', 'docs/**'] },
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
     languageOptions: {


### PR DESCRIPTION
## What

Adds the planning docs for the **warm editorial "paper"** redesign of akli.dev. **Docs only — nothing ships in the build** (`docs/` is not part of the Vite bundle).

- **`docs/prds/paper-redesign.md`** — the PRD: full token migration, self-hosted fonts (manual woff2), first-class theming with no-flash, all 12 routes with semantic + WCAG 2.2 AA upgrades, adopted interactions, grouped acceptance criteria, and a resolved-decisions log.
- **`docs/design/paper/`** — the design source-of-truth bundle (tokens, component contracts, page prototypes, UI kits, guidelines). Convention: `docs/prds/<slug>.md` ↔ `docs/design/<slug>/`.
- **`CLAUDE.md`** — points to the new PRD; notes the redesign supersedes the neo-brutalist mandate; fixes stale facts (`@models` not `@types`, Vite 7).
- **`docs/prds/redesign.md`** — marked **deprecated** (old neo-brutalist direction), links to the new PRD.

## Scope & principles

- Re-skin + a11y/semantics overhaul of the already-built app; **preserves all product features, routes, state, and API contracts**.
- Design dictates look & behavior; **Claude Code owns code decisions** (no gratuitous churn — keeps the `theme` key, `?tag=` params, `useAutosave`, etc.).
- Testing bar: `vitest-axe` + `eslint-plugin-jsx-a11y` + Testing Library; no visual-regression TDD.

## Not included

- No implementation — this is the plan. Next step after merge: `/prd-to-issues` to generate the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)