### PR TITLE
Build shared core/feedback/overlay primitives

### DIFF
--- a/src/components/AdminLayout/AdminLayout.tsx
+++ b/src/components/AdminLayout/AdminLayout.tsx
@@ -29,7 +29,7 @@ const AdminLayout: FC<AdminLayoutProps> = ({ children }) => {
           <Typography variant="body" as="span">
             {user?.email}
           </Typography>
-          <Button onClick={logout} variant="secondary" ariaLabel="Logout">
+          <Button onClick={logout} variant="outline" ariaLabel="Logout">
             Logout
           </Button>
         </div>

--- a/src/components/AppCard/AppCard.module.css
+++ b/src/components/AppCard/AppCard.module.css
@@ -5,7 +5,7 @@
    the lift shadow is a literal, matching the shared utility. */
 
 .card {
-  composes: cardLift from '../../styles/interactions.module.css';
+  composes: cardLift focusRing from '../../styles/interactions.module.css';
   position: relative;
   display: flex;
   flex-direction: column;
@@ -13,6 +13,8 @@
   border-radius: var(--radius-xl);
   border: var(--border-width) solid var(--color-border);
   background-color: var(--color-surface);
+  text-decoration: none;
+  color: inherit;
   transition: border-color var(--duration-fast) var(--easing-default);
 }
 
@@ -36,6 +38,7 @@
 
 .imageWrapper > figure > div {
   border: none;
+  border-radius: 0;
 }
 
 /* Applied to the underlying <img> (via Image's `className` prop) — pairs
@@ -59,4 +62,14 @@
 
 .description {
   margin-block-end: var(--space-4);
+}
+
+.openApp {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-block-start: auto;
+  color: var(--color-primary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
 }

--- a/src/components/AppCard/AppCard.module.css
+++ b/src/components/AppCard/AppCard.module.css
@@ -1,6 +1,11 @@
-/* Card component styles */
+/* AppCard component styles — the app-grid card: lift + cover-zoom, the
+   design's signature hover (see docs/design/paper/pages/Apps.dc.html
+   .app-card). Uses the shared cardLift/cardLiftImage composables rather
+   than the --shadow-* scale (reserved for toasts/dropdowns/dialogs) —
+   the lift shadow is a literal, matching the shared utility. */
 
 .card {
+  composes: cardLift from '../../styles/interactions.module.css';
   position: relative;
   display: flex;
   flex-direction: column;
@@ -8,15 +13,17 @@
   border-radius: var(--radius-xl);
   border: var(--border-width) solid var(--color-border);
   background-color: var(--color-surface);
-  box-shadow: var(--shadow-md);
-  transition:
-    transform var(--duration-fast) var(--easing-default),
-    box-shadow var(--duration-fast) var(--easing-default);
+  transition: border-color var(--duration-fast) var(--easing-default);
 }
 
 .card:hover {
-  transform: translate(-4px, -4px);
-  box-shadow: var(--shadow-lg);
+  border-color: color-mix(in srgb, var(--color-primary) 35%, var(--color-border));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
 }
 
 .imageWrapper {
@@ -31,14 +38,10 @@
   border: none;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .card {
-    transition: none;
-  }
-
-  .card:hover {
-    transform: none;
-  }
+/* Applied to the underlying <img> (via Image's `className` prop) — pairs
+   with `.card`'s composed `cardLift` for the cover-zoom-on-hover effect. */
+.imageScaled {
+  composes: cardLiftImage from '../../styles/interactions.module.css';
 }
 
 .body {

--- a/src/components/AppCard/AppCard.module.css
+++ b/src/components/AppCard/AppCard.module.css
@@ -5,7 +5,7 @@
    the lift shadow is a literal, matching the shared utility. */
 
 .card {
-  composes: cardLift focusRing from '../../styles/interactions.module.css';
+  composes: cardLift focusRing nudgeUpRight from '../../styles/interactions.module.css';
   position: relative;
   display: flex;
   flex-direction: column;
@@ -56,8 +56,23 @@
   padding-inline: var(--space-6);
 }
 
-.title {
+.titleRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
   margin-block-end: var(--space-2);
+}
+
+.title {
+  margin-block-end: 0;
+}
+
+.arrowIcon {
+  composes: linkIcon from '../../styles/interactions.module.css';
+  flex-shrink: 0;
+  color: var(--color-primary);
+  font-size: var(--font-size-lg);
 }
 
 .description {
@@ -65,9 +80,6 @@
 }
 
 .openApp {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
   margin-block-start: auto;
   color: var(--color-primary);
   font-size: var(--font-size-sm);

--- a/src/components/AppCard/AppCard.module.css
+++ b/src/components/AppCard/AppCard.module.css
@@ -1,0 +1,59 @@
+/* Card component styles */
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: var(--radius-xl);
+  border: var(--border-width) solid var(--color-border);
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-md);
+  transition:
+    transform var(--duration-fast) var(--easing-default),
+    box-shadow var(--duration-fast) var(--easing-default);
+}
+
+.card:hover {
+  transform: translate(-4px, -4px);
+  box-shadow: var(--shadow-lg);
+}
+
+.imageWrapper {
+  /* aspect-video = 16/9 */
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  overflow: hidden;
+  border-bottom: var(--border-width) solid var(--color-border);
+}
+
+.imageWrapper > figure > div {
+  border: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    transition: none;
+  }
+
+  .card:hover {
+    transform: none;
+  }
+}
+
+.body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding-block-start: 0;
+  padding-block-end: var(--space-6);
+  padding-inline: var(--space-6);
+}
+
+.title {
+  margin-block-end: var(--space-2);
+}
+
+.description {
+  margin-block-end: var(--space-4);
+}

--- a/src/components/AppCard/AppCard.test.tsx
+++ b/src/components/AppCard/AppCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import AppCard, { AppCardProps } from './AppCard'
 
@@ -48,8 +48,25 @@ describe('AppCard', () => {
   it('renders the link with the correct destination', () => {
     renderCard()
 
-    const link = screen.getByRole('link')
+    const link = screen.getByRole('link', { name: new RegExp(mockProps.title) })
     expect(link).toHaveAttribute('href', mockProps.href)
-    expect(link).toHaveTextContent(mockProps.href)
+  })
+
+  it('makes the whole card a single interactive element', () => {
+    renderCard()
+
+    const link = screen.getByRole('link', { name: new RegExp(mockProps.title) })
+    expect(within(link).getByRole('img')).toBeInTheDocument()
+    expect(within(link).getByText(mockProps.description)).toBeInTheDocument()
+    expect(screen.getAllByRole('link')).toHaveLength(1)
+  })
+
+  it('opens external hrefs in a new tab', () => {
+    renderCard({ ...mockProps, href: 'https://example.com/apps/test' })
+
+    const link = screen.getByRole('link', { name: new RegExp(mockProps.title) })
+    expect(link).toHaveAttribute('href', 'https://example.com/apps/test')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noreferrer')
   })
 })

--- a/src/components/AppCard/AppCard.test.tsx
+++ b/src/components/AppCard/AppCard.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import Card, { CardProps } from './Card'
+import AppCard, { AppCardProps } from './AppCard'
 
