### PR TITLE
Port interaction utilities + focus/motion a11y

### DIFF
--- a/src/components/ThemeToggle/ThemeToggle.module.css
+++ b/src/components/ThemeToggle/ThemeToggle.module.css
@@ -1,6 +1,7 @@
 /* ThemeToggle component styles */
 
 .toggle {
+  composes: focusRing from '../../styles/interactions.module.css';
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -19,11 +20,6 @@
 /* Subtle theme-aware shade on hover — not an accent color */
 .toggle:hover {
   background: color-mix(in srgb, var(--color-text-strong) 6%, transparent);
-}
-
-.toggle:focus-visible {
-  outline: none;
-  box-shadow: var(--ring);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -10,6 +10,14 @@
   100% { transform: translateX(150%); }
 }
 
+/* Background-position sweep variant — used by src/styles/interactions.module.css
+   .shimmer (ported from design-system _helpers.css .ds-shimmer). Distinct
+   from `shimmer` above (which animates transform on an overlay pseudo-element)
+   because it drives background-position on a gradient background instead. */
+@keyframes shimmerSweep {
+  to { background-position: -200% 0; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   @keyframes spin {
     from, to { transform: none; }
@@ -17,5 +25,9 @@
 
   @keyframes shimmer {
     0%, 100% { transform: none; }
+  }
+
+  @keyframes shimmerSweep {
+    from, to { background-position: 0 0; }
   }
 }

--- a/src/styles/interactions.module.css
+++ b/src/styles/interactions.module.css
@@ -1,0 +1,170 @@
+/* Shared interaction-utility classes — CSS Modules port of the design
+   system's `_helpers.css` (`.ds-*`) behaviors: link icon nudge, card
+   lift+zoom, chip/tag/suggest/upload/danger-iconbtn hovers, spinner,
+   shimmer. See docs/prds/paper-redesign.md (line 71) — the `.ds-*` global
+   class contract is intentionally NOT shipped; component `.module.css`
+   files consume these via `composes: x from '../../styles/interactions.module.css';`
+   (relative path from a component two levels down in src/components/<Name>/ —
+   there is no `@/` or `@styles` alias in this project) instead.
+
+   Field focus-ring and the `--ring` box-shadow are deliberately NOT in this
+   file — that's owned by the a11y-engineer pass (issue #221 AC2), which
+   also adds the forced-colors / `@supports(color-mix/backdrop-filter)`
+   fallbacks. Toast hover-reveal, header sticky-blur, and theme-toggle hover
+   are out of scope here too: each belongs to a component that either
+   already has its own paper-spec styling (ThemeToggle) or is a separate
+   future rebuild issue (Toast, Header) that will port its own `_helpers.css`
+   rule when it lands. */
+
+/* ── Links — icon nudge ──────────────────────────────────────
+   Apply `linkIcon` to the icon element, and one direction class to the
+   link (ancestor). e.g. (path relative to a component two levels down in
+   src/components/<Name>/ — adjust for the consuming file's actual depth)
+     .link  { composes: nudgeRight from '../../styles/interactions.module.css'; }
+     .icon  { composes: linkIcon   from '../../styles/interactions.module.css'; } */
+.linkIcon {
+  display: inline-flex;
+  transition: transform var(--duration-fast) var(--easing-default);
+}
+
+.nudgeRight:hover .linkIcon {
+  transform: translateX(3px);
+}
+
+.nudgeLeft:hover .linkIcon {
+  transform: translateX(-3px);
+}
+
+.nudgeUpRight:hover .linkIcon {
+  transform: translate(3px, -3px);
+}
+
+/* ── Recipe card — lift + cover zoom (the signature hover) ───
+   Durations/curve are a deliberate custom easing distinct from the
+   standard --duration-fast/--duration-base scale (source: _helpers.css
+   ".ds-recipe-card", labelled "the signature hover") — not in the token
+   scale, kept literal on purpose. Apply `cardLift` to the card root and
+   `cardLiftImage` to the cover image inside it. */
+.cardLift {
+  transition:
+    transform 0.3s cubic-bezier(0.2, 0.7, 0.2, 1),
+    box-shadow 0.3s var(--easing-default);
+}
+
+.cardLift:hover {
+  transform: translateY(-4px);
+  /* Elevation shadow doesn't match an existing --shadow-* token exactly
+     (closest is --shadow-lg); kept literal per _helpers.css spec. */
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.1);
+}
+
+.cardLiftImage {
+  transition: transform 0.5s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.cardLift:hover .cardLiftImage {
+  transform: scale(1.04);
+}
+
+/* ── Surface hover wash — generic card/tag background tint ───
+   (source: _helpers.css ".ds-card-hover") */
+.surfaceHover:hover {
+  background: var(--color-hover);
+}
+
+/* ── Chip hover — tag buttons + suggestion pills ──────────────
+   ds-tag-btn and ds-suggest are identical in _helpers.css; shared here
+   via one composable class. */
+.chipHover:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+/* ── Upload dropzone hover ─────────────────────────────────── */
+.uploadHover:hover {
+  border-color: var(--color-primary);
+  background: var(--color-hover);
+}
+
+/* ── Danger icon-button hover ──────────────────────────────── */
+.dangerIconButtonHover:hover {
+  color: var(--color-error);
+  border-color: color-mix(in srgb, var(--color-error) 40%, var(--color-border));
+}
+
+/* ── Spinner ───────────────────────────────────────────────── */
+.spinner {
+  /* 24px === --space-6 */
+  width: var(--space-6);
+  height: var(--space-6);
+  border-radius: var(--radius-full);
+  /* border-width doesn't match --border-width/--border-width-thick; kept
+     literal per _helpers.css spec. */
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  /* 0.7s not in the duration token scale; kept literal per _helpers.css spec. */
+  animation: spin 0.7s linear infinite;
+}
+
+.spinnerSm {
+  /* 15px doesn't match a --space-* token; kept literal per _helpers.css spec. */
+  width: 15px;
+  height: 15px;
+  border-width: 2px;
+}
+
+/* ── Shimmer (processing placeholders) ────────────────────────
+   Distinct technique from the existing `shimmer` keyframe in
+   animations.css (translateX sweep of an overlay pseudo-element, used by
+   Image's blur placeholder) — this ports _helpers.css's own
+   background-position sweep on a gradient background, so it gets its own
+   keyframe (`shimmerSweep`) rather than overloading the existing one. */
+.shimmer {
+  background: linear-gradient(
+    100deg,
+    var(--color-surface) 30%,
+    var(--color-hover) 50%,
+    var(--color-surface) 70%
+  );
+  background-size: 200% 100%;
+  /* 1.3s not in the duration token scale; kept literal per _helpers.css spec. */
+  animation: shimmerSweep 1.3s linear infinite;
+}
+
+/* ── Reduced motion ────────────────────────────────────────────
+   Disables ALL transform/opacity motion from this file: animations,
+   transitions, and the hover-triggered transform values themselves (not
+   just their timing), matching/exceeding _helpers.css's own
+   `prefers-reduced-motion` block. */
+@media (prefers-reduced-motion: reduce) {
+  .linkIcon {
+    transition: none;
+  }
+
+  .nudgeRight:hover .linkIcon,
+  .nudgeLeft:hover .linkIcon,
+  .nudgeUpRight:hover .linkIcon {
+    transform: none;
+  }
+
+  .cardLift,
+  .cardLiftImage {
+    transition: none;
+  }
+
+  .cardLift:hover {
+    transform: none;
+  }
+
+  .cardLift:hover .cardLiftImage {
+    transform: none;
+  }
+
+  .spinner {
+    animation: none;
+  }
+
+  .shimmer {
+    animation: none;
+  }
+}

--- a/src/styles/interactions.module.css
+++ b/src/styles/interactions.module.css
@@ -136,20 +136,10 @@
   }
 }
 
-/* Reusable pattern for the future Header rebuild (issue #224): the
-   sticky header's `backdrop-filter` blur needs the same treatment —
-   guard it with `@supports (backdrop-filter: blur(1px))` for the blur
-   itself, and provide an opaque `background` fallback in the negated
-   query so text never bleeds through an unblurred translucent bg:
-     .stickyHeader { background: var(--color-bg); }
-     @supports (backdrop-filter: blur(1px)) {
-       .stickyHeader {
-         background: color-mix(in srgb, var(--color-bg) 85%, transparent);
-         backdrop-filter: blur(8px);
-       }
-     }
-   Not applied anywhere in this file — no component in scope for issue
-   #221 uses `backdrop-filter` yet (Header is still old neo-brutalist). */
+/* The sticky header's future `backdrop-filter` blur (issue #224) needs an
+   analogous @supports(backdrop-filter) fallback with an opaque `background`
+   default — not written here since nothing in scope today uses
+   `backdrop-filter` yet (Header is still old neo-brutalist). */
 
 /* ── Spinner ───────────────────────────────────────────────── */
 .spinner {
@@ -191,10 +181,12 @@
 }
 
 /* ── Reduced motion ────────────────────────────────────────────
-   Disables ALL transform/opacity motion from this file: animations,
-   transitions, and the hover-triggered transform values themselves (not
-   just their timing), matching/exceeding _helpers.css's own
-   `prefers-reduced-motion` block. */
+   Disables the transitions/hover-transforms defined in this file (not
+   just their timing) that `animations.css` has no way to know about.
+   `.spinner`/`.shimmer` need no entry here — their `spin`/`shimmerSweep`
+   keyframes are already neutered under reduced motion at the keyframe
+   level in `animations.css`, so re-disabling `animation` here would just
+   duplicate that same outcome through a second mechanism. */
 @media (prefers-reduced-motion: reduce) {
   .linkIcon {
     transition: none;
@@ -217,13 +209,5 @@
 
   .cardLift:hover .cardLiftImage {
     transform: none;
-  }
-
-  .spinner {
-    animation: none;
-  }
-
-  .shimmer {
-    animation: none;
   }
 }

--- a/src/styles/interactions.module.css
+++ b/src/styles/interactions.module.css
@@ -7,14 +7,19 @@
    (relative path from a component two levels down in src/components/<Name>/ —
    there is no `@/` or `@styles` alias in this project) instead.
 
-   Field focus-ring and the `--ring` box-shadow are deliberately NOT in this
-   file — that's owned by the a11y-engineer pass (issue #221 AC2), which
-   also adds the forced-colors / `@supports(color-mix/backdrop-filter)`
-   fallbacks. Toast hover-reveal, header sticky-blur, and theme-toggle hover
-   are out of scope here too: each belongs to a component that either
-   already has its own paper-spec styling (ThemeToggle) or is a separate
-   future rebuild issue (Toast, Header) that will port its own `_helpers.css`
-   rule when it lands. */
+   Toast hover-reveal and theme-toggle hover are out of scope here: each
+   belongs to a component that either already has its own paper-spec
+   styling (ThemeToggle) or is a separate future rebuild issue (Toast)
+   that will port its own `_helpers.css` rule when it lands.
+
+   The focus-ring composable below (`.focusRing`) is the a11y-engineer
+   pass's addition (issue #221 AC2) — it's the canonical `:focus-visible`
+   + forced-colors + `@supports(color-mix)` pattern future component
+   rebuilds should `composes` from, same as the utilities above. There is
+   no `backdrop-filter` `@supports` fallback here: nothing in scope today
+   uses `backdrop-filter` (the sticky header's blur, and its solid-bg
+   fallback, land with the Header rebuild in issue #224) — see the note
+   above `.focusRing` for the fallback pattern to reuse when that lands. */
 
 /* ── Links — icon nudge ──────────────────────────────────────
    Apply `linkIcon` to the icon element, and one direction class to the
@@ -91,6 +96,60 @@
   color: var(--color-error);
   border-color: color-mix(in srgb, var(--color-error) 40%, var(--color-border));
 }
+
+/* ── Focus ring ────────────────────────────────────────────────
+   Composable `:focus-visible` ring — apply by composing `focusRing` onto
+   the interactive element's own class (not onto a `:focus-visible` rule;
+   CSS Modules only allows `composes` on a plain single-class selector),
+   e.g. (path relative to a component two levels down in
+   src/components/<Name>/):
+     .toggle { composes: focusRing from '../../styles/interactions.module.css'; }
+   Never pair this with the element's own `outline: none` — `.focusRing`
+   already owns `outline` on :focus-visible and must be the only source
+   of it, or forced-colors mode below loses its indicator.
+
+   Pairs the `--ring` box-shadow (tokens.css) with a transparent 2px
+   outline: box-shadow is dropped in forced-colors/Windows High Contrast
+   mode, but browsers substitute a visible system color for *any*
+   `outline-color` (even `transparent`) in that mode, so the outline
+   alone keeps the indicator visible there. `outline-offset` is literal
+   (no matching --space-* token, mirrors this file's other literal
+   values) — kept separate from the ring so the two don't visually
+   merge into one thick band. */
+.focusRing:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: var(--ring);
+}
+
+/* `--ring` uses color-mix(); without support it resolves to an invalid
+   custom property, which makes `box-shadow` compute to `none` (guaranteed-
+   invalid value → property's initial value) — silently invisible focus in
+   normal (non-forced-colors) rendering, since the outline above is
+   transparent there. Detect the same function used by `--ring` (not just
+   any `color-mix()`, since browsers may support different color spaces)
+   and fall back to a solid, opaque outline instead. */
+@supports not (color: color-mix(in srgb, red 50%, transparent)) {
+  .focusRing:focus-visible {
+    outline-color: var(--color-primary);
+    box-shadow: none;
+  }
+}
+
+/* Reusable pattern for the future Header rebuild (issue #224): the
+   sticky header's `backdrop-filter` blur needs the same treatment —
+   guard it with `@supports (backdrop-filter: blur(1px))` for the blur
+   itself, and provide an opaque `background` fallback in the negated
+   query so text never bleeds through an unblurred translucent bg:
+     .stickyHeader { background: var(--color-bg); }
+     @supports (backdrop-filter: blur(1px)) {
+       .stickyHeader {
+         background: color-mix(in srgb, var(--color-bg) 85%, transparent);
+         backdrop-filter: blur(8px);
+       }
+     }
+   Not applied anywhere in this file — no component in scope for issue
+   #221 uses `backdrop-filter` yet (Header is still old neo-brutalist). */
 
 /* ── Spinner ───────────────────────────────────────────────── */
 .spinner {

--- a/src/styles/interactions.module.css
+++ b/src/styles/interactions.module.css
@@ -29,7 +29,7 @@
      .icon  { composes: linkIcon   from '../../styles/interactions.module.css'; } */
 .linkIcon {
   display: inline-flex;
-  transition: transform var(--duration-fast) var(--easing-default);
+  transition: transform var(--duration-base) var(--easing-default);
 }
 
 .nudgeRight:hover .linkIcon {


### PR DESCRIPTION
Closes #221

## What changed
- `src/styles/interactions.module.css` (new) — composable, non-`:global` CSS Modules classes porting the design system's `_helpers.css` (`.ds-*`) behaviors: link icon nudge (right/left/up-right), card lift+zoom (the "signature hover"), surface/chip/upload/danger-icon-button hover washes, spinner, shimmer, and a canonical `.focusRing` composable — each faithful to the source spec's values/timings (deviations from the token scale are commented and justified), with full `prefers-reduced-motion` coverage.
- `src/styles/animations.css` — added a `shimmerSweep` keyframe (background-position sweep, distinct from the existing transform-based `shimmer`) with its own reduced-motion override.
- `src/components/ThemeToggle/ThemeToggle.module.css` — composes the new `.focusRing` instead of its old bare `.toggle:focus-visible { outline: none; box-shadow: var(--ring); }`, which had neither a forced-colors fallback nor a `color-mix()` `@supports` fallback.

## Why
Part of the paper redesign PRD (`docs/prds/paper-redesign.md`) — this is deliberately phase-0 work (line 150), landing before the phase-1+ issues that rebuild Button/Card/Tag/Toast/Link/Header to the new paper design. The PRD (line 71) explicitly forbids shipping the design system's global `.ds-*` classes into this CSS-Modules codebase, since global classes break module scoping and `composes` — so these behaviors are ported into a shared, composable CSS-Modules partial instead, ready for future rebuild issues (#223 onward) to `composes` from as they land.

## How to verify
- `pnpm test` — 645/645 passing, no regressions.
- Inspect `src/styles/interactions.module.css` — confirm no `!important`, no `:global`, `:focus-visible` (not bare `:focus`), and the `@media (prefers-reduced-motion: reduce)` block at the bottom covers every transform/transition this file defines.
- ThemeToggle: tab to the toggle in a browser and confirm a visible focus ring; in a browser/OS with forced-colors (Windows High Contrast) enabled, confirm the outline is still visible.

## Decisions made
- **Only `ThemeToggle` currently consumes this file** (via `.focusRing`) — the other 7 utility classes (nudge/lift-zoom/chip-hovers/spinner/shimmer) have zero consumers yet by design. Per the PRD's phase-0-before-phase-1 sequencing, the components that will use them (Link, RecipeCard, Toast, Tag, ImageUpload, etc.) are still old neo-brutalist styling awaiting their own rebuild issues (#223+); retrofitting them now would pre-empt and duplicate that future work. Surfaced to the orchestrator's human user directly given the PRD's line 71 wording ("port the behaviors into the relevant component `.module.css` files") could also be read as requiring an immediate consumer — the user confirmed shipping as built.
- **`@supports` fallback for `color-mix()` is implemented and applied; the one for `backdrop-filter` is documented but not applied anywhere** — nothing in scope today uses `backdrop-filter` (the sticky header's blur lands with the Header rebuild in #224). Also surfaced to and confirmed by the user rather than inventing a Header consumer just to satisfy the AC literally.
- **The design system's "field focus ring" behavior (`_helpers.css`'s `.ds-field:focus` border-color highlight) was not ported** — only its box-shadow ring maps cleanly onto the generic `.focusRing` composable; the border-color half is specific to form fields, which have no rebuilt component in this issue's scope. The future Input rebuild (#223+) should add it when it references `_helpers.css` for its own styling.
- `.cardLift` transitions `box-shadow` alongside `transform` (not fully compositor-only) — flagged by a `/simplify` efficiency pass, but this is a literal, faithful port of `_helpers.css`'s own `.ds-recipe-card` technique and matches the existing (pre-redesign) `RecipeCard.module.css` pattern already in this codebase; not treated as a regression introduced here.
- `.linkIcon`'s transition duration was corrected from `--duration-fast` (180ms) to `--duration-base` (250ms) during review — `_helpers.css`'s `.25s` matches `--duration-base` exactly.