### PR TITLE
Add no-flash theming and restyle ThemeToggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,15 @@
       type="font/woff2"
       crossorigin
     />
+    <script>
+      try {
+        var persistedTheme = localStorage.getItem('theme')
+        var theme =
+          persistedTheme ||
+          (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+        document.documentElement.setAttribute('data-theme', theme)
+      } catch (error) {}
+    </script>
     <!--ssr-head-->
   </head>
   <body>

--- a/index.html.test.ts
+++ b/index.html.test.ts
@@ -81,20 +81,13 @@ describe('index.html no-flash theme script', () => {
   })
 
   it('does not throw when localStorage access fails (e.g. private browsing)', () => {
-    const throwingRun = () => {
-      const setAttribute = vi.fn()
-      const documentElement = { getAttribute: vi.fn(), setAttribute }
-      const mockDocument = { documentElement }
-      const mockLocalStorage = {
-        getItem: vi.fn(() => {
+    const throwingRun = () =>
+      run({
+        getItem: () => {
           throw new Error('SecurityError: access denied')
-        }),
-      }
-      const mockWindow = { matchMedia: vi.fn(() => ({ matches: false })) }
-
-      const scriptFn = new Function('document', 'localStorage', 'window', scriptBody)
-      scriptFn(mockDocument, mockLocalStorage, mockWindow)
-    }
+        },
+        matches: false,
+      })
 
     expect(throwingRun).not.toThrow()
   })

--- a/index.html.test.ts
+++ b/index.html.test.ts
@@ -1,0 +1,43 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// Static-content check for the blocking no-flash theme script that must live
+// in index.html's <head>, before React ever mounts. jsdom can't observe an
+// actual paint, so this only verifies the mechanism has the right shape
+// (reads persisted theme, falls back to prefers-color-scheme, sets
+// data-theme before first paint, fails safe) — it does not prove there is
+// zero visual flash. That's a manual/build-verification concern.
+describe('index.html no-flash theme script', () => {
+  const currentDir = path.dirname(fileURLToPath(import.meta.url))
+  const html = fs.readFileSync(path.join(currentDir, 'index.html'), 'utf-8')
+
+  const headSection = html.slice(html.indexOf('<head>'), html.indexOf('<!--ssr-head-->'))
+  const inlineScriptMatch = headSection.match(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/)
+
+  it('has a blocking inline <script> in <head>, before <!--ssr-head-->', () => {
+    expect(inlineScriptMatch).not.toBeNull()
+  })
+
+  const scriptBody = inlineScriptMatch?.[1] ?? ''
+
+  it('reads the persisted theme from localStorage', () => {
+    expect(scriptBody).toMatch(/localStorage/)
+  })
+
+  it('falls back to prefers-color-scheme via matchMedia', () => {
+    expect(scriptBody).toMatch(/matchMedia/)
+    expect(scriptBody).toMatch(/prefers-color-scheme/)
+  })
+
+  it('sets data-theme on document.documentElement', () => {
+    expect(scriptBody).toMatch(/documentElement/)
+    expect(scriptBody).toMatch(/setAttribute\(\s*['"]data-theme['"]/)
+  })
+
+  it('is wrapped in try/catch so a storage/API failure never blocks render', () => {
+    expect(scriptBody).toMatch(/\btry\b/)
+    expect(scriptBody).toMatch(/\bcatch\b/)
+  })
+})

--- a/index.html.test.ts
+++ b/index.html.test.ts
@@ -1,14 +1,16 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-// Static-content check for the blocking no-flash theme script that must live
-// in index.html's <head>, before React ever mounts. jsdom can't observe an
-// actual paint, so this only verifies the mechanism has the right shape
-// (reads persisted theme, falls back to prefers-color-scheme, sets
-// data-theme before first paint, fails safe) — it does not prove there is
-// zero visual flash. That's a manual/build-verification concern.
+// Behavioral check for the blocking no-flash theme script that must live in
+// index.html's <head>, before React ever mounts. jsdom can't observe an
+// actual paint, so this executes the *real* extracted script body against
+// controlled mock inputs (document/localStorage/window) and asserts the
+// resulting document.documentElement.setAttribute calls — proving the actual
+// priority order and try/catch behavior, not just vocabulary. It still does
+// not prove there is zero visual flash in a real browser — that's a
+// manual/build-verification concern.
 describe('index.html no-flash theme script', () => {
   const currentDir = path.dirname(fileURLToPath(import.meta.url))
   const html = fs.readFileSync(path.join(currentDir, 'index.html'), 'utf-8')
@@ -22,22 +24,78 @@ describe('index.html no-flash theme script', () => {
 
   const scriptBody = inlineScriptMatch?.[1] ?? ''
 
-  it('reads the persisted theme from localStorage', () => {
-    expect(scriptBody).toMatch(/localStorage/)
+  const run = (options: {
+    getItem: (key: string) => string | null
+    matches: boolean
+  }) => {
+    const setAttribute = vi.fn()
+    const getAttribute = vi.fn()
+    const documentElement = { getAttribute, setAttribute }
+    const mockDocument = { documentElement }
+    const mockLocalStorage = { getItem: vi.fn(options.getItem) }
+    const mockMatchMedia = vi.fn(() => ({ matches: options.matches }))
+    const mockWindow = { matchMedia: mockMatchMedia }
+
+    const scriptFn = new Function('document', 'localStorage', 'window', scriptBody)
+    scriptFn(mockDocument, mockLocalStorage, mockWindow)
+
+    return { setAttribute, matchMedia: mockMatchMedia }
+  }
+
+  it('uses persisted dark theme over system preference', () => {
+    const { setAttribute, matchMedia } = run({
+      getItem: () => 'dark',
+      matches: false, // system prefers light — persisted value should still win
+    })
+
+    expect(setAttribute).toHaveBeenCalledWith('data-theme', 'dark')
+    expect(matchMedia).not.toHaveBeenCalled()
   })
 
-  it('falls back to prefers-color-scheme via matchMedia', () => {
-    expect(scriptBody).toMatch(/matchMedia/)
-    expect(scriptBody).toMatch(/prefers-color-scheme/)
+  it('uses persisted light theme over system preference', () => {
+    const { setAttribute, matchMedia } = run({
+      getItem: () => 'light',
+      matches: true, // system prefers dark — persisted value should still win
+    })
+
+    expect(setAttribute).toHaveBeenCalledWith('data-theme', 'light')
+    expect(matchMedia).not.toHaveBeenCalled()
   })
 
-  it('sets data-theme on document.documentElement', () => {
-    expect(scriptBody).toMatch(/documentElement/)
-    expect(scriptBody).toMatch(/setAttribute\(\s*['"]data-theme['"]/)
+  it('falls back to prefers-color-scheme: dark when nothing is persisted', () => {
+    const { setAttribute } = run({
+      getItem: () => null,
+      matches: true,
+    })
+
+    expect(setAttribute).toHaveBeenCalledWith('data-theme', 'dark')
   })
 
-  it('is wrapped in try/catch so a storage/API failure never blocks render', () => {
-    expect(scriptBody).toMatch(/\btry\b/)
-    expect(scriptBody).toMatch(/\bcatch\b/)
+  it('falls back to light when nothing is persisted and system prefers light', () => {
+    const { setAttribute } = run({
+      getItem: () => null,
+      matches: false,
+    })
+
+    expect(setAttribute).toHaveBeenCalledWith('data-theme', 'light')
+  })
+
+  it('does not throw when localStorage access fails (e.g. private browsing)', () => {
+    const throwingRun = () => {
+      const setAttribute = vi.fn()
+      const documentElement = { getAttribute: vi.fn(), setAttribute }
+      const mockDocument = { documentElement }
+      const mockLocalStorage = {
+        getItem: vi.fn(() => {
+          throw new Error('SecurityError: access denied')
+        }),
+      }
+      const mockWindow = { matchMedia: vi.fn(() => ({ matches: false })) }
+
+      const scriptFn = new Function('document', 'localStorage', 'window', scriptBody)
+      scriptFn(mockDocument, mockLocalStorage, mockWindow)
+    }
+
+    expect(throwingRun).not.toThrow()
   })
 })

--- a/src/components/ThemeToggle/ThemeToggle.module.css
+++ b/src/components/ThemeToggle/ThemeToggle.module.css
@@ -1,80 +1,34 @@
 /* ThemeToggle component styles */
 
-.wrapper {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-}
-
-.label {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text);
-}
-
-/* ── Toggle label (clickable area) ──────────────────────────── */
-
-.toggleLabel {
-  position: relative;
+.toggle {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  width: 32px;  /* icon-button box — no spacing token matches this exact size */
+  height: 32px;
+  font-size: 13px; /* sizes the ☾/☀ glyph within the 32px box */
+  color: var(--color-text-strong);
+  background: transparent;
+  border: var(--border-width) solid var(--color-border-strong);
+  border-radius: var(--radius-full);
   cursor: pointer;
+  transition: background var(--duration-fast) var(--easing-default),
+              border-color var(--duration-fast) var(--easing-default);
 }
 
-/* Visually hidden checkbox — keeps native semantics */
-.input {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+/* Subtle theme-aware shade on hover — not an accent color */
+.toggle:hover {
+  border-color: var(--color-border-strong);
+  background: color-mix(in srgb, var(--color-text-strong) 6%, transparent);
 }
 
-/* ── Track ───────────────────────────────────────────────────── */
-
-.track {
-  position: relative;
-  width: 2.5rem;
-  height: 1.5rem;
-  background-color: var(--color-surface);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-full);
-  transition: background-color var(--duration-base) var(--easing-default);
-}
-
-.track.checked {
-  background-color: var(--color-primary);
-}
-
-.input:focus-visible + .track {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
-
-/* ── Thumb ───────────────────────────────────────────────────── */
-
-.thumb {
-  position: absolute;
-  top: 50%;
-  width: 1rem;
-  height: 1rem;
-  background-color: var(--color-bg);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-full);
-  transform: translateX(3px) translateY(-50%);
-  transition: transform var(--duration-fast) var(--easing-default);
-}
-
-.thumb.checked {
-  transform: translateX(calc(2.5rem - 1rem - 5px)) translateY(-50%);
+.toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--ring);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .thumb {
+  .toggle {
     transition: none;
   }
 }

--- a/src/components/ThemeToggle/ThemeToggle.module.css
+++ b/src/components/ThemeToggle/ThemeToggle.module.css
@@ -18,7 +18,6 @@
 
 /* Subtle theme-aware shade on hover — not an accent color */
 .toggle:hover {
-  border-color: var(--color-border-strong);
   background: color-mix(in srgb, var(--color-text-strong) 6%, transparent);
 }
 

--- a/src/components/ThemeToggle/ThemeToggle.test.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.test.tsx
@@ -8,41 +8,58 @@ describe('ThemeToggle', () => {
     document.documentElement.removeAttribute('data-theme')
   })
 
-  it('renders the toggle component', () => {
-    render(<ThemeToggle />)
-    expect(screen.getByLabelText(/dark mode/i)).toBeInTheDocument()
-  })
-
-  it('toggles theme from light to dark', () => {
+  it('renders a round icon button with an accessible label describing the switch action', () => {
     render(<ThemeToggle />)
 
-    const toggle = screen.getByRole('checkbox')
-
-    expect(toggle).not.toBeChecked()
-    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
-
-    fireEvent.click(toggle)
-
-    expect(toggle).toBeChecked()
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
-    expect(localStorage.getItem('theme')).toBe('dark')
+    expect(
+      screen.getByRole('button', { name: /switch to (dark|light) mode/i })
+    ).toBeInTheDocument()
   })
 
-  it('toggles theme from dark to light', () => {
-    localStorage.setItem('theme', 'dark')
+  it('labels the button "Switch to dark mode" when the current theme is light', () => {
+    document.documentElement.setAttribute('data-theme', 'light')
+
+    render(<ThemeToggle />)
+
+    expect(screen.getByRole('button', { name: 'Switch to dark mode' })).toBeInTheDocument()
+  })
+
+  it('reflects the theme already set on the document root on initial render (no hydration mismatch)', () => {
+    // Simulates the blocking no-flash script having already set data-theme
+    // before React mounts. The toggle must reflect that on first render,
+    // not default to assuming light.
     document.documentElement.setAttribute('data-theme', 'dark')
 
     render(<ThemeToggle />)
 
-    const toggle = screen.getByRole('checkbox')
+    expect(screen.getByRole('button', { name: 'Switch to light mode' })).toBeInTheDocument()
+  })
 
-    expect(toggle).toBeChecked()
+  it('flips data-theme on the document root and updates its label when clicked', () => {
+    document.documentElement.setAttribute('data-theme', 'light')
+
+    render(<ThemeToggle />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to dark mode' }))
+
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    expect(screen.getByRole('button', { name: 'Switch to light mode' })).toBeInTheDocument()
 
-    fireEvent.click(toggle)
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to light mode' }))
 
-    expect(toggle).not.toBeChecked()
     expect(document.documentElement.getAttribute('data-theme')).toBe('light')
-    expect(localStorage.getItem('theme')).toBe('light')
+    expect(screen.getByRole('button', { name: 'Switch to dark mode' })).toBeInTheDocument()
+  })
+
+  it('persists the new theme to the existing "theme" localStorage key (kept, not renamed)', () => {
+    document.documentElement.setAttribute('data-theme', 'light')
+
+    render(<ThemeToggle />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to dark mode' }))
+
+    expect(localStorage.getItem('theme')).toBe('dark')
+    // The design reference's `akli-theme` key is an explicit non-adoption per the PRD.
+    expect(localStorage.getItem('akli-theme')).toBeNull()
   })
 })

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,20 +1,15 @@
-import { useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 import styles from './ThemeToggle.module.css'
 
 type Theme = 'light' | 'dark'
 
-const getInitialTheme = (): Theme => {
-  if (typeof document === 'undefined') return 'light'
-
-  const domTheme = document.documentElement.getAttribute('data-theme')
-  if (domTheme === 'light' || domTheme === 'dark') return domTheme
-
-  const storedTheme = typeof window !== 'undefined' ? localStorage.getItem('theme') : null
-  return storedTheme === 'dark' ? 'dark' : 'light'
-}
-
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState<Theme>(getInitialTheme)
+  const [theme, setTheme] = useState<Theme>('light')
+
+  useLayoutEffect(() => {
+    const domTheme = document.documentElement.getAttribute('data-theme')
+    if (domTheme === 'dark') setTheme('dark')
+  }, [])
 
   const isDark = theme === 'dark'
 

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,41 +1,38 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import styles from './ThemeToggle.module.css'
 
+type Theme = 'light' | 'dark'
+
+const getInitialTheme = (): Theme => {
+  if (typeof document === 'undefined') return 'light'
+
+  const domTheme = document.documentElement.getAttribute('data-theme')
+  if (domTheme === 'light' || domTheme === 'dark') return domTheme
+
+  const storedTheme = typeof window !== 'undefined' ? localStorage.getItem('theme') : null
+  return storedTheme === 'dark' ? 'dark' : 'light'
+}
+
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState(() =>
-    typeof window !== 'undefined' ? localStorage.getItem('theme') || 'light' : 'light'
-  )
-  useEffect(() => {
-    document.documentElement.setAttribute('data-theme', theme)
-    localStorage.setItem('theme', theme)
-  }, [theme])
+  const [theme, setTheme] = useState<Theme>(getInitialTheme)
 
   const isDark = theme === 'dark'
 
-  const trackClass = [styles.track, isDark ? styles.checked : ''].filter(Boolean).join(' ')
-
-  const thumbClass = [styles.thumb, isDark ? styles.checked : ''].filter(Boolean).join(' ')
+  const handleClick = () => {
+    const nextTheme: Theme = isDark ? 'light' : 'dark'
+    document.documentElement.setAttribute('data-theme', nextTheme)
+    localStorage.setItem('theme', nextTheme)
+    setTheme(nextTheme)
+  }
 
   return (
-    <div className={styles.wrapper}>
-      <span id="theme-toggle-label" className={styles.label}>
-        Dark Mode
-      </span>
-
-      <label htmlFor="theme-toggle" className={styles.toggleLabel}>
-        <input
-          id="theme-toggle"
-          type="checkbox"
-          className={styles.input}
-          checked={isDark}
-          onChange={() => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))}
-          aria-labelledby="theme-toggle-label"
-          aria-checked={isDark}
-        />
-        <div className={trackClass}>
-          <div className={thumbClass} />
-        </div>
-      </label>
-    </div>
+    <button
+      type="button"
+      className={styles.toggle}
+      onClick={handleClick}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      <span aria-hidden="true">{isDark ? '☀' : '☾'}</span>
+    </button>
   )
 }

--- a/src/entry-server.test.tsx
+++ b/src/entry-server.test.tsx
@@ -39,6 +39,18 @@ describe('entry-server render', () => {
       // The root div should not be empty — it should have rendered content
       expect(html).not.toContain('<div id="root"></div>')
     })
+
+    it('always renders ThemeToggle in its light-theme state, since SSR has no way to know the visitor\'s real theme', async () => {
+      const html = await render('/')
+      // The server always runs with no `document`, so ThemeToggle must always
+      // start from its light-theme markup — the client's mount-gated
+      // useLayoutEffect correction depends on the first client render
+      // matching this exactly. If SSR output ever became theme-dependent,
+      // this would drift from the client's first render and reintroduce a
+      // hydration mismatch.
+      expect(html).toContain('aria-label="Switch to dark mode"')
+      expect(html).not.toContain('aria-label="Switch to light mode"')
+    })
   })
 
   describe('apps page /apps', () => {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -14,6 +14,7 @@
     "tests/**/*.tsx",
     "sitemap-plugin.ts",
     "sitemap-plugin.test.ts",
+    "index.html.test.ts",
     "plugins/**/*.ts"
   ],
   "exclude": ["node_modules", "dist", "coverage"]


### PR DESCRIPTION
Closes #220

## What changed
- `index.html`: blocking inline `<script>` in `<head>` (before `<!--ssr-head-->`) that reads `localStorage('theme')`, falls back to `prefers-color-scheme`, and sets `data-theme` on `<html>` before first paint. Wrapped in `try/catch`.
- `ThemeToggle`: rewritten from a checkbox "Dark Mode" switch to a 32px round icon button (☾/☀, `aria-label`), per the paper design reference. Mount-gated to avoid a hydration mismatch (see Decisions made).
- `ThemeToggle.module.css`: restyled using paper tokens (`--color-border-strong`, `--radius-full`, `--duration-fast`/`--easing-default`, `--ring` for focus-visible — the first component in this epic to consume `--ring`).
- Tests: `ThemeToggle.test.tsx` rewritten for the icon-button contract; new `index.html.test.ts` executes the real blocking script against mocked `document`/`localStorage`/`window` to prove priority order and try/catch behavior; new `entry-server.test.tsx` regression test locks in that SSR always emits the light-theme markup.

## Why
Part of the paper redesign PRD (`docs/prds/paper-redesign.md`) — "no theme flash on load" is an explicit quality goal, and the `theme` localStorage key must not be renamed (PRD's own example of the "no gratuitous churn" rule).

## How to verify
- `pnpm build:client && pnpm build:server` (or `pnpm dev`), load the site with a persisted `dark` theme, hard-reload — no flash of the light theme, no console hydration warning.
- `pnpm test` — all green, including the new behavioral/regression tests.

## Decisions made
- **Real bug caught in review, fixed in a follow-up commit**: the first implementation read `document.documentElement`'s `data-theme` inside `useState`'s initializer. That works client-side, but `entry-server.tsx` runs in Node with no `document` at all, so SSR always fell back to a hardcoded `'light'` default regardless of the visitor's real theme — meaning a dark-theme visitor's client-side first render would compute `'dark'` before hydration ran, a genuine mismatch (React hydration warning + a visible post-hydration flip of the toggle's icon/label). Fixed via mount-gating per the PRD's own suggested alternative (`docs/prds/paper-redesign.md:84`): `useState` always starts at `'light'` (matching SSR unconditionally), then a `useLayoutEffect` corrects to the real theme by reading `data-theme` before the browser paints — server/client first render now match exactly (no warning), and the correction lands pre-paint (no visible flash).
- Kept `ThemeToggle` self-contained (local `useState`, no `useTheme`/context) — the PRD left this as an implementation choice, and there's only one consumer today (`Header.tsx`); a shared hook would be premature for n=1.
- `.toggle`'s 32×32px box and `13px` font-size are literals, not tokens — `--space-8` numerically matches 32px but was deliberately not used, since a spacing-scale token implies gap/margin intent, not a fixed icon-button dimension; considered and rejected rather than an oversight (a `/simplify` reuse pass also flagged this against `BlogPost.module.css`'s `.shareLink`, which uses a *different*, also-deliberate 40px per its own design context — not a real duplication, two components with two different specified sizes).
- `tsconfig.eslint.json` gained `index.html.test.ts` in its `include` list, matching the existing `sitemap-plugin.test.ts` root-level-test precedent — needed for ESLint's typed linting to parse the new root test file.

## Out of scope
None filed as follow-up issues.