-describe('Card', () => {
+describe('AppCard', () => {
   beforeEach(() => {
     vi.resetAllMocks()
   })
 
-  const mockProps: CardProps = {
+  const mockProps: AppCardProps = {
     title: 'Test Project',
     description: 'This is a test description for the card component.',
     image: { src: '/test-image.jpg', alt: 'Test Project' },
@@ -17,7 +17,7 @@ describe('Card', () => {
   const renderCard = (props = mockProps) =>
     render(
       <MemoryRouter>
-        <Card {...props} />
+        <AppCard {...props} />
       </MemoryRouter>
     )
 

--- a/src/components/AppCard/AppCard.test.tsx
+++ b/src/components/AppCard/AppCard.test.tsx
@@ -69,4 +69,18 @@ describe('AppCard', () => {
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noreferrer')
   })
+
+  it('renders the arrow once, hidden from assistive tech, next to the title rather than "Open app"', () => {
+    renderCard()
+
+    const arrows = screen.getAllByText('↗', { selector: '[aria-hidden="true"]' })
+    expect(arrows).toHaveLength(1)
+
+    const title = screen.getByRole('heading', { name: mockProps.title })
+    const openApp = screen.getByText('Open app')
+
+    expect(openApp).toHaveTextContent('Open app')
+    expect(title.parentElement).toContainElement(arrows[0])
+    expect(openApp).not.toContainElement(arrows[0])
+  })
 })

--- a/src/components/AppCard/AppCard.tsx
+++ b/src/components/AppCard/AppCard.tsx
@@ -1,8 +1,8 @@
 import Image from '@components/Image'
 import type { ImageProps } from '@components/Image/Image'
-import Link from '@components/Link'
 import Typography from '@components/Typography'
 import type { FC } from 'react'
+import { Link as RouterLink } from 'react-router-dom'
 import styles from './AppCard.module.css'
 
 export interface AppCardProps {
@@ -12,9 +12,12 @@ export interface AppCardProps {
   image: ImageProps
 }
 
+const isExternalHref = (href: string) =>
+  /^https?:\/\//.test(href) || href.startsWith('mailto:') || href.startsWith('tel:')
+
 const AppCard: FC<AppCardProps> = ({ title, description, href, image }) => {
-  return (
-    <article className={styles.card}>
+  const content = (
+    <>
       <div className={styles.imageWrapper}>
         <Image
           {...image}
@@ -31,9 +34,25 @@ const AppCard: FC<AppCardProps> = ({ title, description, href, image }) => {
 
         <Typography variant="body" className={styles.description}>{description}</Typography>
 
-        <Link to={href}>{href}</Link>
+        <span className={styles.openApp}>
+          Open app <span aria-hidden="true">↗</span>
+        </span>
       </div>
-    </article>
+    </>
+  )
+
+  if (isExternalHref(href)) {
+    return (
+      <a href={href} className={styles.card} target="_blank" rel="noreferrer">
+        {content}
+      </a>
+    )
+  }
+
+  return (
+    <RouterLink to={href} className={styles.card}>
+      {content}
+    </RouterLink>
   )
 }
 

--- a/src/components/AppCard/AppCard.tsx
+++ b/src/components/AppCard/AppCard.tsx
@@ -47,16 +47,20 @@ const AppCard: FC<AppCardProps> = ({ title, description, href, image }) => {
 
   if (isExternalHref(href)) {
     return (
-      <a href={href} className={styles.card} target="_blank" rel="noreferrer">
-        {content}
-      </a>
+      <article>
+        <a href={href} className={styles.card} target="_blank" rel="noreferrer">
+          {content}
+        </a>
+      </article>
     )
   }
 
   return (
-    <RouterLink to={href} className={styles.card}>
-      {content}
-    </RouterLink>
+    <article>
+      <RouterLink to={href} className={styles.card}>
+        {content}
+      </RouterLink>
+    </article>
   )
 }
 

--- a/src/components/AppCard/AppCard.tsx
+++ b/src/components/AppCard/AppCard.tsx
@@ -28,15 +28,19 @@ const AppCard: FC<AppCardProps> = ({ title, description, href, image }) => {
       </div>
 
       <div className={styles.body}>
-        <Typography variant="heading3" as="h2" className={styles.title}>
-          {title}
-        </Typography>
+        <div className={styles.titleRow}>
+          <Typography variant="heading3" as="h2" className={styles.title}>
+            {title}
+          </Typography>
+
+          <span className={styles.arrowIcon} aria-hidden="true">
+            ↗
+          </span>
+        </div>
 
         <Typography variant="body" className={styles.description}>{description}</Typography>
 
-        <span className={styles.openApp}>
-          Open app <span aria-hidden="true">↗</span>
-        </span>
+        <span className={styles.openApp}>Open app</span>
       </div>
     </>
   )

--- a/src/components/AppCard/AppCard.tsx
+++ b/src/components/AppCard/AppCard.tsx
@@ -1,0 +1,40 @@
+import Image from '@components/Image'
+import type { ImageProps } from '@components/Image/Image'
+import Link from '@components/Link'
+import Typography from '@components/Typography'
+import type { FC } from 'react'
+import styles from './AppCard.module.css'
+
+export interface AppCardProps {
+  title: string
+  description: string
+  href: string
+  image: ImageProps
+}
+
+const AppCard: FC<AppCardProps> = ({ title, description, href, image }) => {
+  return (
+    <article className={styles.card}>
+      <div className={styles.imageWrapper}>
+        <Image
+          {...image}
+          className={styles.imageScaled}
+          aspectRatio="16/9"
+          objectFit="cover"
+        />
+      </div>
+
+      <div className={styles.body}>
+        <Typography variant="heading3" as="h2" className={styles.title}>
+          {title}
+        </Typography>
+
+        <Typography variant="body" className={styles.description}>{description}</Typography>
+
+        <Link to={href}>{href}</Link>
+      </div>
+    </article>
+  )
+}
+
+export default AppCard

--- a/src/components/AppCard/index.ts
+++ b/src/components/AppCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from './AppCard'
+export type { AppCardProps } from './AppCard'

--- a/src/components/AutosaveStatus/AutosaveStatus.module.css
+++ b/src/components/AutosaveStatus/AutosaveStatus.module.css
@@ -49,6 +49,7 @@
 }
 
 .retryButton {
+  composes: focusRing from '../../styles/interactions.module.css';
   padding: 0;
   font: inherit;
   color: var(--color-primary);
@@ -57,11 +58,6 @@
   border-radius: var(--radius-sm);
   text-decoration: underline;
   cursor: pointer;
-}
-
-.retryButton:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-  outline-offset: 2px;
 }
 
 @keyframes autosaveStatusPulse {

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -122,5 +122,9 @@
   border: 2px solid currentcolor;
   border-right-color: transparent;
   border-radius: var(--radius-full);
-  animation: spin var(--duration-base) linear infinite;
+  /* `global(...)` is required here — without it, Vite's CSS Modules
+     transform scopes the `spin` identifier to a hashed local name that has
+     no matching @keyframes, silently no-op'ing the animation (spin lives,
+     unscoped, in the plain src/styles/animations.css file). */
+  animation: global(spin) var(--duration-base) linear infinite;
 }

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -19,11 +19,12 @@
   border: var(--border-width) solid var(--color-border-strong);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: background-color var(--duration-fast) var(--easing-default),
-              border-color var(--duration-fast) var(--easing-default),
-              color var(--duration-fast) var(--easing-default),
-              opacity var(--duration-fast) var(--easing-default),
-              transform var(--duration-fast) var(--easing-default);
+  transition:
+    background-color var(--duration-fast) var(--easing-default),
+    border-color var(--duration-fast) var(--easing-default),
+    color var(--duration-fast) var(--easing-default),
+    opacity var(--duration-fast) var(--easing-default),
+    transform var(--duration-fast) var(--easing-default);
 }
 
 .button:active:not(:disabled) {
@@ -111,32 +112,15 @@
 }
 
 .spinner {
+  /* Size/border/color are a legitimate delta (must inherit the button's own
+     text color across variants) — but the rotation itself reuses the
+     sitewide `spin` keyframe (src/styles/animations.css), which is already
+     neutered under prefers-reduced-motion at the keyframe level, instead of
+     a second identical keyframe + reduced-motion override. */
   width: 1em;
   height: 1em;
   border: 2px solid currentcolor;
   border-right-color: transparent;
   border-radius: var(--radius-full);
-  animation: btn-spin var(--duration-base) linear infinite;
-}
-
-@keyframes btn-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  /* Freeze rotation entirely (keyframe-level override), matching the
-     sitewide convention in src/styles/animations.css rather than merely
-     slowing the spin down — a still spinner remains a valid, understood
-     "in progress" affordance. */
-  @keyframes btn-spin {
-    from,
-    to {
-      transform: none;
-    }
-  }
+  animation: spin var(--duration-base) linear infinite;
 }

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -1,41 +1,48 @@
-/* Button component styles */
+/* Button component styles.
+   Soft box-shadow (the --shadow-* scale) is deliberately not used here —
+   the PRD reserves it for toasts/dropdowns/dialogs; buttons carry no
+   ambient elevation in the design. */
 
 .button {
+  composes: focusRing from '../../styles/interactions.module.css';
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--space-2);
-  padding: var(--space-2) var(--space-6);
+  /* Design prototype: 11/16px. --space-3/--space-4 (12/16px) is the
+     nearest token pairing. */
+  padding: var(--space-3) var(--space-4);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
   line-height: var(--line-height-normal);
   font-family: inherit;
   border: var(--border-width) solid var(--color-border-strong);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
   cursor: pointer;
-  transition: transform var(--duration-fast) var(--easing-default),
-              box-shadow var(--duration-fast) var(--easing-default);
+  transition: background-color var(--duration-fast) var(--easing-default),
+              border-color var(--duration-fast) var(--easing-default),
+              color var(--duration-fast) var(--easing-default),
+              opacity var(--duration-fast) var(--easing-default),
+              transform var(--duration-fast) var(--easing-default);
 }
 
-.button:hover:not(:disabled) {
-  transform: translate(2px, 2px);
-  box-shadow: 0 0 0 var(--color-border);
-}
-
-.button[aria-pressed='true'] {
-  transform: translate(2px, 2px);
-  box-shadow: 0 0 0 var(--color-border);
-}
-
-.button:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+.button:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 .button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button {
+    transition: none;
+  }
+
+  .button:active:not(:disabled) {
+    transform: none;
+  }
 }
 
 /* ── Variants ────────────────────────────────────────────────── */
@@ -49,6 +56,7 @@
 .outline {
   background-color: transparent;
   color: var(--color-text);
+  font-weight: var(--font-weight-medium);
 }
 
 .danger {
@@ -57,10 +65,27 @@
   border-color: var(--color-error);
 }
 
+/* Filled variants (solid/danger) dim slightly on hover — matches the
+   design's admin ".primary-btn"/".danger-btn" hover (opacity .9); the new
+   token system has no hover-color tokens to reach for instead. */
+.solid:hover:not(:disabled),
+.danger:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.outline:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background-color: var(--color-hover);
+}
+
 /* ── Shape ───────────────────────────────────────────────────── */
 
 .pill {
   border-radius: var(--radius-full);
+  /* Marketing CTA pills get a slightly larger tap target than form buttons
+     (design: 12/24px). */
+  padding: var(--space-3) var(--space-6);
 }
 
 /* ── Size ────────────────────────────────────────────────────── */
@@ -104,7 +129,14 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .spinner {
-    animation-duration: 1.5s;
+  /* Freeze rotation entirely (keyframe-level override), matching the
+     sitewide convention in src/styles/animations.css rather than merely
+     slowing the spin down — a still spinner remains a valid, understood
+     "in progress" affordance. */
+  @keyframes btn-spin {
+    from,
+    to {
+      transform: none;
+    }
   }
 }

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -4,11 +4,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: var(--space-2);
   padding: var(--space-2) var(--space-6);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
   line-height: var(--line-height-normal);
-  border: var(--border-width) solid var(--color-border);
+  font-family: inherit;
+  border: var(--border-width) solid var(--color-border-strong);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
   cursor: pointer;
@@ -38,12 +40,71 @@
 
 /* ── Variants ────────────────────────────────────────────────── */
 
-.primary {
-  background-color: var(--color-primary);
-  color: var(--color-on-primary);
+.solid {
+  background-color: var(--color-btn-bg);
+  color: var(--color-btn-fg);
+  border-color: var(--color-btn-bg);
 }
 
-.secondary {
+.outline {
   background-color: transparent;
   color: var(--color-text);
+}
+
+.danger {
+  background-color: var(--color-error);
+  color: var(--color-on-primary);
+  border-color: var(--color-error);
+}
+
+/* ── Shape ───────────────────────────────────────────────────── */
+
+.pill {
+  border-radius: var(--radius-full);
+}
+
+/* ── Size ────────────────────────────────────────────────────── */
+
+.sm {
+  padding: var(--space-1) var(--space-4);
+  font-size: var(--font-size-sm);
+}
+
+/* ── Modifiers ───────────────────────────────────────────────── */
+
+.fullWidth {
+  width: 100%;
+}
+
+.loading {
+  cursor: wait;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.spinner {
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentcolor;
+  border-right-color: transparent;
+  border-radius: var(--radius-full);
+  animation: btn-spin var(--duration-base) linear infinite;
+}
+
+@keyframes btn-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation-duration: 1.5s;
+  }
 }

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -54,4 +54,32 @@ describe('Button', () => {
 
     expect(button).toBeDisabled()
   })
+
+  it('keeps the original label in the accessible name, and sets disabled/aria-busy, while loading', () => {
+    render(
+      <Button onClick={mockOnClick} loading>
+        Save
+      </Button>
+    )
+
+    // The visible label is only visually hidden while loading (an sr-only
+    // "Loading" prefix is added alongside it) — the original label text
+    // must still be reachable in the accessible name.
+    const button = screen.getByRole('button', { name: /save/i })
+
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('does not fire onClick while loading', () => {
+    render(
+      <Button onClick={mockOnClick} loading>
+        Save
+      </Button>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(mockOnClick).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,12 +1,22 @@
-import { ReactNode, ReactElement } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import styles from './Button.module.css'
 
-interface ButtonProps {
+export interface ButtonProps {
   onClick?: () => void
   children: ReactNode
   type?: 'button' | 'submit' | 'reset'
-  variant?: 'primary' | 'secondary'
+  /** Visual weight. @default 'solid' */
+  variant?: 'solid' | 'outline' | 'danger'
+  /** Corner treatment. `pill` for marketing CTAs, `rounded` for forms. @default 'rounded' */
+  shape?: 'rounded' | 'pill'
+  /** @default 'md' */
+  size?: 'sm' | 'md'
   disabled?: boolean
+  /** Shows a spinner and blocks interaction. @default false */
+  loading?: boolean
+  iconLeft?: ReactNode
+  iconRight?: ReactNode
+  fullWidth?: boolean
   ariaLabel?: string
   ariaPressed?: 'true' | 'false'
   ariaDescribedBy?: string
@@ -17,26 +27,59 @@ const Button = ({
   onClick,
   children,
   type = 'button',
-  variant = 'primary',
+  variant = 'solid',
+  shape = 'rounded',
+  size = 'md',
   disabled = false,
+  loading = false,
+  iconLeft,
+  iconRight,
+  fullWidth = false,
   ariaLabel,
   ariaPressed,
   ariaDescribedBy,
   className: extraClassName,
 }: ButtonProps): ReactElement => {
-  const className = [styles.button, styles[variant], extraClassName].filter(Boolean).join(' ')
+  const className = [
+    styles.button,
+    styles[variant],
+    styles[shape],
+    styles[size],
+    fullWidth && styles.fullWidth,
+    loading && styles.loading,
+    extraClassName,
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <button
       type={type}
       onClick={onClick}
       className={className}
-      disabled={disabled}
+      disabled={disabled || loading}
       aria-label={ariaLabel}
       aria-pressed={ariaPressed}
       aria-describedby={ariaDescribedBy}
+      aria-busy={loading || undefined}
     >
-      {children}
+      {loading && (
+        <>
+          <span className={styles.spinner} aria-hidden="true" />
+          <span className="sr-only">Loading</span>
+        </>
+      )}
+      {iconLeft && !loading && (
+        <span className={styles.icon} aria-hidden="true">
+          {iconLeft}
+        </span>
+      )}
+      <span className={loading ? 'sr-only' : undefined}>{children}</span>
+      {iconRight && !loading && (
+        <span className={styles.icon} aria-hidden="true">
+          {iconRight}
+        </span>
+      )}
     </button>
   )
 }

--- a/src/components/Callout/Callout.module.css
+++ b/src/components/Callout/Callout.module.css
@@ -1,38 +1,37 @@
 .callout {
-  display: flex;
   margin: var(--space-4) 0;
+  padding: var(--space-4);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-lg);
   background-color: var(--color-surface);
-  box-shadow: var(--shadow-md);
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
   line-height: var(--line-height-normal);
   color: var(--color-text);
 }
 
-.accentBar {
-  flex-shrink: 0;
-  width: 10px;
-}
-
-.content {
-  padding: var(--space-4);
-}
-
 .indicator {
   font-weight: var(--font-weight-semibold);
   margin-bottom: var(--space-2);
+  text-transform: uppercase;
 }
 
-.tip .accentBar {
-  background-color: var(--color-success);
+.tip {
+  background-color: var(--color-success-bg);
 }
 
-.warning .accentBar {
-  background-color: var(--color-warning);
+.tip .indicator {
+  color: var(--color-success);
 }
 
-.info .accentBar {
-  background-color: var(--color-primary);
+.warning {
+  background-color: var(--color-warning-bg);
+}
+
+.warning .indicator {
+  color: var(--color-warning);
+}
+
+.info .indicator {
+  color: var(--color-primary);
 }

--- a/src/components/Callout/Callout.module.css
+++ b/src/components/Callout/Callout.module.css
@@ -1,23 +1,37 @@
 .callout {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
   margin: var(--space-4) 0;
-  padding: var(--space-4);
-  border: var(--border-width) solid var(--color-border);
+  padding: var(--space-4) var(--space-5);
   border-radius: var(--radius-lg);
-  background-color: var(--color-surface);
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
-  line-height: var(--line-height-normal);
+  line-height: var(--line-height-relaxed);
   color: var(--color-text);
 }
 
 .indicator {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
-  margin-bottom: var(--space-2);
+  letter-spacing: var(--tracking-eyebrow);
   text-transform: uppercase;
 }
 
+/* Upsizes the emoji glyph (the indicator's first child) relative to the
+   mono label text beside it — no separate DOM hook needed. */
+.indicator span:first-child {
+  font-size: var(--font-size-lg);
+}
+
 .tip {
-  background-color: var(--color-success-bg);
+  border: var(--border-width) solid color-mix(in srgb, var(--color-success) 24%, var(--color-border));
+  background: color-mix(in srgb, var(--color-success) 6%, var(--color-surface));
 }
 
 .tip .indicator {
@@ -25,11 +39,17 @@
 }
 
 .warning {
-  background-color: var(--color-warning-bg);
+  border: var(--border-width) solid color-mix(in srgb, var(--color-warning) 24%, var(--color-border));
+  background: color-mix(in srgb, var(--color-warning) 6%, var(--color-surface));
 }
 
 .warning .indicator {
   color: var(--color-warning);
+}
+
+.info {
+  border: var(--border-width) solid color-mix(in srgb, var(--color-primary) 24%, var(--color-border));
+  background: color-mix(in srgb, var(--color-primary) 6%, var(--color-surface));
 }
 
 .info .indicator {

--- a/src/components/Callout/Callout.module.css
+++ b/src/components/Callout/Callout.module.css
@@ -11,11 +11,15 @@
   color: var(--color-text);
 }
 
-.indicator {
+.emoji {
   flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
+  /* Design spec is 17px; --font-size-lg (18px) is the closest token. */
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-normal);
+}
+
+.label {
+  margin-bottom: var(--space-2);
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
@@ -23,18 +27,12 @@
   text-transform: uppercase;
 }
 
-/* Upsizes the emoji glyph (the indicator's first child) relative to the
-   mono label text beside it — no separate DOM hook needed. */
-.indicator span:first-child {
-  font-size: var(--font-size-lg);
-}
-
 .tip {
   border: var(--border-width) solid color-mix(in srgb, var(--color-success) 24%, var(--color-border));
   background: color-mix(in srgb, var(--color-success) 6%, var(--color-surface));
 }
 
-.tip .indicator {
+.tip .label {
   color: var(--color-success);
 }
 
@@ -43,7 +41,7 @@
   background: color-mix(in srgb, var(--color-warning) 6%, var(--color-surface));
 }
 
-.warning .indicator {
+.warning .label {
   color: var(--color-warning);
 }
 
@@ -52,6 +50,6 @@
   background: color-mix(in srgb, var(--color-primary) 6%, var(--color-surface));
 }
 
-.info .indicator {
+.info .label {
   color: var(--color-primary);
 }

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -16,11 +16,8 @@ const indicators: Record<CalloutProps['type'], { emoji: string; label: string }>
 const Callout: FC<CalloutProps> = ({ type, children }) => {
   return (
     <div className={`${styles.callout} ${styles[type]}`} role="note" aria-labelledby={`callout-${type}`}>
-      <div className={styles.accentBar} />
-      <div className={styles.content}>
-        <div id={`callout-${type}`} className={styles.indicator}><span aria-hidden="true">{indicators[type].emoji}</span> {indicators[type].label}</div>
-        <div>{children}</div>
-      </div>
+      <div id={`callout-${type}`} className={styles.indicator}><span aria-hidden="true">{indicators[type].emoji}</span> {indicators[type].label}</div>
+      <div>{children}</div>
     </div>
   )
 }

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -16,8 +16,11 @@ const indicators: Record<CalloutProps['type'], { emoji: string; label: string }>
 const Callout: FC<CalloutProps> = ({ type, children }) => {
   return (
     <div className={`${styles.callout} ${styles[type]}`} role="note" aria-labelledby={`callout-${type}`}>
-      <div id={`callout-${type}`} className={styles.indicator}><span aria-hidden="true">{indicators[type].emoji}</span> {indicators[type].label}</div>
-      <div>{children}</div>
+      <span className={styles.emoji} aria-hidden="true">{indicators[type].emoji}</span>
+      <div>
+        <div id={`callout-${type}`} className={styles.label}>{indicators[type].label}</div>
+        <div>{children}</div>
+      </div>
     </div>
   )
 }

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -6,26 +6,28 @@
   border-radius: var(--radius-xl);
   background-color: var(--color-bg);
   padding: var(--space-6);
-  transition: background-color var(--duration-fast) var(--easing-default);
 }
 
 .fill {
   background-color: var(--color-surface);
 }
 
-.hover:hover {
-  background-color: var(--color-hover);
+.hover {
+  composes: surfaceHover from '../../styles/interactions.module.css';
+  transition: background-color var(--duration-fast) var(--easing-default);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hover {
+    transition: none;
+  }
 }
 
 .asButton {
+  composes: focusRing from '../../styles/interactions.module.css';
   width: 100%;
   font: inherit;
   color: inherit;
   text-align: inherit;
   cursor: pointer;
-}
-
-.asButton:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
 }

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -1,59 +1,31 @@
-/* Card component styles */
+/* Generic Card container — hairline border, optional fill + hover. */
 
 .card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  border-radius: var(--radius-xl);
+  display: block;
   border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-xl);
+  background-color: var(--color-bg);
+  padding: var(--space-6);
+  transition: background-color var(--duration-fast) var(--easing-default);
+}
+
+.fill {
   background-color: var(--color-surface);
-  box-shadow: var(--shadow-md);
-  transition:
-    transform var(--duration-fast) var(--easing-default),
-    box-shadow var(--duration-fast) var(--easing-default);
 }
 
-.card:hover {
-  transform: translate(-4px, -4px);
-  box-shadow: var(--shadow-lg);
+.hover:hover {
+  background-color: var(--color-hover);
 }
 
-.imageWrapper {
-  /* aspect-video = 16/9 */
-  aspect-ratio: 16 / 9;
+.asButton {
   width: 100%;
-  overflow: hidden;
-  border-bottom: var(--border-width) solid var(--color-border);
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+  cursor: pointer;
 }
 
-.imageWrapper > figure > div {
-  border: none;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .card {
-    transition: none;
-  }
-
-  .card:hover {
-    transform: none;
-  }
-}
-
-.body {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  padding-block-start: 0;
-  padding-block-end: var(--space-6);
-  padding-inline: var(--space-6);
-}
-
-.title {
-  margin-block-end: var(--space-2);
-}
-
-.description {
-  margin-block-end: var(--space-4);
+.asButton:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -1,0 +1,57 @@
+import Card from '@components/Card'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import styles from './Card.module.css'
+
+describe('Card', () => {
+  it('renders children inside a div by default', () => {
+    render(<Card>Card content</Card>)
+
+    const card = screen.getByText('Card content')
+
+    expect(card).toBeInTheDocument()
+    expect(card.tagName).toBe('DIV')
+  })
+
+  it('renders as the element passed via the "as" prop', () => {
+    render(<Card as="section">Section content</Card>)
+
+    const card = screen.getByText('Section content')
+
+    expect(card.tagName).toBe('SECTION')
+  })
+
+  it('renders a real button with the shared focus ring when onClick is provided, and fires onClick when clicked', async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+
+    render(<Card onClick={handleClick}>Click me</Card>)
+
+    const button = screen.getByRole('button', { name: /click me/i })
+
+    expect(button).toHaveAttribute('type', 'button')
+    // Card.module.css's `.asButton` composes the shared `focusRing` utility
+    // from interactions.module.css. Vitest's CSS Modules transform doesn't
+    // resolve cross-file `composes` merging (only Card.module.css's own
+    // local token is present at test time), so we assert the `asButton`
+    // class itself — the token that carries the focus ring in the real
+    // stylesheet — rather than the composed class name directly.
+    expect(button).toHaveClass(styles.asButton)
+
+    await user.click(button)
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies the fill class when fill is true', () => {
+    render(<Card fill>Filled content</Card>)
+
+    expect(screen.getByText('Filled content')).toHaveClass(styles.fill)
+  })
+
+  it('applies the hover class when hover is true', () => {
+    render(<Card hover>Hoverable content</Card>)
+
+    expect(screen.getByText('Hoverable content')).toHaveClass(styles.hover)
+  })
+})

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,39 +1,54 @@
-import Image from '@components/Image'
-import type { ImageProps } from '@components/Image/Image'
-import Link from '@components/Link'
-import Typography from '@components/Typography'
-import type { FC } from 'react'
+import type { CSSProperties, ElementType, MouseEvent, ReactNode } from 'react'
 import styles from './Card.module.css'
 
 export interface CardProps {
-  title: string
-  description: string
-  href: string
-  image: ImageProps
+  as?: ElementType
+  /** Surface fill vs page background. @default false */
+  fill?: boolean
+  /** CSS padding value. */
+  padding?: string
+  /** CSS border-radius. */
+  radius?: string
+  /** Subtle hover wash for clickable cards. @default false */
+  hover?: boolean
+  onClick?: (e: MouseEvent) => void
+  children?: ReactNode
+  className?: string
+  style?: CSSProperties
 }
 
-const Card: FC<CardProps> = ({ title, description, href, image }) => {
+const Card = ({
+  as,
+  fill = false,
+  padding,
+  radius,
+  hover = false,
+  onClick,
+  children,
+  className: extraClassName,
+  style,
+}: CardProps) => {
+  const Component = as ?? (onClick ? 'button' : 'div')
+
+  const className = [
+    styles.card,
+    fill && styles.fill,
+    hover && styles.hover,
+    Component === 'button' && styles.asButton,
+    extraClassName,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
-    <article className={styles.card}>
-      <div className={styles.imageWrapper}>
-        <Image
-          {...image}
-          className={styles.imageScaled}
-          aspectRatio="16/9"
-          objectFit="cover"
-        />
-      </div>
-
-      <div className={styles.body}>
-        <Typography variant="heading3" as="h2" className={styles.title}>
-          {title}
-        </Typography>
-
-        <Typography variant="body" className={styles.description}>{description}</Typography>
-
-        <Link to={href}>{href}</Link>
-      </div>
-    </article>
+    <Component
+      type={Component === 'button' ? 'button' : undefined}
+      className={className}
+      onClick={onClick}
+      style={{ padding, borderRadius: radius, ...style }}
+    >
+      {children}
+    </Component>
   )
 }
 

--- a/src/components/ConfirmDialog/ConfirmDialog.module.css
+++ b/src/components/ConfirmDialog/ConfirmDialog.module.css
@@ -1,17 +1,19 @@
 .dialog {
-  background: var(--color-surface);
+  background: var(--color-bg);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-2xl);
   box-shadow: var(--shadow-xl);
   padding: var(--space-6);
-  /* No paper max-w token fits; see token-migration.md §3c. */
-  max-width: 24rem;
-  width: 100%;
+  /* No paper max-w token fits a dialog; see token-migration.md §3c — kept
+     as a literal, capped against the viewport for small screens. */
+  inline-size: min(92vw, 24rem);
   color: var(--color-text);
 }
 
 .dialog::backdrop {
-  background: rgba(0, 0, 0, 0.5);
+  /* No design scrim/overlay color token exists; kept literal. No blur —
+     the PRD reserves backdrop-filter for the sticky header only. */
+  background: rgb(0 0 0 / 0.5);
 }
 
 .message {
@@ -23,4 +25,32 @@
   gap: var(--space-3);
   justify-content: flex-end;
   margin-top: var(--space-6);
+}
+
+/* ── Danger variant — header icon chip ──────────────────────────
+   The design precedes the title with a 36px danger-tinted icon chip for
+   destructive confirmations. Rather than adding a new DOM node, this is
+   wired via a conditional className on the existing title (Typography
+   accepts `className`) and rendered as generated content — decorative
+   only, consistent with the Toast tone-icon approach elsewhere in this
+   pass. */
+.dangerTitle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.dangerTitle::before {
+  content: '⚠';
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  /* Design: 36px. No exact token; --space-8 (32px) is the nearest step. */
+  width: var(--space-8);
+  height: var(--space-8);
+  border-radius: var(--radius-md);
+  background: var(--color-error-bg);
+  color: var(--color-error);
+  font-size: var(--font-size-lg);
 }

--- a/src/components/ConfirmDialog/ConfirmDialog.module.css
+++ b/src/components/ConfirmDialog/ConfirmDialog.module.css
@@ -1,22 +1,17 @@
-.overlay {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 100;
-}
-
 .dialog {
   background: var(--color-surface);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-2xl);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-xl);
   padding: var(--space-6);
   /* No paper max-w token fits; see token-migration.md §3c. */
   max-width: 24rem;
   width: 100%;
+  color: var(--color-text);
+}
+
+.dialog::backdrop {
+  background: rgba(0, 0, 0, 0.5);
 }
 
 .message {

--- a/src/components/ConfirmDialog/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog/ConfirmDialog.test.tsx
@@ -1,5 +1,7 @@
 import ConfirmDialog from '@components/ConfirmDialog'
 import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState, type FC } from 'react'
 
 describe('ConfirmDialog', () => {
   let mockOnConfirm = vi.fn()
@@ -10,30 +12,32 @@ describe('ConfirmDialog', () => {
     mockOnCancel = vi.fn()
   })
 
-  it('renders title and message when isOpen is true', () => {
+  it('renders title and children when open is true', () => {
     render(
       <ConfirmDialog
         title="Delete recipe"
-        message="Are you sure you want to delete this recipe?"
         onConfirm={mockOnConfirm}
         onCancel={mockOnCancel}
-        isOpen={true}
-      />
+        open={true}
+      >
+        Are you sure you want to delete this recipe?
+      </ConfirmDialog>
     )
 
     expect(screen.getByText('Delete recipe')).toBeInTheDocument()
     expect(screen.getByText('Are you sure you want to delete this recipe?')).toBeInTheDocument()
   })
 
-  it('does not render when isOpen is false', () => {
+  it('does not render content when open is false', () => {
     render(
       <ConfirmDialog
         title="Delete recipe"
-        message="Are you sure you want to delete this recipe?"
         onConfirm={mockOnConfirm}
         onCancel={mockOnCancel}
-        isOpen={false}
-      />
+        open={false}
+      >
+        Are you sure you want to delete this recipe?
+      </ConfirmDialog>
     )
 
     expect(screen.queryByText('Delete recipe')).not.toBeInTheDocument()
@@ -42,15 +46,11 @@ describe('ConfirmDialog', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('has role="dialog" with aria-labelledby', () => {
+  it('has an accessible dialog role with aria-labelledby pointing at the title', () => {
     render(
-      <ConfirmDialog
-        title="Delete recipe"
-        message="Are you sure you want to delete this recipe?"
-        onConfirm={mockOnConfirm}
-        onCancel={mockOnCancel}
-        isOpen={true}
-      />
+      <ConfirmDialog title="Delete recipe" onConfirm={mockOnConfirm} onCancel={mockOnCancel} open>
+        Are you sure you want to delete this recipe?
+      </ConfirmDialog>
     )
 
     const dialog = screen.getByRole('dialog')
@@ -63,64 +63,163 @@ describe('ConfirmDialog', () => {
     expect(document.getElementById(labelId!)).toHaveTextContent('Delete recipe')
   })
 
-  it('calls onConfirm when confirm button clicked', () => {
+  it('calls onConfirm when the confirm button is clicked', () => {
     render(
-      <ConfirmDialog
-        title="Delete recipe"
-        message="Are you sure you want to delete this recipe?"
-        onConfirm={mockOnConfirm}
-        onCancel={mockOnCancel}
-        isOpen={true}
-      />
+      <ConfirmDialog title="Delete recipe" onConfirm={mockOnConfirm} onCancel={mockOnCancel} open>
+        Are you sure you want to delete this recipe?
+      </ConfirmDialog>
     )
 
-    const confirmButton = screen.getByRole('button', { name: /confirm/i })
-
-    fireEvent.click(confirmButton)
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
 
     expect(mockOnConfirm).toHaveBeenCalledTimes(1)
   })
 
-  it('calls onCancel when cancel button clicked', () => {
+  it('calls onCancel when the cancel button is clicked', () => {
     render(
-      <ConfirmDialog
-        title="Delete recipe"
-        message="Are you sure you want to delete this recipe?"
-        onConfirm={mockOnConfirm}
-        onCancel={mockOnCancel}
-        isOpen={true}
-      />
+      <ConfirmDialog title="Delete recipe" onConfirm={mockOnConfirm} onCancel={mockOnCancel} open>
+        Are you sure you want to delete this recipe?
+      </ConfirmDialog>
     )
 
-    const cancelButton = screen.getByRole('button', { name: /cancel/i })
-
-    fireEvent.click(cancelButton)
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
 
     expect(mockOnCancel).toHaveBeenCalledTimes(1)
   })
 
-  it('traps focus within the dialog', () => {
+  it('renders the danger variant with the given confirm label, still queryable by role/name', () => {
     render(
       <ConfirmDialog
         title="Delete recipe"
-        message="Are you sure you want to delete this recipe?"
+        confirmLabel="Delete"
+        danger
         onConfirm={mockOnConfirm}
         onCancel={mockOnCancel}
-        isOpen={true}
-      />
+        open
+      >
+        Are you sure you want to delete this recipe?
+      </ConfirmDialog>
+    )
+
+    expect(screen.getByRole('heading', { name: /delete recipe/i })).toBeInTheDocument()
+
+    const confirmButton = screen.getByRole('button', { name: 'Delete' })
+    expect(confirmButton).toBeInTheDocument()
+
+    fireEvent.click(confirmButton)
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('moves focus into the dialog when it opens', () => {
+    render(
+      <ConfirmDialog title="Delete recipe" onConfirm={mockOnConfirm} onCancel={mockOnCancel} open>
+        Are you sure you want to delete this recipe?
+      </ConfirmDialog>
     )
 
     const dialog = screen.getByRole('dialog')
-    const focusableElements = dialog.querySelectorAll(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+
+    expect(dialog).toContainElement(document.activeElement as HTMLElement)
+  })
+
+  it('restores focus to the triggering element after close', async () => {
+    // A harness that owns `open` state so the ConfirmDialog transitions from
+    // closed -> open -> closed, exercising the real trigger-focus save and
+    // close-triggered restore (jsdom does not auto-focus on mount the way a
+    // browser does, so the trigger's focus has to come from a real
+    // interaction before the dialog opens).
+    const Harness: FC = () => {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open dialog</button>
+          <ConfirmDialog
+            title="Delete recipe"
+            onConfirm={mockOnConfirm}
+            onCancel={() => setOpen(false)}
+            open={open}
+          >
+            Are you sure you want to delete this recipe?
+          </ConfirmDialog>
+        </>
+      )
+    }
+
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    const trigger = screen.getByRole('button', { name: /open dialog/i })
+    await user.click(trigger)
+
+    const cancelButton = await screen.findByRole('button', { name: /cancel/i })
+    await user.click(cancelButton)
+
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('closes on the native dialog cancel event (fired by the browser on Escape)', () => {
+    render(
+      <ConfirmDialog title="Delete recipe" onConfirm={mockOnConfirm} onCancel={mockOnCancel} open>
+        Are you sure you want to delete this recipe?
+      </ConfirmDialog>
     )
-    const lastFocusable = focusableElements[focusableElements.length - 1] as HTMLElement
 
-    lastFocusable.focus()
-    fireEvent.keyDown(dialog, { key: 'Tab', shiftKey: false })
+    const dialog = screen.getByRole('dialog')
+    fireEvent(dialog, new Event('cancel', { cancelable: true }))
 
-    const firstFocusable = focusableElements[0] as HTMLElement
+    expect(mockOnCancel).toHaveBeenCalledTimes(1)
+  })
 
-    expect(document.activeElement).toBe(firstFocusable)
+  it('clicking the scrim outside the rendered dialog box closes it', () => {
+    render(
+      <ConfirmDialog title="Delete recipe" onConfirm={mockOnConfirm} onCancel={mockOnCancel} open>
+        Are you sure you want to delete this recipe?
+      </ConfirmDialog>
+    )
+
+    const dialog = screen.getByRole('dialog')
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue({
+      left: 100,
+      right: 300,
+      top: 100,
+      bottom: 300,
+      width: 200,
+      height: 200,
+      x: 100,
+      y: 100,
+      toJSON: () => {},
+    })
+
+    fireEvent.click(dialog, { clientX: 10, clientY: 10 })
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking inside the rendered dialog box (its own padding) does not close it — regression for the scrim-click bug', () => {
+    render(
+      <ConfirmDialog title="Delete recipe" onConfirm={mockOnConfirm} onCancel={mockOnCancel} open>
+        Are you sure you want to delete this recipe?
+      </ConfirmDialog>
+    )
+
+    const dialog = screen.getByRole('dialog')
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue({
+      left: 100,
+      right: 300,
+      top: 100,
+      bottom: 300,
+      width: 200,
+      height: 200,
+      x: 100,
+      y: 100,
+      toJSON: () => {},
+    })
+
+    // Clicking in the dialog's own padding still has `target === dialog`
+    // (no inner wrapper), but the coordinates fall inside the rendered box —
+    // this must NOT be treated as a scrim click.
+    fireEvent.click(dialog, { clientX: 150, clientY: 150 })
+
+    expect(mockOnCancel).not.toHaveBeenCalled()
   })
 })

--- a/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,94 +1,107 @@
-
 import Button from '@components/Button'
 import Typography from '@components/Typography'
-import { useRef, type FC, type KeyboardEvent } from 'react'
+import { useEffect, useRef, type FC, type MouseEvent, type ReactNode } from 'react'
 
 import styles from './ConfirmDialog.module.css'
 
 export interface ConfirmDialogProps {
+  open: boolean
   title: string
-  message: string
-  onConfirm: () => void
-  onCancel: () => void
-  isOpen: boolean
+  children?: ReactNode
   confirmLabel?: string
   cancelLabel?: string
+  /** Danger icon + red confirm button (destructive actions). @default false */
+  danger?: boolean
+  onConfirm: () => void
+  onCancel: () => void
 }
 
 const TITLE_ID = 'confirm-dialog-title'
 
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+
 const ConfirmDialog: FC<ConfirmDialogProps> = ({
+  open,
   title,
-  message,
-  onConfirm,
-  onCancel,
-  isOpen,
+  children,
   confirmLabel = 'Confirm',
   cancelLabel = 'Cancel',
+  danger = false,
+  onConfirm,
+  onCancel,
 }) => {
-  const dialogRef = useRef<HTMLDivElement>(null)
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const triggerRef = useRef<HTMLElement | null>(null)
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'Escape') {
-      onCancel()
-      return
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    if (open) {
+      triggerRef.current =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null
+      if (!dialog.open) dialog.showModal()
+      dialog.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus()
+    } else if (dialog.open) {
+      dialog.close()
     }
-    if (e.key === 'Tab') {
-      const dialog = dialogRef.current
-      if (!dialog) return
+  }, [open])
 
-      const focusable = dialog.querySelectorAll<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      )
-      if (focusable.length === 0) return
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
 
-      const first = focusable[0]
-      const last = focusable[focusable.length - 1]
+    const handleClose = () => {
+      triggerRef.current?.focus()
+      triggerRef.current = null
+    }
 
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault()
-          last.focus()
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault()
-          first.focus()
-        }
-      }
+    dialog.addEventListener('close', handleClose)
+    return () => dialog.removeEventListener('close', handleClose)
+  }, [])
+
+  const handleScrimClick = (event: MouseEvent<HTMLDialogElement>) => {
+    if (event.target === dialogRef.current) {
+      onCancel()
     }
   }
 
-  if (!isOpen) return null
-
   return (
-    <div className={styles.overlay}>
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions --
-          stopgap until #223 moves this to native <dialog>/showModal(). */}
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={TITLE_ID}
-        className={styles.dialog}
-        onKeyDown={handleKeyDown}
-      >
-        <Typography variant="heading3" as="h2" id={TITLE_ID}>
-          {title}
-        </Typography>
-        <Typography variant="body" className={styles.message}>
-          {message}
-        </Typography>
-        <div className={styles.actions}>
-          <Button onClick={onCancel} variant="secondary">
-            {cancelLabel}
-          </Button>
-          <Button onClick={onConfirm} variant="primary">
-            {confirmLabel}
-          </Button>
-        </div>
-      </div>
-    </div>
+    // The click listener only distinguishes a scrim click (event.target ===
+    // the dialog element itself, since the ::backdrop is not a real
+    // descendant) from a click inside the dialog's content; Escape/close is
+    // handled natively by <dialog>. There is no interactive-element
+    // alternative for this check.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
+    <dialog
+      ref={dialogRef}
+      aria-labelledby={TITLE_ID}
+      className={styles.dialog}
+      onClick={handleScrimClick}
+      onCancel={onCancel}
+    >
+      {open && (
+        <>
+          <Typography variant="heading3" as="h2" id={TITLE_ID}>
+            {title}
+          </Typography>
+          {children && (
+            <Typography variant="body" className={styles.message}>
+              {children}
+            </Typography>
+          )}
+          <div className={styles.actions}>
+            <Button onClick={onCancel} variant="outline">
+              {cancelLabel}
+            </Button>
+            <Button onClick={onConfirm} variant={danger ? 'danger' : 'solid'}>
+              {confirmLabel}
+            </Button>
+          </div>
+        </>
+      )}
+    </dialog>
   )
 }
 

--- a/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -83,7 +83,12 @@ const ConfirmDialog: FC<ConfirmDialogProps> = ({
     >
       {open && (
         <>
-          <Typography variant="heading3" as="h2" id={TITLE_ID}>
+          <Typography
+            variant="heading3"
+            as="h2"
+            id={TITLE_ID}
+            className={danger ? styles.dangerTitle : undefined}
+          >
             {title}
           </Typography>
           {children && (

--- a/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -62,7 +62,24 @@ const ConfirmDialog: FC<ConfirmDialogProps> = ({
   }, [])
 
   const handleScrimClick = (event: MouseEvent<HTMLDialogElement>) => {
-    if (event.target === dialogRef.current) {
+    const dialog = dialogRef.current
+    if (!dialog || event.target !== dialog) return
+
+    // `.dialog`'s background/border/padding live on the <dialog> element
+    // itself (no separate inner wrapper), so `target === dialog` alone
+    // doesn't distinguish a genuine scrim click from a click that lands in
+    // the dialog's own padding (still `target === dialog`, since the padding
+    // area has no other element painted over it). Compare against the
+    // rendered box instead: outside it is the ::backdrop (scrim), inside it
+    // is dialog content/whitespace.
+    const rect = dialog.getBoundingClientRect()
+    const clickedInsideDialogBox =
+      event.clientX >= rect.left &&
+      event.clientX <= rect.right &&
+      event.clientY >= rect.top &&
+      event.clientY <= rect.bottom
+
+    if (!clickedInsideDialogBox) {
       onCancel()
     }
   }

--- a/src/components/FileMeta/FileMeta.test.tsx
+++ b/src/components/FileMeta/FileMeta.test.tsx
@@ -35,6 +35,6 @@ describe('FileMeta', () => {
 
   it('renders loading component when no fileInfo and no error', () => {
     render(<FileMeta fileInfo={null} hasError={false} />)
-    expect(screen.getByRole('status', { name: /loading content/i })).toBeInTheDocument()
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
   })
 })

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -140,18 +140,18 @@ const ImageUpload: FC<ImageUploadProps> = ({
       {error && (
         <div className={styles.error} role="alert">
           <span>{error}</span>
-          <Button onClick={handleRetry} variant="secondary" ariaLabel="Retry">
+          <Button onClick={handleRetry} variant="outline" ariaLabel="Retry">
             Retry
           </Button>
         </div>
       )}
 
       {hasCurrentImage && !preview ? (
-        <Button onClick={handleClick} ariaLabel="Replace image" variant="secondary">
+        <Button onClick={handleClick} ariaLabel="Replace image" variant="outline">
           Replace
         </Button>
       ) : (
-        <Button onClick={handleClick} variant="primary">
+        <Button onClick={handleClick} variant="solid">
           Upload
         </Button>
       )}

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -79,7 +79,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
             <Button
               onClick={() => handleMoveUp(index)}
               ariaLabel={`Move up ingredient ${index + 1}`}
-              variant="secondary"
+              variant="outline"
               disabled={index === 0}
               className={styles.actionButton}
             >
@@ -88,7 +88,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
             <Button
               onClick={() => handleMoveDown(index)}
               ariaLabel={`Move down ingredient ${index + 1}`}
-              variant="secondary"
+              variant="outline"
               disabled={index === ingredients.length - 1}
               className={styles.actionButton}
             >
@@ -97,7 +97,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
             <Button
               onClick={() => handleRemove(index)}
               ariaLabel={`Remove ingredient ${index + 1}`}
-              variant="secondary"
+              variant="outline"
               disabled={ingredients.length <= 1}
               className={styles.actionButton}
             >
@@ -106,7 +106,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
           </div>
         </div>
       ))}
-      <Button onClick={handleAdd} variant="secondary">
+      <Button onClick={handleAdd} variant="outline">
         Add ingredient
       </Button>
     </div>

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -1,6 +1,7 @@
 /* Link component styles */
 
 .link {
+  composes: focusRing from '../../styles/interactions.module.css';
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
@@ -9,6 +10,7 @@
   text-decoration: underline;
   text-underline-offset: 2px;
   width: fit-content;
+  border-radius: var(--radius-sm);
   transition: color var(--duration-fast) var(--easing-default);
 }
 
@@ -16,10 +18,10 @@
   color: var(--color-primary);
 }
 
-.link:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-  border-radius: var(--radius-sm);
+@media (prefers-reduced-motion: reduce) {
+  .link {
+    transition: none;
+  }
 }
 
 /* ── Tone ────────────────────────────────────────────────────── */
@@ -43,22 +45,23 @@
   text-underline-offset: 2px;
 }
 
-/* ── Icon + nudge ────────────────────────────────────────────── */
+/* ── Icon + nudge ────────────────────────────────────────────────
+   Ported from the shared interactions.module.css composables (itself a
+   port of _helpers.css .ds-link/.ds-link-ic) rather than duplicating the
+   transition/transform declarations locally. */
 
 .icon {
-  display: inline-flex;
-  align-items: center;
-  transition: transform var(--duration-base) var(--easing-default);
+  composes: linkIcon from '../../styles/interactions.module.css';
 }
 
-.link:hover .nudge-right {
-  transform: translateX(3px);
+.nudgeRight {
+  composes: nudgeRight from '../../styles/interactions.module.css';
 }
 
-.link:hover .nudge-left {
-  transform: translateX(-3px);
+.nudgeLeft {
+  composes: nudgeLeft from '../../styles/interactions.module.css';
 }
 
-.link:hover .nudge-up-right {
-  transform: translate(3px, -3px);
+.nudgeUpRight {
+  composes: nudgeUpRight from '../../styles/interactions.module.css';
 }

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -1,6 +1,9 @@
 /* Link component styles */
 
 .link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
   color: var(--color-link);
   font-weight: inherit;
   text-decoration: underline;
@@ -9,10 +12,28 @@
   transition: color var(--duration-fast) var(--easing-default);
 }
 
+.link:hover {
+  color: var(--color-primary);
+}
+
 .link:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
   border-radius: var(--radius-sm);
+}
+
+/* ── Tone ────────────────────────────────────────────────────── */
+
+.inherit {
+  color: inherit;
+}
+
+.muted {
+  color: var(--color-text-muted);
+}
+
+.accent {
+  color: var(--color-primary);
 }
 
 /* ── Underline modifier ──────────────────────────────────────── */
@@ -20,4 +41,24 @@
 .underline {
   text-decoration: underline;
   text-underline-offset: 2px;
+}
+
+/* ── Icon + nudge ────────────────────────────────────────────── */
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  transition: transform var(--duration-base) var(--easing-default);
+}
+
+.link:hover .nudge-right {
+  transform: translateX(3px);
+}
+
+.link:hover .nudge-left {
+  transform: translateX(-3px);
+}
+
+.link:hover .nudge-up-right {
+  transform: translate(3px, -3px);
 }

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -1,6 +1,7 @@
 import Link from '@components/Link'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import styles from './Link.module.css'
 
 describe('Link', () => {
   it('renders correctly with children', () => {
@@ -41,5 +42,84 @@ describe('Link', () => {
     expect(linkElement).toHaveAttribute('href', externalUrl)
     expect(linkElement).toHaveAttribute('target', '_blank')
     expect(linkElement).toHaveAttribute('rel', 'noreferrer')
+  })
+
+  it('wraps the icon in an aria-hidden element so it does not gain its own accessible name', () => {
+    render(
+      <MemoryRouter>
+        <Link to="/apps" icon={<span data-testid="icon">{'→'}</span>}>
+          Apps
+        </Link>
+      </MemoryRouter>
+    )
+
+    const icon = screen.getByTestId('icon')
+
+    expect(icon.parentElement).toHaveAttribute('aria-hidden', 'true')
+
+    // The icon must not contribute to the accessible name — only the
+    // link's own text should.
+    const linkElement = screen.getByRole('link', { name: 'Apps' })
+    expect(linkElement).toBeInTheDocument()
+  })
+
+  it('positions the icon before the link text when iconSide is "left"', () => {
+    render(
+      <MemoryRouter>
+        <Link to="/apps" icon={<span data-testid="icon" />} iconSide="left">
+          <span data-testid="text">Apps</span>
+        </Link>
+      </MemoryRouter>
+    )
+
+    const linkElement = screen.getByRole('link')
+    const icon = within(linkElement).getByTestId('icon')
+    const text = within(linkElement).getByTestId('text')
+
+    expect(icon.compareDocumentPosition(text) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('positions the icon after the link text when iconSide is "right" (default)', () => {
+    render(
+      <MemoryRouter>
+        <Link to="/apps" icon={<span data-testid="icon" />}>
+          <span data-testid="text">Apps</span>
+        </Link>
+      </MemoryRouter>
+    )
+
+    const linkElement = screen.getByRole('link')
+    const icon = within(linkElement).getByTestId('icon')
+    const text = within(linkElement).getByTestId('text')
+
+    expect(text.compareDocumentPosition(icon) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('applies the tone class for the given tone', () => {
+    render(
+      <MemoryRouter>
+        <Link to="/apps" tone="accent">
+          Apps
+        </Link>
+      </MemoryRouter>
+    )
+
+    const linkElement = screen.getByRole('link', { name: /apps/i })
+
+    expect(linkElement).toHaveClass(styles.accent)
+  })
+
+  it('applies the nudge direction class to the icon wrapper', () => {
+    render(
+      <MemoryRouter>
+        <Link to="/apps" icon={<span data-testid="icon" />} nudge="left">
+          Apps
+        </Link>
+      </MemoryRouter>
+    )
+
+    const icon = screen.getByTestId('icon')
+
+    expect(icon.parentElement).toHaveClass(styles.nudgeLeft)
   })
 })

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -18,6 +18,13 @@ export interface LinkProps {
   className?: string
 }
 
+const NUDGE_CLASSES: Record<NonNullable<LinkProps['nudge']>, string | undefined> = {
+  left: styles.nudgeLeft,
+  right: styles.nudgeRight,
+  'up-right': styles.nudgeUpRight,
+  none: undefined,
+}
+
 const Link: FC<LinkProps> = ({
   children,
   to,
@@ -41,7 +48,7 @@ const Link: FC<LinkProps> = ({
     .filter(Boolean)
     .join(' ')
 
-  const iconClassName = [styles.icon, styles[`nudge-${nudge}`]].filter(Boolean).join(' ')
+  const iconClassName = [styles.icon, NUDGE_CLASSES[nudge]].filter(Boolean).join(' ')
 
   const content = icon ? (
     <>

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -2,10 +2,18 @@ import { FC, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import styles from './Link.module.css'
 
-interface LinkProps {
+export interface LinkProps {
   children: ReactNode
   to: string
   underline?: boolean
+  /** @default 'inherit' */
+  tone?: 'inherit' | 'muted' | 'accent'
+  /** Optional icon (chevron/arrow) that animates on hover. */
+  icon?: ReactNode
+  /** @default 'right' */
+  iconSide?: 'left' | 'right'
+  /** Direction the icon nudges on hover. @default 'right' */
+  nudge?: 'left' | 'right' | 'up-right' | 'none'
   ariaLabel?: string
   className?: string
 }
@@ -14,13 +22,44 @@ const Link: FC<LinkProps> = ({
   children,
   to,
   underline = false,
+  tone = 'inherit',
+  icon,
+  iconSide = 'right',
+  nudge = 'right',
   ariaLabel,
   className: externalClassName,
 }) => {
   const isExternal =
     /^https?:\/\//.test(to) || to.startsWith('mailto:') || to.startsWith('tel:')
 
-  const className = [styles.link, underline ? styles.underline : '', externalClassName].filter(Boolean).join(' ')
+  const className = [
+    styles.link,
+    styles[tone],
+    underline ? styles.underline : '',
+    externalClassName,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const iconClassName = [styles.icon, styles[`nudge-${nudge}`]].filter(Boolean).join(' ')
+
+  const content = icon ? (
+    <>
+      {iconSide === 'left' && (
+        <span className={iconClassName} aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      {children}
+      {iconSide === 'right' && (
+        <span className={iconClassName} aria-hidden="true">
+          {icon}
+        </span>
+      )}
+    </>
+  ) : (
+    children
+  )
 
   if (isExternal) {
     return (
@@ -31,14 +70,14 @@ const Link: FC<LinkProps> = ({
         rel="noreferrer"
         aria-label={ariaLabel}
       >
-        {children}
+        {content}
       </a>
     )
   }
 
   return (
     <RouterLink to={to} className={className} aria-label={ariaLabel}>
-      {children}
+      {content}
     </RouterLink>
   )
 }

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -1,8 +1,18 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-12) 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
 .spinner {
   display: inline-block;
-  width: 1em;
-  height: 1em;
-  vertical-align: middle;
+  width: 2rem;
+  height: 2rem;
   border-radius: var(--radius-full);
   border: var(--border-width-thick) solid var(--color-border);
   border-block-start-color: var(--color-primary);
@@ -10,10 +20,8 @@
   animation: spin 0.8s linear infinite;
 }
 
-.small {
-  width: 0.75em;
-  height: 0.75em;
-  border-width: 2px;
+.label {
+  font-family: var(--font-mono);
 }
 
 @keyframes spin {

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -24,25 +24,7 @@
   font-family: var(--font-mono);
 }
 
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .spinner {
-    animation: pulse 1.5s ease-in-out infinite;
-  }
-
-  @keyframes pulse {
-    0%,
-    100% {
-      opacity: 1;
-    }
-
-    50% {
-      opacity: 0.4;
-    }
-  }
-}
+/* Uses the global `spin` keyframe (src/styles/animations.css), which is
+   already neutered under prefers-reduced-motion at the keyframe level
+   (rotation frozen) — no local override needed, matching the convention
+   documented in src/styles/interactions.module.css. */

--- a/src/components/Loading/Loading.module.css
+++ b/src/components/Loading/Loading.module.css
@@ -10,21 +10,21 @@
 }
 
 .spinner {
+  composes: spinner from '../../styles/interactions.module.css';
   display: inline-block;
+  /* Larger + a two-sided arc than the shared 24px/single-edge default —
+     this is the prominent whole-view variant, not the inline/toast one. */
   width: 2rem;
   height: 2rem;
-  border-radius: var(--radius-full);
-  border: var(--border-width-thick) solid var(--color-border);
-  border-block-start-color: var(--color-primary);
+  border-width: var(--border-width-thick);
   border-inline-end-color: var(--color-primary);
-  animation: spin 0.8s linear infinite;
 }
 
 .label {
   font-family: var(--font-mono);
 }
 
-/* Uses the global `spin` keyframe (src/styles/animations.css), which is
-   already neutered under prefers-reduced-motion at the keyframe level
-   (rotation frozen) — no local override needed, matching the convention
-   documented in src/styles/interactions.module.css. */
+/* Uses the global `spin` keyframe (src/styles/animations.css) via the
+   composed `spinner` class, which is already neutered under
+   prefers-reduced-motion at the keyframe level (rotation frozen) — no
+   local override needed. */

--- a/src/components/Loading/Loading.test.tsx
+++ b/src/components/Loading/Loading.test.tsx
@@ -5,9 +5,15 @@ describe('Loading', () => {
   it('renders the spinner with correct role and aria attributes', () => {
     render(<Loading />)
 
-    const spinner = screen.getByRole('status', { name: /loading content/i })
+    const spinner = screen.getByRole('status', { name: /loading/i })
 
     expect(spinner).toBeInTheDocument()
     expect(spinner.tagName).toBe('SPAN')
+  })
+
+  it('accepts a custom label', () => {
+    render(<Loading label="Loading recipes…" />)
+
+    expect(screen.getByRole('status', { name: /loading recipes/i })).toBeInTheDocument()
   })
 })

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -2,21 +2,17 @@ import type { FC } from 'react'
 import styles from './Loading.module.css'
 
 export interface LoadingProps {
-  size?: 'default' | 'small'
+  label?: string
 }
 
-const Loading: FC<LoadingProps> = ({ size = 'default' }) => {
-  const className = size === 'small'
-    ? `${styles.spinner} ${styles.small}`
-    : styles.spinner
-
+const Loading: FC<LoadingProps> = ({ label = 'Loading…' }) => {
   return (
-    <span
-      role="status"
-      aria-live="polite"
-      aria-label="Loading content"
-      className={className}
-    />
+    <span role="status" aria-live="polite" aria-label={label} className={styles.container}>
+      <span className={styles.spinner} aria-hidden="true" />
+      <span className={styles.label} aria-hidden="true">
+        {label}
+      </span>
+    </span>
   )
 }
 

--- a/src/components/ProcessingPlaceholder/ProcessingPlaceholder.module.css
+++ b/src/components/ProcessingPlaceholder/ProcessingPlaceholder.module.css
@@ -2,6 +2,10 @@
   margin: 0;
 }
 
+.small .inner {
+  border-radius: var(--radius-md);
+}
+
 .inner {
   position: relative;
   overflow: hidden;

--- a/src/components/ProcessingPlaceholder/ProcessingPlaceholder.module.css
+++ b/src/components/ProcessingPlaceholder/ProcessingPlaceholder.module.css
@@ -14,38 +14,32 @@
   border-radius: var(--radius-lg);
 }
 
-/* ── Pulsing overlay ─────────────────────────────────────── */
+/* ── Shimmer overlay ───────────────────────────────────────
+   Ported from interactions.module.css's `.shimmer` (itself a port of
+   _helpers.css .ds-shimmer — a sweeping gradient highlight), replacing
+   the previous plain opacity pulse to match the design's actual
+   "shimmer placeholder" treatment. */
 .overlay {
+  composes: shimmer from '../../styles/interactions.module.css';
   position: absolute;
   inset: 0;
-  background-color: var(--color-surface);
-  opacity: 0.4;
-  animation: pulse 1.6s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 0.4;
-  }
-
-  50% {
-    opacity: 0.8;
-  }
 }
 
 /* ── Reduced-motion fallbacks ────────────────────────────── */
-/* Class-based path — set by the TSX when matchMedia reports reduce. */
+/* The composed `.shimmer` already relies on the global `shimmerSweep`
+   keyframe being neutered under reduced motion (see
+   src/styles/interactions.module.css), but these two paths are kept for
+   defense-in-depth / explicitness, matching this component's pre-existing
+   dual (class + media-query) strategy. */
 .root.reducedMotion .overlay {
   animation: none;
-  opacity: 0.6;
+  background-position: 0 0;
 }
 
-/* Media-query path — covers cases where JS hasn't applied the class yet. */
 @media (prefers-reduced-motion: reduce) {
   .overlay {
     animation: none;
-    opacity: 0.6;
+    background-position: 0 0;
   }
 }
 

--- a/src/components/ProcessingPlaceholder/ProcessingPlaceholder.tsx
+++ b/src/components/ProcessingPlaceholder/ProcessingPlaceholder.tsx
@@ -3,7 +3,10 @@ import styles from './ProcessingPlaceholder.module.css'
 
 export interface ProcessingPlaceholderProps {
   aspectRatio?: string
+  height?: string
   caption?: string
+  /** Compact variant (step thumbnails). @default false */
+  small?: boolean
   className?: string
 }
 
@@ -11,7 +14,9 @@ const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
 
 const ProcessingPlaceholder: FC<ProcessingPlaceholderProps> = ({
   aspectRatio,
+  height,
   caption = 'Processing image…',
+  small = false,
   className = '',
 }) => {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
@@ -34,6 +39,7 @@ const ProcessingPlaceholder: FC<ProcessingPlaceholderProps> = ({
 
   const rootClassName = [
     styles.root,
+    small ? styles.small : '',
     prefersReducedMotion ? styles.reducedMotion : '',
     className,
   ]
@@ -44,11 +50,11 @@ const ProcessingPlaceholder: FC<ProcessingPlaceholderProps> = ({
     <figure className={rootClassName}>
       <div
         className={styles.inner}
-        style={{ aspectRatio: aspectRatio ?? undefined }}
+        style={{ aspectRatio: aspectRatio ?? undefined, height }}
       >
         <div className={styles.overlay} aria-hidden="true" />
       </div>
-      <figcaption className={styles.caption}>{caption}</figcaption>
+      <figcaption className={small ? 'sr-only' : styles.caption}>{caption}</figcaption>
     </figure>
   )
 }

--- a/src/components/RecipeTagFilter/RecipeTagFilter.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.tsx
@@ -15,7 +15,7 @@ const RecipeTagFilter: FC<RecipeTagFilterProps> = ({ tags, activeTag, onTagClick
       {tags.map(({ tag, count }) => (
         <Button
           key={tag}
-          variant="secondary"
+          variant="outline"
           className={styles.tag}
           ariaPressed={activeTag === tag ? 'true' : 'false'}
           onClick={() => onTagClick(tag)}

--- a/src/components/StatusBadge/StatusBadge.module.css
+++ b/src/components/StatusBadge/StatusBadge.module.css
@@ -1,19 +1,41 @@
 .badge {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
   padding: var(--space-1) var(--space-2);
-  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-meta);
   border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-sm);
-}
-
-.badge[data-status='published'] {
-  background: var(--color-surface);
-  color: var(--color-text);
-  border-color: var(--color-primary);
-}
-
-.badge[data-status='draft'] {
+  border-radius: var(--radius-full);
   background: var(--color-surface);
   color: var(--color-text-muted);
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: currentcolor;
+}
+
+.success {
+  color: var(--color-success);
+  background: var(--color-success-bg);
+}
+
+.warning {
+  color: var(--color-warning);
+  background: var(--color-warning-bg);
+}
+
+.error {
+  color: var(--color-error);
+  background: var(--color-error-bg);
+}
+
+.neutral {
+  color: var(--color-text-muted);
+  background: var(--color-surface);
 }

--- a/src/components/StatusBadge/StatusBadge.module.css
+++ b/src/components/StatusBadge/StatusBadge.module.css
@@ -8,7 +8,9 @@
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-meta);
   border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-full);
+  /* Chips/tags/badges → --radius-sm per docs/design/paper/token-migration.md §3a
+     (StatusBadge .badge is listed explicitly). */
+  border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text-muted);
 }

--- a/src/components/StatusBadge/StatusBadge.test.tsx
+++ b/src/components/StatusBadge/StatusBadge.test.tsx
@@ -2,39 +2,21 @@ import StatusBadge from '@components/StatusBadge'
 import { render, screen } from '@testing-library/react'
 
 describe('StatusBadge', () => {
-  it('renders "Draft" text when status is draft', () => {
-    render(<StatusBadge status="draft" />)
-
-    expect(screen.getByText('Draft')).toBeInTheDocument()
-  })
-
-  it('renders "Published" text when status is published', () => {
-    render(<StatusBadge status="published" />)
+  it('renders the provided children as its text content', () => {
+    render(<StatusBadge tone="success">Published</StatusBadge>)
 
     expect(screen.getByText('Published')).toBeInTheDocument()
   })
 
-  it('sets data-status="draft" on the element when status is draft', () => {
-    render(<StatusBadge status="draft" />)
+  it('renders different label text per tone', () => {
+    render(<StatusBadge tone="warning">Draft</StatusBadge>)
 
-    const badge = screen.getByText('Draft').closest('[data-status]')
-
-    expect(badge).toHaveAttribute('data-status', 'draft')
+    expect(screen.getByText('Draft')).toBeInTheDocument()
   })
 
-  it('sets data-status="published" on the element when status is published', () => {
-    render(<StatusBadge status="published" />)
+  it('is visible to assistive tech (not aria-hidden itself)', () => {
+    render(<StatusBadge tone="error">Failed</StatusBadge>)
 
-    const badge = screen.getByText('Published').closest('[data-status]')
-
-    expect(badge).toHaveAttribute('data-status', 'published')
-  })
-
-  it('includes a visually-hidden "Status:" prefix for screen readers', () => {
-    render(<StatusBadge status="draft" />)
-
-    const prefix = screen.getByText('Status:', { exact: false, selector: '.sr-only' })
-
-    expect(prefix).toBeInTheDocument()
+    expect(screen.getByText('Failed')).toBeVisible()
   })
 })

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -1,17 +1,30 @@
-import type { Recipe } from '@models/recipe'
-import type { FC } from 'react'
+import type { CSSProperties, FC, ReactNode } from 'react'
 
 import styles from './StatusBadge.module.css'
 
 export interface StatusBadgeProps {
-  status: Recipe['status']
+  /** @default 'neutral' */
+  tone?: 'success' | 'warning' | 'error' | 'neutral'
+  /** Show the leading dot. @default true */
+  dot?: boolean
+  children?: ReactNode
+  className?: string
+  style?: CSSProperties
 }
 
-const StatusBadge: FC<StatusBadgeProps> = ({ status }) => {
+const StatusBadge: FC<StatusBadgeProps> = ({
+  tone = 'neutral',
+  dot = true,
+  children,
+  className: extraClassName,
+  style,
+}) => {
+  const className = [styles.badge, styles[tone], extraClassName].filter(Boolean).join(' ')
+
   return (
-    <span className={styles.badge} data-status={status}>
-      <span className="sr-only">Status: </span>
-      {status === 'published' ? 'Published' : 'Draft'}
+    <span className={className} style={style}>
+      {dot && <span aria-hidden="true" className={styles.dot} />}
+      {children}
     </span>
   )
 }

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -116,7 +116,7 @@ const StepList: FC<StepListProps> = ({
             <Button
               onClick={() => handleMoveUp(index)}
               ariaLabel={`Move up step ${index + 1}`}
-              variant="secondary"
+              variant="outline"
               disabled={index === 0}
               className={styles.actionButton}
             >
@@ -125,7 +125,7 @@ const StepList: FC<StepListProps> = ({
             <Button
               onClick={() => handleMoveDown(index)}
               ariaLabel={`Move down step ${index + 1}`}
-              variant="secondary"
+              variant="outline"
               disabled={index === steps.length - 1}
               className={styles.actionButton}
             >
@@ -134,7 +134,7 @@ const StepList: FC<StepListProps> = ({
             <Button
               onClick={() => handleRemove(index)}
               ariaLabel={`Remove step ${index + 1}`}
-              variant="secondary"
+              variant="outline"
               disabled={steps.length <= 1}
               className={styles.actionButton}
             >
@@ -143,7 +143,7 @@ const StepList: FC<StepListProps> = ({
           </div>
         </div>
       ))}
-      <Button onClick={handleAdd} variant="secondary">
+      <Button onClick={handleAdd} variant="outline">
         Add step
       </Button>
     </div>

--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -1,6 +1,7 @@
 /* Mono chip — tech tag, category, removable, or filter button. */
 
 .tag {
+  composes: focusRing from '../../styles/interactions.module.css';
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
@@ -9,24 +10,32 @@
   font-size: var(--font-size-xs);
   letter-spacing: var(--tracking-meta);
   border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-full);
+  /* Chips/tags/badges → --radius-sm per docs/design/paper/token-migration.md §3a. */
+  border-radius: var(--radius-sm);
   background-color: var(--color-surface);
   color: var(--color-text-muted);
 }
 
 button.tag {
   cursor: pointer;
-  transition: background-color var(--duration-fast) var(--easing-default),
+  transition: border-color var(--duration-fast) var(--easing-default),
               color var(--duration-fast) var(--easing-default);
 }
 
-button.tag:hover {
-  background-color: var(--color-hover);
+/* Mirrors interactions.module.css's chipHover (border-color/color → accent
+   on hover) — can't `composes` it here since composition only applies to a
+   simple single-class selector, and this hover must be scoped to
+   interactive (button) tags only, not static display spans. Guarded against
+   .active so the hover tint doesn't fight the selected-filter fill. */
+button.tag:hover:not(.active) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
-button.tag:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+@media (prefers-reduced-motion: reduce) {
+  button.tag {
+    transition: none;
+  }
 }
 
 .active {
@@ -36,6 +45,7 @@ button.tag:focus-visible {
 }
 
 .remove {
+  composes: focusRing from '../../styles/interactions.module.css';
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -45,9 +55,4 @@ button.tag:focus-visible {
   cursor: pointer;
   padding: 0;
   line-height: 1;
-}
-
-.remove:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
 }

--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -1,0 +1,53 @@
+/* Mono chip — tech tag, category, removable, or filter button. */
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  letter-spacing: var(--tracking-meta);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-full);
+  background-color: var(--color-surface);
+  color: var(--color-text-muted);
+}
+
+button.tag {
+  cursor: pointer;
+  transition: background-color var(--duration-fast) var(--easing-default),
+              color var(--duration-fast) var(--easing-default);
+}
+
+button.tag:hover {
+  background-color: var(--color-hover);
+}
+
+button.tag:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.active {
+  background-color: var(--color-primary);
+  color: var(--color-on-primary);
+  border-color: var(--color-primary);
+}
+
+.remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+.remove:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -49,6 +49,11 @@ button.tag:hover:not(.active) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  /* SC 2.5.8 Target size (minimum) — the glyph alone renders well under
+     24x24 CSS px at --font-size-xs; give the control an explicit minimum
+     hit area. */
+  min-width: 24px;
+  min-height: 24px;
   border: none;
   background: transparent;
   color: inherit;

--- a/src/components/Tag/Tag.test.tsx
+++ b/src/components/Tag/Tag.test.tsx
@@ -1,0 +1,54 @@
+import Tag from '@components/Tag'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+describe('Tag', () => {
+  it('as="button" exposes aria-pressed reflecting `active` and toggles via click', async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+
+    const { rerender } = render(
+      <Tag as="button" active={false} onClick={handleClick}>
+        Italian
+      </Tag>
+    )
+
+    const chip = screen.getByRole('button', { name: 'Italian' })
+    expect(chip).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(chip)
+    expect(handleClick).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <Tag as="button" active={true} onClick={handleClick}>
+        Italian
+      </Tag>
+    )
+    expect(screen.getByRole('button', { name: 'Italian' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('as="span" (default) does not expose a button role or aria-pressed', () => {
+    render(<Tag active>Italian</Tag>)
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+
+    const tag = screen.getByText('Italian')
+    expect(tag).not.toHaveAttribute('aria-pressed')
+  })
+
+  it('removable renders a control with an accessible name that calls onRemove when activated', async () => {
+    const user = userEvent.setup()
+    const handleRemove = vi.fn()
+
+    render(
+      <Tag removable onRemove={handleRemove}>
+        Italian
+      </Tag>
+    )
+
+    const removeControl = screen.getByRole('button', { name: /remove italian/i })
+    await user.click(removeControl)
+
+    expect(handleRemove).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,0 +1,60 @@
+import type { CSSProperties, FC, MouseEvent, ReactNode } from 'react'
+import styles from './Tag.module.css'
+
+export interface TagProps {
+  /** `span` for display, `button` for an interactive filter chip. @default 'span' */
+  as?: 'span' | 'button'
+  /** Selected filter state (accent fill). @default false */
+  active?: boolean
+  /** Adds a remove control (editor tag input). @default false */
+  removable?: boolean
+  onRemove?: (e: MouseEvent) => void
+  onClick?: (e: MouseEvent) => void
+  children?: ReactNode
+  className?: string
+  style?: CSSProperties
+}
+
+const Tag: FC<TagProps> = ({
+  as = 'span',
+  active = false,
+  removable = false,
+  onRemove,
+  onClick,
+  children,
+  className: extraClassName,
+  style,
+}) => {
+  const className = [styles.tag, active && styles.active, extraClassName]
+    .filter(Boolean)
+    .join(' ')
+
+  if (as === 'button') {
+    return (
+      <button
+        type="button"
+        className={className}
+        style={style}
+        aria-pressed={active}
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    )
+  }
+
+  const removeLabel = typeof children === 'string' ? `Remove ${children}` : 'Remove tag'
+
+  return (
+    <span className={className} style={style}>
+      {children}
+      {removable && (
+        <button type="button" className={styles.remove} aria-label={removeLabel} onClick={onRemove}>
+          <span aria-hidden="true">&times;</span>
+        </button>
+      )}
+    </span>
+  )
+}
+
+export default Tag

--- a/src/components/Tag/index.ts
+++ b/src/components/Tag/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Tag'
+export type { TagProps } from './Tag'

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -59,7 +59,7 @@ const TagInput: FC<TagInputProps> = ({
             <Button
               onClick={() => removeTag(i)}
               ariaLabel={`Remove ${tag}`}
-              variant="secondary"
+              variant="outline"
               className={styles.removeBtn}
             >
               &times;

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -3,6 +3,7 @@
 }
 
 .toast {
+  composes: focusRing from '../../styles/interactions.module.css';
   display: flex;
   align-items: center;
   gap: var(--space-3);
@@ -11,20 +12,25 @@
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
-  background: var(--color-surface);
+  /* Design: toast sits on the page background, not the surface tone. */
+  background: var(--color-bg);
   color: var(--color-text);
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
   text-align: left;
   cursor: pointer;
+  transition: border-color var(--duration-fast) var(--easing-default);
 }
 
-.success {
-  color: var(--color-success);
+/* Ported from _helpers.css .ds-toast:hover. */
+.toast:hover {
+  border-color: color-mix(in srgb, var(--color-text-strong) 18%, var(--color-border));
 }
 
-.error {
-  color: var(--color-error);
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    transition: none;
+  }
 }
 
 .message {
@@ -34,6 +40,7 @@
 
 .close {
   opacity: 0;
+  color: var(--color-text-faint);
   transition: opacity var(--duration-fast) var(--easing-default);
 }
 
@@ -42,7 +49,53 @@
   opacity: 1;
 }
 
-.toast:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+@media (prefers-reduced-motion: reduce) {
+  .close {
+    transition: none;
+  }
+}
+
+/* ── Tone indicator ────────────────────────────────────────────
+   The design shows a small tone-tinted glyph circle before the message
+   (see docs/design/paper/design_system/components/feedback/feedback.card.html
+   ".tdot"). Toast.tsx renders no dedicated icon element for it, so this is
+   implemented as generated content on `.toast::before` rather than adding
+   new markup — a deliberate CSS-only tradeoff, flagged in the PR: it's
+   decorative only (the message text + aria-live region remain the source
+   of truth for screen readers), but a future react pass could promote it
+   to a real `aria-hidden` element if that's ever preferred. */
+.toast::before {
+  content: '';
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  /* Design's ".tdot" is 18px; between --space-4 (16px) and --space-5
+     (20px) with no exact token, kept literal. */
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+}
+
+.success::before {
+  content: '✓';
+  background: var(--color-success-bg);
+  color: var(--color-success);
+}
+
+.error::before {
+  content: '✕';
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+/* No dedicated --color-info-bg token exists; --color-hover (the generic
+   subtle wash) stands in for it. */
+.info::before {
+  content: 'ℹ';
+  background: var(--color-hover);
+  color: var(--color-primary);
 }

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -1,11 +1,12 @@
+.item {
+  list-style: none;
+}
+
 .toast {
-  position: fixed;
-  top: var(--space-4);
-  right: var(--space-4);
-  z-index: 50;
   display: flex;
   align-items: center;
   gap: var(--space-3);
+  width: 100%;
   padding: var(--space-3) var(--space-4);
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-lg);
@@ -14,22 +15,34 @@
   color: var(--color-text);
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
-  max-width: 24rem;
+  text-align: left;
+  cursor: pointer;
 }
 
 .success {
-  border-left: 4px solid var(--color-success);
+  color: var(--color-success);
 }
 
 .error {
-  border-left: 4px solid var(--color-error);
+  color: var(--color-error);
 }
 
 .message {
   flex: 1;
+  color: var(--color-text);
 }
 
 .close {
-  padding: var(--space-1) var(--space-2);
-  min-width: auto;
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--easing-default);
+}
+
+.toast:hover .close,
+.toast:focus-visible .close {
+  opacity: 1;
+}
+
+.toast:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -1,66 +1,30 @@
 import Toast from '@components/Toast'
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 describe('Toast', () => {
   let mockOnDismiss = vi.fn()
 
   beforeEach(() => {
     mockOnDismiss = vi.fn()
-    vi.useFakeTimers()
   })
 
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('renders message text', () => {
-    render(<Toast message="Recipe saved" type="success" onDismiss={mockOnDismiss} />)
+  it('renders its message text', () => {
+    render(<Toast tone="success">Recipe saved</Toast>)
 
     expect(screen.getByText('Recipe saved')).toBeInTheDocument()
   })
 
-  it('has role="status" and aria-live="polite"', () => {
-    render(<Toast message="Recipe saved" type="success" onDismiss={mockOnDismiss} />)
-
-    const toast = screen.getByRole('status')
-
-    expect(toast).toBeInTheDocument()
-    expect(toast).toHaveAttribute('aria-live', 'polite')
-  })
-
-  it('calls onDismiss after 5 seconds', () => {
-    render(<Toast message="Recipe saved" type="success" onDismiss={mockOnDismiss} />)
-
-    expect(mockOnDismiss).not.toHaveBeenCalled()
-
-    act(() => {
-      vi.advanceTimersByTime(5000)
-    })
-
-    expect(mockOnDismiss).toHaveBeenCalledTimes(1)
-  })
-
-  it('has a close button that calls onDismiss on click', () => {
-    render(<Toast message="Recipe saved" type="success" onDismiss={mockOnDismiss} />)
-
-    const closeButton = screen.getByRole('button', { name: /close/i })
-
-    fireEvent.click(closeButton)
-
-    expect(mockOnDismiss).toHaveBeenCalledTimes(1)
-  })
-
-  it('auto-dismiss timer is cleared on unmount', () => {
-    const { unmount } = render(
-      <Toast message="Recipe saved" type="success" onDismiss={mockOnDismiss} />
+  it('is a single button so the whole pill is clickable to dismiss', () => {
+    render(
+      <Toast tone="success" onDismiss={mockOnDismiss}>
+        Recipe saved
+      </Toast>
     )
 
-    unmount()
+    const toast = screen.getByRole('button', { name: /recipe saved/i })
 
-    act(() => {
-      vi.advanceTimersByTime(5000)
-    })
+    fireEvent.click(toast)
 
-    expect(mockOnDismiss).not.toHaveBeenCalled()
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -14,7 +14,11 @@ export interface ToastProps {
 
 const Toast: FC<ToastProps> = ({ tone = 'info', children, onDismiss }) => {
   return (
-    <li className={styles.item}>
+    // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
+    // `list-style: none` is applied anywhere in it; role="listitem" (paired
+    // with role="list" on the <ul> in ToastProvider) restores it explicitly.
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+    <li className={styles.item} role="listitem">
       <button
         type="button"
         className={[styles.toast, styles[tone]].filter(Boolean).join(' ')}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,38 +1,31 @@
-import Button from '@components/Button'
-import { useEffect, useRef, type FC } from 'react'
-
+import type { FC, ReactNode } from 'react'
 
 import styles from './Toast.module.css'
 
-export interface ToastState {
-  message: string
-  type: 'success' | 'error'
+export type ToastTone = 'success' | 'error' | 'info'
+
+export interface ToastProps {
+  /** @default 'info' */
+  tone?: ToastTone
+  children?: ReactNode
+  /** Click-anywhere dismiss handler. */
+  onDismiss?: () => void
 }
 
-export interface ToastProps extends ToastState {
-  onDismiss: () => void
-}
-
-const Toast: FC<ToastProps> = ({ message, type, onDismiss }) => {
-  const onDismissRef = useRef(onDismiss)
-  onDismissRef.current = onDismiss
-
-  useEffect(() => {
-    const timer = setTimeout(() => onDismissRef.current(), 5000)
-    return () => clearTimeout(timer)
-  }, [])
-
+const Toast: FC<ToastProps> = ({ tone = 'info', children, onDismiss }) => {
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      className={[styles.toast, styles[type]].join(' ')}
-    >
-      <span className={styles.message}>{message}</span>
-      <Button onClick={onDismiss} ariaLabel="Close" variant="secondary" className={styles.close}>
-        &times;
-      </Button>
-    </div>
+    <li className={styles.item}>
+      <button
+        type="button"
+        className={[styles.toast, styles[tone]].filter(Boolean).join(' ')}
+        onClick={onDismiss}
+      >
+        <span className={styles.message}>{children}</span>
+        <span className={styles.close} aria-hidden="true">
+          &times;
+        </span>
+      </button>
+    </li>
   )
 }
 

--- a/src/components/Toast/index.ts
+++ b/src/components/Toast/index.ts
@@ -1,2 +1,2 @@
 export { default } from './Toast'
-export type { ToastProps, ToastState } from './Toast'
+export type { ToastProps, ToastTone } from './Toast'

--- a/src/contexts/ToastContext/ToastProvider.module.css
+++ b/src/contexts/ToastContext/ToastProvider.module.css
@@ -1,9 +1,9 @@
 .container {
   position: fixed;
-  bottom: var(--space-4);
-  right: var(--space-4);
+  inset-block-end: var(--space-4);
+  inset-inline-end: var(--space-4);
   z-index: var(--z-toast);
-  max-width: 24rem;
+  max-width: min(24rem, calc(100vw - 2 * var(--space-4)));
 }
 
 .list {

--- a/src/contexts/ToastContext/ToastProvider.module.css
+++ b/src/contexts/ToastContext/ToastProvider.module.css
@@ -1,0 +1,15 @@
+.container {
+  position: fixed;
+  bottom: var(--space-4);
+  right: var(--space-4);
+  z-index: var(--z-toast);
+  max-width: 24rem;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+}

--- a/src/contexts/ToastContext/ToastProvider.test.tsx
+++ b/src/contexts/ToastContext/ToastProvider.test.tsx
@@ -1,0 +1,85 @@
+import { ToastProvider, useToast } from '@contexts/ToastContext'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { FC } from 'react'
+
+// A minimal consumer that exercises `showToast` for different tones, so the
+// provider's timer/aria-live behaviour can be driven through real usage
+// rather than reaching into its internals.
+const TestConsumer: FC = () => {
+  const { showToast } = useToast()
+  return (
+    <>
+      <button onClick={() => showToast('Recipe saved', 'success')}>Show success</button>
+      <button onClick={() => showToast('Something broke', 'error')}>Show error</button>
+    </>
+  )
+}
+
+describe('ToastProvider', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('auto-dismisses a toast after ~3.6s', async () => {
+    vi.useFakeTimers()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>
+    )
+
+    await user.click(screen.getByRole('button', { name: /show success/i }))
+    expect(screen.getByText('Recipe saved')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(3600)
+    })
+
+    expect(screen.queryByText('Recipe saved')).not.toBeInTheDocument()
+  })
+
+  it('escalates the live region to aria-live="assertive" when an error toast is present, and is "polite" otherwise', async () => {
+    const user = userEvent.setup()
+
+    // The live region wrapping the toast list has no accessible role/name of
+    // its own (it exists purely for AT announcement, per the PRD's jsdom
+    // testing notes), so there is no semantic role/text query for it —
+    // asserting its `aria-live` attribute directly is the documented
+    // exception.
+    const { container } = render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>
+    )
+    const getLiveRegion = () => container.querySelector('[aria-live]') as HTMLElement
+
+    expect(getLiveRegion()).toHaveAttribute('aria-live', 'polite')
+
+    await user.click(screen.getByRole('button', { name: /show success/i }))
+    expect(getLiveRegion()).toHaveAttribute('aria-live', 'polite')
+
+    await user.click(screen.getByRole('button', { name: /show error/i }))
+    expect(getLiveRegion()).toHaveAttribute('aria-live', 'assertive')
+  })
+
+  it('clicking a toast dismisses it immediately, without waiting for the auto-dismiss timer', async () => {
+    vi.useFakeTimers()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    render(
+      <ToastProvider>
+        <TestConsumer />
+      </ToastProvider>
+    )
+
+    await user.click(screen.getByRole('button', { name: /show success/i }))
+
+    const toast = screen.getByRole('button', { name: /recipe saved/i })
+    await user.click(toast)
+
+    expect(screen.queryByText('Recipe saved')).not.toBeInTheDocument()
+  })
+})

--- a/src/contexts/ToastContext/ToastProvider.tsx
+++ b/src/contexts/ToastContext/ToastProvider.tsx
@@ -1,0 +1,72 @@
+import Toast, { type ToastTone } from '@components/Toast'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FC,
+  type ReactNode,
+} from 'react'
+import { ToastContext } from './context'
+import styles from './ToastProvider.module.css'
+
+interface ToastItem {
+  id: string
+  message: string
+  tone: ToastTone
+}
+
+const AUTO_DISMISS_MS = 3600
+
+export const ToastProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const [toasts, setToasts] = useState<ToastItem[]>([])
+  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>())
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id))
+    const timer = timers.current.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      timers.current.delete(id)
+    }
+  }, [])
+
+  const showToast = useCallback((message: string, tone: ToastTone = 'info') => {
+    const id = crypto.randomUUID()
+    setToasts((current) => [...current, { id, message, tone }])
+    timers.current.set(
+      id,
+      setTimeout(() => dismissToast(id), AUTO_DISMISS_MS)
+    )
+  }, [dismissToast])
+
+  useEffect(() => {
+    const timerMap = timers.current
+    return () => {
+      timerMap.forEach(clearTimeout)
+    }
+  }, [])
+
+  const value = useMemo(() => ({ showToast }), [showToast])
+  const hasError = toasts.some((toast) => toast.tone === 'error')
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        className={styles.container}
+        aria-live={hasError ? 'assertive' : 'polite'}
+        aria-atomic="false"
+      >
+        <ul className={styles.list}>
+          {toasts.map((toast) => (
+            <Toast key={toast.id} tone={toast.tone} onDismiss={() => dismissToast(toast.id)}>
+              {toast.message}
+            </Toast>
+          ))}
+        </ul>
+      </div>
+    </ToastContext.Provider>
+  )
+}

--- a/src/contexts/ToastContext/ToastProvider.tsx
+++ b/src/contexts/ToastContext/ToastProvider.tsx
@@ -59,7 +59,8 @@ export const ToastProvider: FC<{ children: ReactNode }> = ({ children }) => {
         aria-live={hasError ? 'assertive' : 'polite'}
         aria-atomic="false"
       >
-        <ul className={styles.list}>
+        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- Toast's .item sets list-style: none, which drops implicit list semantics in Safari/VoiceOver; role="list" (paired with role="listitem" in Toast) restores it */}
+        <ul className={styles.list} role="list">
           {toasts.map((toast) => (
             <Toast key={toast.id} tone={toast.tone} onDismiss={() => dismissToast(toast.id)}>
               {toast.message}

--- a/src/contexts/ToastContext/context.ts
+++ b/src/contexts/ToastContext/context.ts
@@ -1,0 +1,12 @@
+import type { ToastTone } from '@components/Toast'
+import { createContext, useContext } from 'react'
+
+export interface ToastContextValue {
+  showToast: (message: string, tone?: ToastTone) => void
+}
+
+export const ToastContext = createContext<ToastContextValue>({
+  showToast: () => {},
+})
+
+export const useToast = () => useContext(ToastContext)

--- a/src/contexts/ToastContext/index.ts
+++ b/src/contexts/ToastContext/index.ts
@@ -1,0 +1,2 @@
+export { ToastContext, useToast, type ToastContextValue } from './context'
+export { ToastProvider } from './ToastProvider'

--- a/src/entry-client.tsx
+++ b/src/entry-client.tsx
@@ -1,4 +1,5 @@
 import { AuthProvider } from '@contexts/AuthContext'
+import { ToastProvider } from '@contexts/ToastContext'
 import { StrictMode } from 'react'
 import { hydrateRoot } from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
@@ -12,7 +13,9 @@ hydrateRoot(
   document.getElementById('root')!,
   <StrictMode>
     <AuthProvider>
-      <RouterProvider router={router} />
+      <ToastProvider>
+        <RouterProvider router={router} />
+      </ToastProvider>
     </AuthProvider>
   </StrictMode>
 )

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -11,6 +11,7 @@ import {
 import { AuthProvider } from './contexts/AuthContext'
 import { RecipeDataContext } from './contexts/RecipeDataContext'
 import type { RecipeData } from './contexts/RecipeDataContext'
+import { ToastProvider } from './contexts/ToastContext'
 import { getMetaTags, escapeHtml } from './meta'
 import { routes } from './routes'
 
@@ -102,9 +103,11 @@ export const render = async (url: string, data?: RecipeData): Promise<string> =>
   return new Promise<string>((resolve, reject) => {
     const { pipe } = renderToPipeableStream(
       <AuthProvider>
-        <RecipeDataContext.Provider value={data ?? {}}>
-          <StaticRouterProvider router={router} context={context} />
-        </RecipeDataContext.Provider>
+        <ToastProvider>
+          <RecipeDataContext.Provider value={data ?? {}}>
+            <StaticRouterProvider router={router} context={context} />
+          </RecipeDataContext.Provider>
+        </ToastProvider>
       </AuthProvider>,
       {
         onAllReady() {

--- a/src/pages/Apps/Apps.test.tsx
+++ b/src/pages/Apps/Apps.test.tsx
@@ -1,11 +1,11 @@
-import type { CardProps } from '@components/Card'
+import type { AppCardProps } from '@components/AppCard'
 import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import Apps from './Apps'
 
-vi.mock('@components/Card', () => ({
-  default: ({ title, description, href }: CardProps) => (
+vi.mock('@components/AppCard', () => ({
+  default: ({ title, description, href }: AppCardProps) => (
     <div data-testid="card-mock">
       <h3>{title}</h3>
       <p>{description}</p>

--- a/src/pages/Apps/Apps.tsx
+++ b/src/pages/Apps/Apps.tsx
@@ -1,5 +1,5 @@
-import Card from '@components/Card'
-import type { CardProps } from '@components/Card'
+import AppCard from '@components/AppCard'
+import type { AppCardProps } from '@components/AppCard'
 import Grid from '@components/Grid'
 import SocialCard from '@components/SocialCard'
 import Typography from '@components/Typography'
@@ -10,7 +10,7 @@ import imgSrc from '../../assets/sand-box.webp'
 import imgSrcSet from '../../assets/sand-box.webp?w=320;640;768;1024;1280;1536;1920&format=webp&as=srcset'
 import styles from './Apps.module.css'
 
-const CARDS: CardProps[] = [
+const CARDS: AppCardProps[] = [
   {
     title: 'Pokedex',
     description:
@@ -46,7 +46,7 @@ const Apps: FC = () => {
       </Typography>
       <Grid columns={3}>
         {CARDS.map((card) => (
-          <Card {...card} key={card.href} />
+          <AppCard {...card} key={card.href} />
         ))}
       </Grid>
       <div className={styles.social}>

--- a/src/pages/Blog/Blog.tsx
+++ b/src/pages/Blog/Blog.tsx
@@ -70,7 +70,7 @@ const Blog = () => {
                 {post.tags.map((tag) => (
                   <Button
                     key={tag}
-                    variant="secondary"
+                    variant="outline"
                     className={styles.tag}
                     ariaPressed={activeTag === tag ? 'true' : 'false'}
                     onClick={() => handleTagClick(tag)}

--- a/src/pages/RecipeDetail/RecipeDetail.tsx
+++ b/src/pages/RecipeDetail/RecipeDetail.tsx
@@ -71,7 +71,7 @@ const RecipeDetail: FC = () => {
       <div className={styles.error}>
         <p>Something went wrong loading this recipe.</p>
         <Button
-          variant="secondary"
+          variant="outline"
           onClick={() => {
             setError(undefined)
             setLoading(true)

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -90,7 +90,7 @@ const Recipes: FC = () => {
           <Typography variant="bodyLarge">
             Something went wrong loading recipes.
           </Typography>
-          <Button variant="secondary" onClick={loadData}>
+          <Button variant="outline" onClick={loadData}>
             Retry
           </Button>
         </div>
@@ -133,7 +133,7 @@ const Recipes: FC = () => {
       {filteredRecipes.length === 0 ? (
         <div className={styles.empty}>
           <Typography variant="bodyLarge">No recipes found</Typography>
-          <Button variant="secondary" onClick={handleClearFilters}>
+          <Button variant="outline" onClick={handleClearFilters}>
             Clear filter
           </Button>
         </div>

--- a/src/pages/admin/Login/Login.tsx
+++ b/src/pages/admin/Login/Login.tsx
@@ -1,6 +1,5 @@
 import { completeNewPassword } from '@api/auth'
 import Button from '@components/Button'
-import Loading from '@components/Loading'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
 import type { AuthChallenge } from '@models/auth'
@@ -123,8 +122,8 @@ const Login = () => {
             </p>
           )}
 
-          <Button type="submit" disabled={loading}>
-            {loading ? <Loading size="small" /> : 'Set new password'}
+          <Button type="submit" loading={loading}>
+            Set new password
           </Button>
         </form>
       </div>
@@ -174,8 +173,8 @@ const Login = () => {
           </p>
         )}
 
-        <Button type="submit" disabled={loading}>
-          {loading ? <Loading size="small" /> : 'Log in'}
+        <Button type="submit" loading={loading}>
+          Log in
         </Button>
       </form>
     </div>

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -9,6 +9,7 @@ import {
   updateRecipe,
 } from '@api/recipes'
 import { useAuth } from '@contexts/AuthContext'
+import { ToastProvider } from '@contexts/ToastContext'
 import { useAutosave, type AutosaveStatus, type UseAutosaveResult } from '@hooks/useAutosave'
 import type {
   ImageReadyUpdate,
@@ -252,7 +253,11 @@ const renderEditor = (route = '/admin/recipes/new') => {
     ],
     { initialEntries: [route] }
   )
-  return render(<RouterProvider router={router} />)
+  return render(
+    <ToastProvider>
+      <RouterProvider router={router} />
+    </ToastProvider>
+  )
 }
 
 describe('RecipeEditor page', () => {
@@ -593,8 +598,10 @@ describe('RecipeEditor page', () => {
         )
       })
 
-      // Primary button still reads "Update" — mode did not change.
-      expect(screen.getByRole('button', { name: /update/i })).toBeInTheDocument()
+      // Primary button still reads "Update" — mode did not change. Match the
+      // exact accessible name so this doesn't also match the "Recipe
+      // updated" success toast that appears after the save resolves.
+      expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument()
       expect(screen.queryByRole('button', { name: /^publish$/i })).not.toBeInTheDocument()
     })
   })

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -18,8 +18,8 @@ import Link from '@components/Link'
 import Loading from '@components/Loading'
 import StepList from '@components/StepList'
 import TagInput from '@components/TagInput'
-import Toast from '@components/Toast'
 import { useAuth } from '@contexts/AuthContext'
+import { useToast } from '@contexts/ToastContext'
 import { useAutosave } from '@hooks/useAutosave'
 import {
   useImageProcessingPoll,
@@ -232,6 +232,7 @@ const NEW_PATH = '/admin/recipes/new'
 const RecipeEditor: FC = () => {
   const { id: routeId } = useParams<{ id: string }>()
   const { getAccessToken } = useAuth()
+  const { showToast } = useToast()
   const location = useLocation()
   const navigate = useNavigate()
 
@@ -241,7 +242,6 @@ const RecipeEditor: FC = () => {
   const [existingTags, setExistingTags] = useState<string[]>([])
   const [loading, setLoading] = useState(Boolean(routeId))
   const [submitting, setSubmitting] = useState(false)
-  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null)
   const [announcement, setAnnouncement] = useState({ message: '', toggle: false })
   const [sessionExpired, setSessionExpired] = useState(false)
   const [discardDialogOpen, setDiscardDialogOpen] = useState(false)
@@ -273,8 +273,8 @@ const RecipeEditor: FC = () => {
     if (err instanceof Error && /^409\b/.test(message)) {
       setSlugError(message.replace(/^409\s*/, ''))
     }
-    setToast({ message: fallback ?? `Error: ${message}`, type: 'error' })
-  }, [])
+    showToast(fallback ?? `Error: ${message}`, 'error')
+  }, [showToast])
 
   const blocker = useBlocker(form.dirty)
 
@@ -436,7 +436,7 @@ const RecipeEditor: FC = () => {
       const updated = await publishRecipe(token, form.id)
       dispatch({ type: 'MARK_PRISTINE' })
       dispatch({ type: 'SET_MODE', mode: updated.status })
-      setToast({ message: 'Recipe published', type: 'success' })
+      showToast('Recipe published', 'success')
     } catch (err) {
       handleError(err)
     } finally {
@@ -451,7 +451,7 @@ const RecipeEditor: FC = () => {
       const token = await getAccessToken()
       await updateRecipe(token, form.id, buildPatchPayload(form))
       dispatch({ type: 'MARK_PRISTINE' })
-      setToast({ message: 'Recipe updated', type: 'success' })
+      showToast('Recipe updated', 'success')
     } catch (err) {
       handleError(err)
     } finally {
@@ -469,7 +469,7 @@ const RecipeEditor: FC = () => {
       const token = await getAccessToken()
       const updated = await unpublishRecipe(token, form.id)
       dispatch({ type: 'SET_MODE', mode: updated.status })
-      setToast({ message: 'Recipe unpublished', type: 'success' })
+      showToast('Recipe unpublished', 'success')
     } catch (err) {
       handleError(err)
     } finally {
@@ -493,10 +493,6 @@ const RecipeEditor: FC = () => {
       handleError(err)
     }
   }
-
-  const handleDismissToast = useCallback(() => {
-    setToast(null)
-  }, [])
 
   const setIngredients = useCallback((next: Ingredient[]) => setField('ingredients', next), [setField])
   const setSteps = useCallback((next: Step[]) => setField('steps', next), [setField])
@@ -601,7 +597,7 @@ const RecipeEditor: FC = () => {
               <Button
                 onClick={() => dispatch({ type: 'RESET_SLUG_TO_TITLE' })}
                 type="button"
-                variant="secondary"
+                variant="outline"
               >
                 Reset to title slug
               </Button>
@@ -735,15 +731,16 @@ const RecipeEditor: FC = () => {
               <Button
                 onClick={handlePublish}
                 type="button"
-                disabled={submitting || !canPublish}
+                loading={submitting}
+                disabled={!canPublish}
                 ariaDescribedBy={!canPublish ? MISSING_FIELDS_ID : undefined}
               >
-                {submitting ? <Loading size="small" /> : 'Publish'}
+                Publish
               </Button>
               <Button
                 onClick={() => setDiscardDialogOpen(true)}
                 type="button"
-                variant="secondary"
+                variant="outline"
                 disabled={submitting}
               >
                 Discard draft
@@ -751,13 +748,13 @@ const RecipeEditor: FC = () => {
             </>
           ) : (
             <>
-              <Button onClick={handleUpdate} type="button" disabled={submitting}>
-                {submitting ? <Loading size="small" /> : 'Update'}
+              <Button onClick={handleUpdate} type="button" loading={submitting}>
+                Update
               </Button>
               <Button
                 onClick={handleUnpublish}
                 type="button"
-                variant="secondary"
+                variant="outline"
                 disabled={submitting}
               >
                 Unpublish
@@ -786,29 +783,29 @@ const RecipeEditor: FC = () => {
         {announcement.message && `${announcement.message}${announcement.toggle ? '\u200B' : ''}`}
       </div>
 
-      {toast && (
-        <Toast message={toast.message} type={toast.type} onDismiss={handleDismissToast} />
-      )}
-
       <ConfirmDialog
-        isOpen={blocker.state === 'blocked'}
+        open={blocker.state === 'blocked'}
         title="Unsaved changes"
-        message="Are you sure you want to leave this page? Your edits will be lost."
+        danger
         confirmLabel="Discard changes"
         cancelLabel="Stay on this page"
         onConfirm={() => blocker.proceed?.()}
         onCancel={() => blocker.reset?.()}
-      />
+      >
+        Are you sure you want to leave this page? Your edits will be lost.
+      </ConfirmDialog>
 
       <ConfirmDialog
-        isOpen={discardDialogOpen}
+        open={discardDialogOpen}
         title="Discard draft?"
-        message="This will permanently delete this draft recipe. This action cannot be undone."
+        danger
         confirmLabel="Discard"
         cancelLabel="Cancel"
         onConfirm={handleDiscardConfirm}
         onCancel={() => setDiscardDialogOpen(false)}
-      />
+      >
+        This will permanently delete this draft recipe. This action cannot be undone.
+      </ConfirmDialog>
     </div>
   )
 }

--- a/src/pages/admin/RecipeList/RecipeList.test.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.test.tsx
@@ -1,5 +1,6 @@
 import { deleteRecipe, fetchAllRecipes, publishRecipe, unpublishRecipe } from '@api/recipes'
 import { useAuth } from '@contexts/AuthContext'
+import { ToastProvider } from '@contexts/ToastContext'
 import type { Recipe } from '@models/recipe'
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
@@ -59,7 +60,9 @@ const mockPublishedRecipe: Recipe = {
 const renderRecipeList = () =>
   render(
     <MemoryRouter initialEntries={['/admin/recipes']}>
-      <RecipeList />
+      <ToastProvider>
+        <RecipeList />
+      </ToastProvider>
     </MemoryRouter>
   )
 
@@ -68,7 +71,9 @@ const renderRecipeListWithAccessDenied = () =>
     <MemoryRouter
       initialEntries={[{ pathname: '/admin/recipes', state: { accessDenied: true } }]}
     >
-      <RecipeList />
+      <ToastProvider>
+        <RecipeList />
+      </ToastProvider>
     </MemoryRouter>
   )
 
@@ -225,13 +230,10 @@ describe('Admin RecipeList page', () => {
   it('shows an "Access denied" toast when navigated here with accessDenied state', async () => {
     renderRecipeListWithAccessDenied()
 
-    const toast = await screen.findByText(/access denied/i)
+    // Toasts render as a dismissible button labelled with the message inside
+    // the ToastProvider's aria-live region.
+    const toast = await screen.findByRole('button', { name: /access denied/i })
     expect(toast).toBeInTheDocument()
-
-    // The toast should use role="status" for accessibility (aria-live)
-    const statuses = await screen.findAllByRole('status')
-    const accessDeniedStatus = statuses.find((el) => /access denied/i.test(el.textContent ?? ''))
-    expect(accessDeniedStatus).toBeDefined()
   })
 
   it('calls fetchAllRecipes (not fetchMyRecipes) to load both draft and published recipes', async () => {
@@ -278,7 +280,7 @@ describe('Admin RecipeList page', () => {
     expect(titles).toEqual(['Newest', 'Middle', 'Oldest'])
   })
 
-  it('renders a StatusBadge with matching data-status for each row in a mixed draft/published list', async () => {
+  it('renders a status label matching each row in a mixed draft/published list', async () => {
     renderRecipeList()
 
     await waitFor(() => {
@@ -291,10 +293,7 @@ describe('Admin RecipeList page', () => {
     expect(draftRow).not.toBeNull()
     expect(publishedRow).not.toBeNull()
 
-    const draftBadge = within(draftRow as HTMLElement).getByText(/draft/i)
-    const publishedBadge = within(publishedRow as HTMLElement).getByText(/^published$/i)
-
-    expect(draftBadge).toHaveAttribute('data-status', 'draft')
-    expect(publishedBadge).toHaveAttribute('data-status', 'published')
+    expect(within(draftRow as HTMLElement).getByText(/draft/i)).toBeInTheDocument()
+    expect(within(publishedRow as HTMLElement).getByText(/^published$/i)).toBeInTheDocument()
   })
 })

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -1,5 +1,10 @@
 import { handleSessionError } from '@api/auth'
-import { deleteRecipe, fetchAllRecipes, publishRecipe, unpublishRecipe } from '@api/recipes'
+import {
+  deleteRecipe,
+  fetchAllRecipes,
+  publishRecipe,
+  unpublishRecipe,
+} from '@api/recipes'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
 import Link from '@components/Link'
@@ -25,8 +30,12 @@ const RecipeList = () => {
   const [deleteTarget, setDeleteTarget] = useState<Recipe | null>(null)
 
   const sortedRecipes = useMemo(
-    () => [...recipes].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
-    [recipes],
+    () =>
+      [...recipes].sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      ),
+    [recipes]
   )
 
   useEffect(() => {
@@ -135,37 +144,51 @@ const RecipeList = () => {
               </tr>
             </thead>
             <tbody>
-              {sortedRecipes.map((recipe) => (
-                <tr key={recipe.id}>
-                  <td>{recipe.title}</td>
-                  <td>
-                    <StatusBadge tone={recipe.status === 'published' ? 'success' : 'warning'}>
-                      {recipe.status === 'published' ? 'Published' : 'Draft'}
-                    </StatusBadge>
-                  </td>
-                  <td>{recipe.tags.join(', ')}</td>
-                  <td>{new Date(recipe.updatedAt).toLocaleDateString()}</td>
-                  <td className={styles.actions}>
-                    <div className={styles.actionsInner}>
-                      <Link to={`/admin/recipes/${recipe.id}/edit`} ariaLabel={`Edit ${recipe.title}`}>
-                        Edit
-                      </Link>
-                      <Link
-                        to={`/admin/recipes/${recipe.id}/preview`}
-                        ariaLabel={`Preview ${recipe.title}`}
-                      >
-                        Preview
-                      </Link>
-                      <button type="button" className={styles.actionLink} onClick={() => handlePublish(recipe)}>
-                        {recipe.status === 'published' ? 'Unpublish' : 'Publish'}
-                      </button>
-                      <button type="button" className={styles.actionLink} onClick={() => setDeleteTarget(recipe)}>
-                        Delete
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
+              {sortedRecipes.map((recipe) => {
+                const isPublished = recipe.status === 'published'
+                return (
+                  <tr key={recipe.id}>
+                    <td>{recipe.title}</td>
+                    <td>
+                      <StatusBadge tone={isPublished ? 'success' : 'warning'}>
+                        {isPublished ? 'Published' : 'Draft'}
+                      </StatusBadge>
+                    </td>
+                    <td>{recipe.tags.join(', ')}</td>
+                    <td>{new Date(recipe.updatedAt).toLocaleDateString()}</td>
+                    <td className={styles.actions}>
+                      <div className={styles.actionsInner}>
+                        <Link
+                          to={`/admin/recipes/${recipe.id}/edit`}
+                          ariaLabel={`Edit ${recipe.title}`}
+                        >
+                          Edit
+                        </Link>
+                        <Link
+                          to={`/admin/recipes/${recipe.id}/preview`}
+                          ariaLabel={`Preview ${recipe.title}`}
+                        >
+                          Preview
+                        </Link>
+                        <button
+                          type="button"
+                          className={styles.actionLink}
+                          onClick={() => handlePublish(recipe)}
+                        >
+                          {isPublished ? 'Unpublish' : 'Publish'}
+                        </button>
+                        <button
+                          type="button"
+                          className={styles.actionLink}
+                          onClick={() => setDeleteTarget(recipe)}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
         </div>
@@ -177,17 +200,14 @@ const RecipeList = () => {
           onConfirm={handleDeleteConfirm}
           onCancel={() => setDeleteTarget(null)}
         >
-          Are you sure you want to delete &quot;{deleteTarget?.title ?? ''}&quot;?
+          Are you sure you want to delete &quot;{deleteTarget?.title ?? ''}
+          &quot;?
         </ConfirmDialog>
       </>
     )
   }
 
-  return (
-    <div className={styles.page}>
-      {renderContent()}
-    </div>
-  )
+  return <div className={styles.page}>{renderContent()}</div>
 }
 
 export default RecipeList

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -5,9 +5,9 @@ import ConfirmDialog from '@components/ConfirmDialog'
 import Link from '@components/Link'
 import Loading from '@components/Loading'
 import StatusBadge from '@components/StatusBadge'
-import Toast, { type ToastState } from '@components/Toast'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
+import { useToast } from '@contexts/ToastContext'
 import type { Recipe } from '@models/recipe'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -16,13 +16,13 @@ import styles from './RecipeList.module.css'
 
 const RecipeList = () => {
   const { getAccessToken, logout } = useAuth()
+  const { showToast } = useToast()
   const navigate = useNavigate()
   const location = useLocation()
   const [recipes, setRecipes] = useState<Recipe[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<Recipe | null>(null)
-  const [toast, setToast] = useState<ToastState | null>(null)
 
   const sortedRecipes = useMemo(
     () => [...recipes].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
@@ -32,7 +32,7 @@ const RecipeList = () => {
   useEffect(() => {
     const state = location.state as { accessDenied?: boolean } | null
     if (state?.accessDenied) {
-      setToast({ message: 'Access denied', type: 'error' })
+      showToast('Access denied', 'error')
       navigate(location.pathname, { replace: true, state: null })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -139,7 +139,9 @@ const RecipeList = () => {
                 <tr key={recipe.id}>
                   <td>{recipe.title}</td>
                   <td>
-                    <StatusBadge status={recipe.status} />
+                    <StatusBadge tone={recipe.status === 'published' ? 'success' : 'warning'}>
+                      {recipe.status === 'published' ? 'Published' : 'Draft'}
+                    </StatusBadge>
                   </td>
                   <td>{recipe.tags.join(', ')}</td>
                   <td>{new Date(recipe.updatedAt).toLocaleDateString()}</td>
@@ -170,11 +172,13 @@ const RecipeList = () => {
 
         <ConfirmDialog
           title="Delete recipe"
-          message={`Are you sure you want to delete "${deleteTarget?.title ?? ''}"?`}
-          isOpen={deleteTarget !== null}
+          danger
+          open={deleteTarget !== null}
           onConfirm={handleDeleteConfirm}
           onCancel={() => setDeleteTarget(null)}
-        />
+        >
+          Are you sure you want to delete &quot;{deleteTarget?.title ?? ''}&quot;?
+        </ConfirmDialog>
       </>
     )
   }
@@ -182,9 +186,6 @@ const RecipeList = () => {
   return (
     <div className={styles.page}>
       {renderContent()}
-      {toast && (
-        <Toast message={toast.message} type={toast.type} onDismiss={() => setToast(null)} />
-      )}
     </div>
   )
 }

--- a/src/pages/admin/UserManagement/UserManagement.test.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.test.tsx
@@ -1,5 +1,6 @@
 import { fetchUsers, inviteUser, removeUser, UserExistsError } from '@api/users'
 import { useAuth } from '@contexts/AuthContext'
+import { ToastProvider } from '@contexts/ToastContext'
 import type { AdminUser } from '@models/auth'
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -48,7 +49,9 @@ const pendingUser: AdminUser = {
 const renderUserManagement = () =>
   render(
     <MemoryRouter initialEntries={['/admin/users']}>
-      <UserManagement />
+      <ToastProvider>
+        <UserManagement />
+      </ToastProvider>
     </MemoryRouter>
   )
 
@@ -188,8 +191,8 @@ describe('Admin UserManagement page', () => {
         expect(inviteUser).toHaveBeenCalledWith('token-123', 'new@akli.dev', 'contributor')
       })
 
-      const toast = await screen.findByRole('status')
-      expect(toast).toHaveTextContent(/invite sent to new@akli\.dev/i)
+      const toast = await screen.findByRole('button', { name: /invite sent to new@akli\.dev/i })
+      expect(toast).toBeInTheDocument()
     })
 
     it('shows an inline "User already exists" error when inviteUser rejects with UserExistsError', async () => {
@@ -278,8 +281,8 @@ describe('Admin UserManagement page', () => {
       })
 
       // Success toast
-      const toasts = await screen.findAllByRole('status')
-      expect(toasts.some((t) => /removed|success/i.test(t.textContent ?? ''))).toBe(true)
+      const toast = await screen.findByRole('button', { name: /removed/i })
+      expect(toast).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -3,9 +3,9 @@ import { fetchUsers, inviteUser, removeUser, UserExistsError } from '@api/users'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
 import Loading from '@components/Loading'
-import Toast, { type ToastState } from '@components/Toast'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
+import { useToast } from '@contexts/ToastContext'
 import type { AdminRole, AdminUser } from '@models/auth'
 import { useCallback, useEffect, useId, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -18,6 +18,7 @@ const isValidEmail = (value: string): boolean => EMAIL_PATTERN.test(value.trim()
 
 const UserManagement = () => {
   const { getAccessToken, logout, user: currentUser } = useAuth()
+  const { showToast } = useToast()
   const navigate = useNavigate()
   const emailInputId = useId()
   const roleInputId = useId()
@@ -26,7 +27,6 @@ const UserManagement = () => {
   const [users, setUsers] = useState<AdminUser[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
-  const [toast, setToast] = useState<ToastState | null>(null)
 
   const [inviteFormOpen, setInviteFormOpen] = useState(false)
   const [inviteEmail, setInviteEmail] = useState('')
@@ -74,7 +74,7 @@ const UserManagement = () => {
       const token = await getAccessToken()
       await inviteUser(token, trimmedEmail, inviteRole)
       resetInviteForm()
-      setToast({ message: `Invite sent to ${trimmedEmail}`, type: 'success' })
+      showToast(`Invite sent to ${trimmedEmail}`, 'success')
       await loadUsers()
     } catch (err) {
       if (err instanceof UserExistsError) {
@@ -94,11 +94,11 @@ const UserManagement = () => {
     try {
       const token = await getAccessToken()
       await removeUser(token, target.userId)
-      setToast({ message: `User ${target.email} removed`, type: 'success' })
+      showToast(`User ${target.email} removed`, 'success')
       await loadUsers()
     } catch (err) {
       if (!handleSessionError(err, logout, navigate)) {
-        setToast({ message: 'Failed to remove user', type: 'error' })
+        showToast('Failed to remove user', 'error')
       }
     }
   }
@@ -176,7 +176,7 @@ const UserManagement = () => {
             </div>
 
             <div className={styles.formActions}>
-              <Button onClick={resetInviteForm} variant="secondary">
+              <Button onClick={resetInviteForm} variant="outline">
                 Cancel
               </Button>
               <Button type="submit" disabled={submitDisabled}>
@@ -216,7 +216,7 @@ const UserManagement = () => {
                       {!isSelf && (
                         <Button
                           onClick={() => setRemoveTarget(userRow)}
-                          variant="secondary"
+                          variant="outline"
                           ariaLabel={`Remove ${userRow.email}`}
                         >
                           Remove
@@ -232,16 +232,15 @@ const UserManagement = () => {
 
         <ConfirmDialog
           title="Remove user"
-          message={
-            removeTarget
-              ? `Are you sure you want to remove ${removeTarget.email}? They will lose access immediately.`
-              : ''
-          }
-          isOpen={removeTarget !== null}
+          danger
+          open={removeTarget !== null}
           onConfirm={handleRemoveConfirm}
           onCancel={() => setRemoveTarget(null)}
           confirmLabel="Confirm"
-        />
+        >
+          {removeTarget &&
+            `Are you sure you want to remove ${removeTarget.email}? They will lose access immediately.`}
+        </ConfirmDialog>
       </>
     )
   }
@@ -249,9 +248,6 @@ const UserManagement = () => {
   return (
     <div className={styles.page}>
       {renderContent()}
-      {toast && (
-        <Toast message={toast.message} type={toast.type} onDismiss={() => setToast(null)} />
-      )}
     </div>
   )
 }

--- a/src/styles/interactions.module.css
+++ b/src/styles/interactions.module.css
@@ -151,8 +151,12 @@
      literal per _helpers.css spec. */
   border: 3px solid var(--color-border);
   border-top-color: var(--color-primary);
-  /* 0.7s not in the duration token scale; kept literal per _helpers.css spec. */
-  animation: spin 0.7s linear infinite;
+  /* 0.7s not in the duration token scale; kept literal per _helpers.css spec.
+     `global(...)` is required — without it, Vite's CSS Modules transform
+     scopes the `spin` identifier to a hashed local name with no matching
+     @keyframes, silently no-op'ing the animation (spin lives, unscoped, in
+     the plain src/styles/animations.css file, not a .module.css). */
+  animation: global(spin) 0.7s linear infinite;
 }
 
 .spinnerSm {
@@ -176,8 +180,9 @@
     var(--color-surface) 70%
   );
   background-size: 200% 100%;
-  /* 1.3s not in the duration token scale; kept literal per _helpers.css spec. */
-  animation: shimmerSweep 1.3s linear infinite;
+  /* 1.3s not in the duration token scale; kept literal per _helpers.css spec.
+     `global(...)` required — see the .spinner comment above. */
+  animation: global(shimmerSweep) 1.3s linear infinite;
 }
 
 /* ── Reduced motion ────────────────────────────────────────────

--- a/tests/renderWithProviders.tsx
+++ b/tests/renderWithProviders.tsx
@@ -1,4 +1,5 @@
 import { AuthProvider } from '@contexts/AuthContext'
+import { ToastProvider } from '@contexts/ToastContext'
 import { render, type RenderOptions } from '@testing-library/react'
 import type { ReactElement, ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
@@ -23,7 +24,11 @@ export const renderWithProviders = (
 ) =>
   render(ui, {
     wrapper: ({ children }: { children: ReactNode }) => {
-      const routed = <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+      const routed = (
+        <MemoryRouter initialEntries={initialEntries}>
+          <ToastProvider>{children}</ToastProvider>
+        </MemoryRouter>
+      )
       return withAuth ? <AuthProvider>{routed}</AuthProvider> : routed
     },
     ...renderOptions,


### PR DESCRIPTION
Closes #223

## What changed

Rebuilds the shared **core** (Button, Card, Link, Tag, StatusBadge), **feedback** (Toast/ToastProvider, Callout, Loading, ProcessingPlaceholder, AutosaveStatus), and **overlay** (ConfirmDialog) primitives against the `docs/design/paper/` design system, in both light and dark themes.

Highlights:
- **Button**: `variant: solid|outline|danger`, `shape: rounded|pill`, `size: sm|md`, `loading`, `iconLeft`/`iconRight`, `fullWidth` — matches the design system's `Button.d.ts` contract. All ~9 existing call sites migrated from the old `primary`/`secondary` variant names.
- **Card split**: the old `Card` was actually an app-card (title/description/href/image) — renamed to `AppCard`, and a real generic `Card` container was built per the design contract (currently unconsumed; wiring it into pages is sequenced into later page-rebuild issues per the PRD).
- **Tag**: new component — chip/filter, `as="span"|"button"`, `active`→`aria-pressed`, `removable`.
- **Toast → ToastProvider**: introduced a shared context so there's exactly one `aria-live` region in the DOM (escalates to `assertive` when an error toast is present), auto-dismiss at 3.6s, whole-pill click-to-dismiss via a real `<button>`. `RecipeList`/`UserManagement`/`RecipeEditor` migrated from local toast state to `useToast()`.
- **ConfirmDialog**: converted to native `<dialog>` + `showModal()` — initial focus on open, native focus-trap, Escape via the `cancel` event, scrim-click close, and focus-restore to the triggering element. `danger` variant wired at all 4 destructive call sites (Delete/Remove/Discard/Leave).
- Every touched interactive element composes the shared `focusRing` utility from `src/styles/interactions.module.css` for consistent `:focus-visible`/forced-colors/reduced-motion coverage.

## Why

Part of the "akli.dev Warm Editorial Paper Redesign" epic (#232) — issue #223 is the shared-primitives slice of the PRD's stated sequencing (tokens/fonts → **primitives** → public pages → admin pages).

## How to verify

- `pnpm test` — 669/669 passing
- `pnpm exec eslint .` — clean
- `pnpm --package=typescript dlx tsc --noEmit` — clean
- Manually: run `pnpm dev`, exercise the Delete confirm dialog on `/admin/recipes` (keyboard-only: Tab into the dialog, Escape to cancel, click the scrim to cancel) and trigger a publish/unpublish toast to see the new pill styling and 3.6s auto-dismiss, in both themes.

## Decisions made

- **Button variant rename** (`primary/secondary` → `solid/outline/danger`) — matches the design system contract; all call sites updated.
- **Card/AppCard split** — resolves a naming collision between the existing app-card component and the design's generic `Card` container; not gratuitous churn.
- **`StatusBadge`** dropped its old `sr-only "Status:"` prefix now that it's a generic primitive — verified its only current call site (`RecipeList`'s admin table) still has an unambiguous accessible name via the `<th>Status</th>` column header; flagged as a watch-item for the future admin-table-to-list-rows redesign issue.
- **`Toast`/`ToastProvider` `role="list"`/`role="listitem"`** — Safari/VoiceOver drops implicit list semantics once `list-style: none` is applied; restored explicitly with an `eslint-disable` justification comment (real fix, not `no-redundant-roles` noise).

## Out of scope (filed as follow-up issues)

- **#239** — Restore list/listitem ARIA roles on list-style:none lists. Six other components (`TagInput`, `FileTree`, `RecipeIngredients`, `FileMeta`, `SocialCard`, `Grid`, `Blog`) share the same Safari/VoiceOver `list-style: none` bug that Toast fixed in this PR, but touching them was well outside this issue's shared-primitives scope.

Also explicitly deferred, not filed as issues (already covered by later milestone issues per the PRD's stated sequencing):
- `Tag` isn't yet wired into `RecipeTagFilter`/`TagInput`/Blog tag chips.
- `Card` has no consumers yet.
- `AppCard`'s hover-nudge icon and the `AppCard`/`RecipeCard` duplicated `.imageWrapper` block — `RecipeCard` itself hasn't been migrated off the old neo-brutalist styling yet; that consolidation naturally belongs to the "Rebuild Recipes + Recipe" page issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)