### PR TITLE
Set up vitest-axe, jsx-a11y, and test harness

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import tsPlugin from '@typescript-eslint/eslint-plugin'
 import tsParser from '@typescript-eslint/parser'
 import prettier from 'eslint-config-prettier'
 import importPlugin from 'eslint-plugin-import'
+import jsxA11y from 'eslint-plugin-jsx-a11y'
 import react from 'eslint-plugin-react'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
@@ -44,6 +45,7 @@ export default [
       'react-refresh': reactRefresh,
       import: importPlugin,
       vitest,
+      'jsx-a11y': jsxA11y,
     },
     rules: {
       ...js.configs.recommended.rules,
@@ -53,6 +55,7 @@ export default [
       ...prettier.rules,
       ...vitest.configs.recommended.rules,
       ...tsPlugin.configs.recommended.rules,
+      ...jsxA11y.flatConfigs.recommended.rules,
 
       'import/order': [
         'error',

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint": "^9.20.1",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.18",
@@ -61,6 +62,7 @@
     "unist-util-visit": "^5.1.0",
     "vite": "^7.3.1",
     "vite-imagetools": "^10.0.0",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-react:
         specifier: ^7.37.4
         version: 7.37.5(eslint@9.39.3(jiti@2.6.1))
@@ -126,6 +129,9 @@ importers:
       vitest:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@24.11.0)(jsdom@26.1.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      vitest-axe:
+        specifier: ^0.1.0
+        version: 0.1.0(vitest@4.1.2(@types/node@24.11.0)(jsdom@26.1.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)))
 
 packages:
 
@@ -1300,6 +1306,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
@@ -1313,6 +1322,14 @@ packages:
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
   bail@2.0.2:
@@ -1378,6 +1395,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1610,6 +1631,9 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -1700,6 +1724,9 @@ packages:
 
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1802,6 +1829,12 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
@@ -2383,6 +2416,13 @@ packages:
   langium@4.2.2:
     resolution: {integrity: sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
 
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
@@ -3119,6 +3159,10 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
+
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
     engines: {node: '>= 0.4'}
@@ -3370,6 +3414,11 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-axe@0.1.0:
+    resolution: {integrity: sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==}
+    peerDependencies:
+      vitest: '>=0.16.0'
 
   vitest@4.1.2:
     resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
@@ -4684,6 +4733,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types-flow@0.0.8: {}
+
   ast-v8-to-istanbul@1.0.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -4697,6 +4748,10 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axe-core@4.12.1: {}
+
+  axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
 
@@ -4760,6 +4815,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -5011,6 +5068,8 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  damerau-levenshtein@1.0.8: {}
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -5099,6 +5158,8 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.302: {}
+
+  emoji-regex@9.2.2: {}
 
   entities@6.0.1: {}
 
@@ -5304,6 +5365,25 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.3(jiti@2.6.1)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.12.1
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.39.3(jiti@2.6.1)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
@@ -6030,6 +6110,12 @@ snapshots:
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
 
   layout-base@1.0.2: {}
 
@@ -7087,6 +7173,12 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.24.1
+
   string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.8
@@ -7374,6 +7466,16 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       yaml: 2.8.3
+
+  vitest-axe@0.1.0(vitest@4.1.2(@types/node@24.11.0)(jsdom@26.1.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))):
+    dependencies:
+      aria-query: 5.3.2
+      axe-core: 4.12.1
+      chalk: 5.6.2
+      dom-accessibility-api: 0.5.16
+      lodash-es: 4.18.1
+      redent: 3.0.0
+      vitest: 4.1.2(@types/node@24.11.0)(jsdom@26.1.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
 
   vitest@4.1.2(@types/node@24.11.0)(jsdom@26.1.0)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     dependencies:

--- a/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -63,6 +63,8 @@ const ConfirmDialog: FC<ConfirmDialogProps> = ({
 
   return (
     <div className={styles.overlay}>
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions --
+          stopgap until #223 moves this to native <dialog>/showModal(). */}
       <div
         ref={dialogRef}
         role="dialog"

--- a/src/components/FileMeta/FileMeta.tsx
+++ b/src/components/FileMeta/FileMeta.tsx
@@ -22,7 +22,7 @@ const FileMeta: FC<FileMetaProps> = ({ fileInfo, hasError }) => {
     const { type, size, date } = fileInfo
 
     return (
-      <ul role="list" className={styles.list}>
+      <ul className={styles.list}>
         <li>{`${type} format`}</li>
         <li aria-hidden="true">•</li>
         <li>{size}</li>

--- a/src/components/SocialCard/SocialCard.tsx
+++ b/src/components/SocialCard/SocialCard.tsx
@@ -65,9 +65,9 @@ const SocialCard: FC = () => {
       <Typography variant="heading3" as="h2" id="social-heading" className={styles.heading}>
         Get in touch
       </Typography>
-      <ul className={styles.list} role="list">
+      <ul className={styles.list}>
         {SOCIAL_CARD_PROPS.map(({ name, url, icon }) => (
-          <li key={name} role="listitem">
+          <li key={name}>
             <a
               href={url}
               target="_blank"

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -84,9 +84,12 @@ const TagInput: FC<TagInputProps> = ({
         {isExpanded && (
           <ul id={listboxId} role="listbox" className={styles.listbox}>
             {filtered.map((tag) => (
+              // Arrow-key highlight + Enter-to-select keyboard nav tracked in #237.
+              // eslint-disable-next-line jsx-a11y/click-events-have-key-events
               <li
                 key={tag}
                 role="option"
+                aria-selected={false}
                 className={styles.option}
                 onClick={() => addTag(tag)}
               >

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -89,7 +89,7 @@ const TagInput: FC<TagInputProps> = ({
               <li
                 key={tag}
                 role="option"
-                aria-selected={false}
+                aria-selected="false"
                 className={styles.option}
                 onClick={() => addTag(tag)}
               >

--- a/tests/renderWithProviders.test.tsx
+++ b/tests/renderWithProviders.test.tsx
@@ -1,0 +1,57 @@
+import * as authApi from '@api/auth'
+import { useAuth } from '@contexts/AuthContext'
+import { screen } from '@testing-library/react'
+import { useLocation } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+import { renderWithProviders } from './renderWithProviders'
+
+vi.mock('@api/auth', () => ({
+  login: vi.fn(),
+  logout: vi.fn(),
+  getCurrentSession: vi.fn(),
+  refreshSession: vi.fn(),
+}))
+
+const LocationDisplay = () => <div data-testid="location">{useLocation().pathname}</div>
+
+const AuthDisplay = () => {
+  const { isAuthenticated, isAdmin } = useAuth()
+  return <div data-testid="auth">{`${isAuthenticated}/${isAdmin}`}</div>
+}
+
+describe('renderWithProviders', () => {
+  it('wraps with MemoryRouter using the given initialEntries', () => {
+    renderWithProviders(<LocationDisplay />, { initialEntries: ['/admin/recipes'] })
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/admin/recipes')
+  })
+
+  it('defaults initialEntries to ["/"] when not provided', () => {
+    renderWithProviders(<LocationDisplay />)
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/')
+  })
+
+  it('does not provide auth context by default', () => {
+    // useAuth() falls back to AuthContext's default value when there's no
+    // AuthProvider ancestor, rather than throwing.
+    renderWithProviders(<AuthDisplay />)
+
+    expect(screen.getByTestId('auth')).toHaveTextContent('false/false')
+  })
+
+  it('wraps with the real AuthProvider when withAuth is true', () => {
+    vi.mocked(authApi.getCurrentSession).mockReturnValue(null)
+
+    renderWithProviders(<AuthDisplay />, { withAuth: true })
+
+    expect(screen.getByTestId('auth')).toHaveTextContent('false/false')
+  })
+
+  it('renders content with no detectable axe violations', async () => {
+    const { container } = renderWithProviders(<LocationDisplay />)
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/tests/renderWithProviders.tsx
+++ b/tests/renderWithProviders.tsx
@@ -1,0 +1,30 @@
+import { AuthProvider } from '@contexts/AuthContext'
+import { render, type RenderOptions } from '@testing-library/react'
+import type { ReactElement, ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+
+export interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+  /** Initial history entries for the MemoryRouter. Defaults to `['/']`. */
+  initialEntries?: string[]
+  /**
+   * Wrap the tree in the real `AuthProvider` for components that read auth
+   * state via `useAuth()` (e.g. admin-only UI). `AuthProvider` derives its
+   * state from `@api/auth`'s `getCurrentSession()`, so mock that module to
+   * control the resulting `isAuthenticated`/`isAdmin`/`user` values. Defaults
+   * to `false` — most components don't need real auth wiring and can mock
+   * `useAuth` directly instead.
+   */
+  withAuth?: boolean
+}
+
+export const renderWithProviders = (
+  ui: ReactElement,
+  { initialEntries = ['/'], withAuth = false, ...renderOptions }: RenderWithProvidersOptions = {}
+) =>
+  render(ui, {
+    wrapper: ({ children }: { children: ReactNode }) => {
+      const routed = <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+      return withAuth ? <AuthProvider>{routed}</AuthProvider> : routed
+    },
+    ...renderOptions,
+  })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,11 @@
 import '@testing-library/jest-dom'
-import { vi } from 'vitest'
+import { expect, vi } from 'vitest'
+import * as matchers from 'vitest-axe/matchers'
+
+// Register vitest-axe's `toHaveNoViolations` matcher project-wide. Note: axe
+// cannot evaluate `color-contrast` under jsdom (no real layout/rendering), so
+// that rule is inherently unreliable in this environment.
+expect.extend(matchers)
 
 // Shim `jest` global so @testing-library's `waitFor` detects vitest's fake
 // timers (it checks `typeof jest !== 'undefined'` plus `setTimeout.clock`).
@@ -28,4 +34,22 @@ export class MockIntersectionObserver {
 
 if (typeof window !== 'undefined') {
   window.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver
+}
+
+// jsdom does not implement the native <dialog> element's `showModal`/`close`
+// behaviour. This minimal polyfill toggles the `open` attribute and dispatches
+// a `close` event so components built on native <dialog> (e.g. a future
+// ConfirmDialog rebuild) can be tested without a headless-browser dependency.
+if (typeof HTMLDialogElement !== 'undefined') {
+  HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+    this.open = true
+  }
+
+  HTMLDialogElement.prototype.close = function (this: HTMLDialogElement, returnValue?: string) {
+    if (returnValue !== undefined) {
+      this.returnValue = returnValue
+    }
+    this.open = false
+    this.dispatchEvent(new Event('close'))
+  }
 }

--- a/tests/vitest-axe.d.ts
+++ b/tests/vitest-axe.d.ts
@@ -1,0 +1,16 @@
+// vitest-axe@0.1.0 ships its matcher types augmenting a legacy `Vi` namespace
+// (`declare global { namespace Vi { interface Assertion ... } }`), which
+// predates Vitest 4's typing convention of augmenting `declare module
+// 'vitest'` directly (see how @testing-library/jest-dom does this in
+// node_modules/@testing-library/jest-dom/types/vitest.d.ts). Without this
+// bridge, `vitest-axe/extend-expect`'s augmentation is inert under Vitest 4
+// and `toHaveNoViolations` doesn't type-check even though it works at
+// runtime (registered via `expect.extend` in tests/setup.ts).
+import type { AxeMatchers } from 'vitest-axe/matchers'
+
+declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type, @typescript-eslint/no-unused-vars
+  interface Assertion<T = unknown> extends AxeMatchers {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface AsymmetricMatchersContaining extends AxeMatchers {}
+}


### PR DESCRIPTION
Closes #222

## What changed

- Installed `vitest-axe` and registered `toHaveNoViolations` (`expect.extend(matchers)`) in `tests/setup.ts`.
- Added a jsdom `HTMLDialogElement.showModal`/`close` polyfill in `tests/setup.ts`, ahead of #223's native-`<dialog>` `ConfirmDialog` rebuild.
- Added `eslint-plugin-jsx-a11y`'s recommended flat-config rules to `eslint.config.js`.
- Added `tests/renderWithProviders.tsx` — a shared `renderWithProviders(ui, { initialEntries, withAuth })` util wrapping RTL's `render` with `MemoryRouter` (+ real `AuthProvider` when `withAuth: true`), plus its own test.
- Fixed the jsx-a11y violations the new lint rules surfaced in existing components: removed redundant `role="list"`/`role="listitem"` on native `<ul>`/`<li>` in `FileMeta` and `SocialCard`; added `aria-selected` to `TagInput`'s listbox options; added scoped, commented `eslint-disable` stopgaps on `ConfirmDialog` (pending #223's native-dialog rebuild) and `TagInput` (pending #237's keyboard-nav follow-up).
- Added `tests/vitest-axe.d.ts` — a small type bridge so `toHaveNoViolations` type-checks under Vitest 4 (the installed `vitest-axe@0.1.0` only augments the legacy `Vi` namespace).

## Why

Per the PRD (`docs/prds/paper-redesign.md`), this is the milestone's "foundation gate" — `vitest-axe` must land before downstream a11y-focused issues (#223 onward) can import it, and the `<dialog>` polyfill needs to exist in `tests/setup.ts` before #223 rebuilds `ConfirmDialog` on native `<dialog>`.

## How to verify

- `pnpm test` — 650/650 passing.
- `pnpm lint` — 0 errors.
- `pnpm --package=typescript dlx tsc --noEmit -p tsconfig.json` and `-p tsconfig.eslint.json` — both clean.
- `tests/renderWithProviders.test.tsx` exercises both the router-only and `withAuth` paths, plus an axe smoke check.

## Decisions made

- Turning on `eslint-plugin-jsx-a11y`'s recommended ruleset surfaced a few pre-existing violations. Fixed the trivial ones (redundant roles, missing `aria-selected`) inline; the two that require real component-behavior changes (`ConfirmDialog`'s div-based dialog, `TagInput`'s missing keyboard nav) are scoped `eslint-disable` stopgaps pointing at their tracked follow-ups rather than being fixed here, since this issue is tooling/harness setup only.
- Considered bumping `vitest-axe` to `1.0.0-pre.5` (which ships Vitest-4-compatible types natively and would let us drop `tests/vitest-axe.d.ts`), but skipped it — that version only exists under the `pre` dist-tag, not `latest`, and pinning the repo's test tooling to an unstable prerelease isn't worth it just to avoid a 15-line, documented type bridge. Worth revisiting once `vitest-axe` cuts a stable 1.x.
- `renderWithProviders` intentionally doesn't add a theme provider — none exists in the codebase yet.

## Out of scope (filed as follow-up issues)

- **#237** — TagInput: add keyboard navigation to suggestions listbox. Surfaced by the new `jsx-a11y/click-events-have-key-events` rule; deferred because it's real component-behavior work, not test-harness setup.