### PR TITLE
Rebuild Recipes + Recipe + shared RecipeView

### DIFF
--- a/src/components/Input/Input.module.css
+++ b/src/components/Input/Input.module.css
@@ -14,11 +14,22 @@
   font-family: var(--font-sans);
   font-size: var(--font-size-md);
   color: var(--color-text-strong);
-  background-color: var(--color-field);
+  /* --input-bg/-radius let a consumer re-theme a specific field (e.g.
+     RecipeSearch's surface-tinted pill) by setting custom properties on
+     an ancestor — they inherit through this wrapper's own internal .field
+     element, so there's no specificity fight with a consumer's own
+     className the way two same-specificity classes on this element would
+     have (whichever landed later in the compiled stylesheet would win). */
+  background-color: var(--input-bg, var(--color-field));
   border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
+  border-radius: var(--input-radius, var(--radius-md));
   padding: var(--space-3);
-  transition: border-color var(--duration-fast) var(--easing-default);
+  transition: border-color var(--duration-fast) var(--easing-default),
+              background-color var(--duration-fast) var(--easing-default);
+}
+
+.field:focus-visible {
+  background-color: var(--input-bg-focus, var(--input-bg, var(--color-field)));
 }
 
 .field:disabled {

--- a/src/components/RecipeDetailView/RecipeDetailView.test.tsx
+++ b/src/components/RecipeDetailView/RecipeDetailView.test.tsx
@@ -2,6 +2,7 @@ import type { Recipe } from '@models/recipe'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
+import { axe } from 'vitest-axe'
 import RecipeDetailView from './RecipeDetailView'
 
 const baseRecipe: Recipe = {
@@ -58,5 +59,12 @@ describe('RecipeDetailView', () => {
 
     expect(screen.getByText(/processing image/i)).toBeInTheDocument()
     expect(screen.queryByRole('img', { name: 'Test cover' })).not.toBeInTheDocument()
+  })
+
+  describe('accessibility', () => {
+    it('renders the default recipe detail view with no detectable axe violations', async () => {
+      const { container } = renderView(baseRecipe)
+      expect(await axe(container)).toHaveNoViolations()
+    })
   })
 })

--- a/src/components/RecipeDetailView/RecipeDetailView.tsx
+++ b/src/components/RecipeDetailView/RecipeDetailView.tsx
@@ -58,7 +58,7 @@ const RecipeDetailView: FC<RecipeDetailViewProps> = ({ recipe }) => (
 
     <section className={styles.section}>
       <Typography variant="heading2" className={styles.sectionHeading}>Ingredients</Typography>
-      <RecipeIngredients ingredients={recipe.ingredients} />
+      <RecipeIngredients ingredients={recipe.ingredients} slug={recipe.slug} />
     </section>
 
     <section className={styles.section}>

--- a/src/components/RecipeIngredients/RecipeIngredients.module.css
+++ b/src/components/RecipeIngredients/RecipeIngredients.module.css
@@ -12,6 +12,19 @@
   border-bottom: 1px solid var(--color-border);
 }
 
+.label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+
+.checkbox {
+  width: var(--space-4);
+  height: var(--space-4);
+  accent-color: var(--color-primary);
+}
+
 .quantity {
   font-weight: var(--font-weight-bold);
 }

--- a/src/components/RecipeIngredients/RecipeIngredients.test.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.test.tsx
@@ -105,4 +105,22 @@ describe('RecipeIngredients checkboxes', () => {
       localStorage.getItem('recipe-ingredients:thai-green-curry')
     ).toBeNull()
   })
+
+  it('does not bleed checked state when the slug prop changes on the same instance (client-side navigation, no unmount)', () => {
+    const { rerender } = render(
+      <RecipeIngredients ingredients={mockIngredients} slug="spaghetti-bolognese" />
+    )
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '200 g flour' }))
+    expect(screen.getByRole('checkbox', { name: '200 g flour' })).toBeChecked()
+
+    // Same component instance, no unmount — mirrors React Router reusing
+    // the <RecipeDetail> route element when navigating between recipes.
+    rerender(<RecipeIngredients ingredients={mockIngredients} slug="thai-green-curry" />)
+
+    expect(screen.getByRole('checkbox', { name: '200 g flour' })).not.toBeChecked()
+    expect(
+      localStorage.getItem('recipe-ingredients:thai-green-curry')
+    ).toBeNull()
+  })
 })

--- a/src/components/RecipeIngredients/RecipeIngredients.test.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.test.tsx
@@ -1,6 +1,6 @@
 import type { Ingredient } from '@models/recipe'
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import RecipeIngredients from './RecipeIngredients'
 
 const mockIngredients: Ingredient[] = [
@@ -26,5 +26,83 @@ describe('RecipeIngredients', () => {
     expect(screen.getByText('200 g flour')).toBeInTheDocument()
     expect(screen.getByText('100 g sugar')).toBeInTheDocument()
     expect(screen.getByText('50 g butter')).toBeInTheDocument()
+  })
+})
+
+// Checked state is persisted to localStorage under the key
+// `recipe-ingredients:${slug}`, whose value is a JSON array of checked
+// ingredient keys. Each ingredient key matches the list's existing React key
+// scheme (`${item}-${idx}`) so the same identifier can be reused for both
+// the DOM key and the persistence key.
+describe('RecipeIngredients checkboxes', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it('renders each ingredient as a checkbox with an accessible name derived from its text', () => {
+    render(<RecipeIngredients ingredients={mockIngredients} slug="spaghetti-bolognese" />)
+
+    expect(screen.getByRole('checkbox', { name: '200 g flour' })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: '100 g sugar' })).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: '50 g butter' })).toBeInTheDocument()
+  })
+
+  it('starts unchecked and toggles checked state on click', () => {
+    render(<RecipeIngredients ingredients={mockIngredients} slug="spaghetti-bolognese" />)
+
+    const flourCheckbox = screen.getByRole('checkbox', { name: '200 g flour' })
+    expect(flourCheckbox).not.toBeChecked()
+
+    fireEvent.click(flourCheckbox)
+    expect(flourCheckbox).toBeChecked()
+
+    fireEvent.click(flourCheckbox)
+    expect(flourCheckbox).not.toBeChecked()
+  })
+
+  it('persists checked state to localStorage keyed by the recipe slug', () => {
+    render(<RecipeIngredients ingredients={mockIngredients} slug="spaghetti-bolognese" />)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '200 g flour' }))
+
+    const stored = localStorage.getItem('recipe-ingredients:spaghetti-bolognese')
+    expect(stored).not.toBeNull()
+    expect(JSON.parse(stored as string)).toContain('flour-0')
+  })
+
+  it('restores checked state from localStorage when remounted with the same slug', () => {
+    const { unmount } = render(
+      <RecipeIngredients ingredients={mockIngredients} slug="spaghetti-bolognese" />
+    )
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '200 g flour' }))
+    unmount()
+
+    render(<RecipeIngredients ingredients={mockIngredients} slug="spaghetti-bolognese" />)
+
+    expect(screen.getByRole('checkbox', { name: '200 g flour' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '100 g sugar' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: '50 g butter' })).not.toBeChecked()
+  })
+
+  it('does not bleed checked state between different recipes', () => {
+    const { unmount } = render(
+      <RecipeIngredients ingredients={mockIngredients} slug="spaghetti-bolognese" />
+    )
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '200 g flour' }))
+    unmount()
+
+    render(<RecipeIngredients ingredients={mockIngredients} slug="thai-green-curry" />)
+
+    expect(screen.getByRole('checkbox', { name: '200 g flour' })).not.toBeChecked()
+    expect(
+      localStorage.getItem('recipe-ingredients:thai-green-curry')
+    ).toBeNull()
   })
 })

--- a/src/components/RecipeIngredients/RecipeIngredients.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.tsx
@@ -1,5 +1,5 @@
 import type { Ingredient } from '@models/recipe'
-import type { FC } from 'react'
+import { useState, type FC } from 'react'
 import styles from './RecipeIngredients.module.css'
 
 export interface RecipeIngredientsProps {
@@ -7,20 +7,74 @@ export interface RecipeIngredientsProps {
   /**
    * Recipe identity used to key per-recipe checked-state persistence in
    * localStorage (mirrors the `slug` prop on the sibling `RecipeSteps`
-   * component). Optional stub for now — checkbox/localStorage behavior is
-   * implemented separately.
+   * component).
    */
   slug?: string
 }
 
-const RecipeIngredients: FC<RecipeIngredientsProps> = ({ ingredients }) => (
-  <ul className={styles.list}>
-    {ingredients.map((ingredient, idx) => (
-      <li key={`${ingredient.item}-${idx}`} className={styles.item}>
-        {ingredient.quantity} {ingredient.unit} {ingredient.item}
-      </li>
-    ))}
-  </ul>
-)
+const storageKey = (slug: string): string => `recipe-ingredients:${slug}`
+
+const loadChecked = (slug?: string): Set<string> => {
+  if (!slug) return new Set()
+  try {
+    const raw = localStorage.getItem(storageKey(slug))
+    const parsed: unknown = raw ? JSON.parse(raw) : []
+    return new Set(Array.isArray(parsed) ? (parsed as string[]) : [])
+  } catch {
+    return new Set()
+  }
+}
+
+const RecipeIngredients: FC<RecipeIngredientsProps> = ({ ingredients, slug }) => {
+  const [loadedSlug, setLoadedSlug] = useState(slug)
+  const [checked, setChecked] = useState<Set<string>>(() => loadChecked(slug))
+
+  // Re-derive checked state from localStorage when `slug` changes on an
+  // already-mounted instance (e.g. client-side navigation between recipes
+  // that reuses the same <RecipeIngredients> element rather than
+  // unmounting it). Adjusting state during render — rather than in a
+  // useEffect — avoids a stale frame where the previous recipe's checked
+  // items would flash before being reset.
+  if (slug !== loadedSlug) {
+    setLoadedSlug(slug)
+    setChecked(loadChecked(slug))
+  }
+
+  const toggle = (key: string): void => {
+    setChecked((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      if (slug) {
+        localStorage.setItem(storageKey(slug), JSON.stringify(Array.from(next)))
+      }
+      return next
+    })
+  }
+
+  return (
+    <ul className={styles.list}>
+      {ingredients.map((ingredient, idx) => {
+        const key = `${ingredient.item}-${idx}`
+        return (
+          <li key={key} className={styles.item}>
+            <label className={styles.label}>
+              <input
+                type="checkbox"
+                className={styles.checkbox}
+                checked={checked.has(key)}
+                onChange={() => toggle(key)}
+              />
+              {ingredient.quantity} {ingredient.unit} {ingredient.item}
+            </label>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
 
 export default RecipeIngredients

--- a/src/components/RecipeIngredients/RecipeIngredients.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.tsx
@@ -41,18 +41,16 @@ const RecipeIngredients: FC<RecipeIngredientsProps> = ({ ingredients, slug }) =>
   }
 
   const toggle = (key: string): void => {
-    setChecked((prev) => {
-      const next = new Set(prev)
-      if (next.has(key)) {
-        next.delete(key)
-      } else {
-        next.add(key)
-      }
-      if (slug) {
-        localStorage.setItem(storageKey(slug), JSON.stringify(Array.from(next)))
-      }
-      return next
-    })
+    const next = new Set(checked)
+    if (next.has(key)) {
+      next.delete(key)
+    } else {
+      next.add(key)
+    }
+    setChecked(next)
+    if (slug) {
+      localStorage.setItem(storageKey(slug), JSON.stringify(Array.from(next)))
+    }
   }
 
   return (

--- a/src/components/RecipeIngredients/RecipeIngredients.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.tsx
@@ -4,6 +4,13 @@ import styles from './RecipeIngredients.module.css'
 
 export interface RecipeIngredientsProps {
   ingredients: Ingredient[]
+  /**
+   * Recipe identity used to key per-recipe checked-state persistence in
+   * localStorage (mirrors the `slug` prop on the sibling `RecipeSteps`
+   * component). Optional stub for now — checkbox/localStorage behavior is
+   * implemented separately.
+   */
+  slug?: string
 }
 
 const RecipeIngredients: FC<RecipeIngredientsProps> = ({ ingredients }) => (

--- a/src/components/RecipeSearch/RecipeSearch.module.css
+++ b/src/components/RecipeSearch/RecipeSearch.module.css
@@ -3,11 +3,15 @@
   margin-block-end: var(--space-6);
 }
 
-.input {
+/* Descendant selector (not a bare `.input` class rule) deliberately raises
+   specificity above Input's own `.field` — `.input` alone ties with `.field`
+   (both single-class selectors), leaving the winner dependent on stylesheet
+   load order rather than this override. */
+.wrapper .input {
   border-radius: var(--radius-full);
 }
 
-.input::-webkit-search-cancel-button {
+.wrapper .input::-webkit-search-cancel-button {
   display: none;
 }
 

--- a/src/components/RecipeSearch/RecipeSearch.module.css
+++ b/src/components/RecipeSearch/RecipeSearch.module.css
@@ -1,24 +1,39 @@
 .wrapper {
+  max-width: 420px;
   margin-block-end: var(--space-6);
 }
 
 .input {
-  width: 100%;
-  padding: var(--space-3) var(--space-4);
-  font-size: var(--font-size-base);
-  font-family: var(--font-sans);
-  color: var(--color-text);
-  background: var(--color-surface);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
+  border-radius: var(--radius-full);
 }
 
-.input::placeholder {
+.input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.clearButton {
+  composes: focusRing from '../../styles/interactions.module.css';
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: transparent;
   color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--easing-default),
+              background var(--duration-fast) var(--easing-default);
 }
 
-.input:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-  outline-offset: 2px;
+.clearButton:hover {
+  color: var(--color-primary);
+  background: var(--color-hover);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .clearButton {
+    transition: none;
+  }
 }

--- a/src/components/RecipeSearch/RecipeSearch.module.css
+++ b/src/components/RecipeSearch/RecipeSearch.module.css
@@ -9,10 +9,26 @@
    load order rather than this override. */
 .wrapper .input {
   border-radius: var(--radius-full);
+  /* Input's own .field defaults to --color-field (white) — this search
+     box instead matches the design's own surface/bg swap: a tinted
+     surface at rest, lightening to the page background on focus. */
+  background-color: var(--color-surface);
+  transition: border-color var(--duration-fast) var(--easing-default),
+              background-color var(--duration-fast) var(--easing-default);
+}
+
+.wrapper .input:focus-visible {
+  background-color: var(--color-bg);
 }
 
 .wrapper .input::-webkit-search-cancel-button {
   display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wrapper .input {
+    transition: none;
+  }
 }
 
 .clearButton {

--- a/src/components/RecipeSearch/RecipeSearch.module.css
+++ b/src/components/RecipeSearch/RecipeSearch.module.css
@@ -1,34 +1,17 @@
 .wrapper {
   max-width: 420px;
   margin-block-end: var(--space-6);
-}
-
-/* Descendant selector (not a bare `.input` class rule) deliberately raises
-   specificity above Input's own `.field` — `.input` alone ties with `.field`
-   (both single-class selectors), leaving the winner dependent on stylesheet
-   load order rather than this override. */
-.wrapper .input {
-  border-radius: var(--radius-full);
   /* Input's own .field defaults to --color-field (white) — this search
      box instead matches the design's own surface/bg swap: a tinted
-     surface at rest, lightening to the page background on focus. */
-  background-color: var(--color-surface);
-  transition: border-color var(--duration-fast) var(--easing-default),
-              background-color var(--duration-fast) var(--easing-default);
+     surface at rest, lightening to the page background on focus. These
+     inherit down to Input's internal .field element (see Input.module.css). */
+  --input-bg: var(--color-surface);
+  --input-bg-focus: var(--color-bg);
+  --input-radius: var(--radius-full);
 }
 
-.wrapper .input:focus-visible {
-  background-color: var(--color-bg);
-}
-
-.wrapper .input::-webkit-search-cancel-button {
+.input::-webkit-search-cancel-button {
   display: none;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .wrapper .input {
-    transition: none;
-  }
 }
 
 .clearButton {

--- a/src/components/RecipeSearch/RecipeSearch.test.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.test.tsx
@@ -1,6 +1,12 @@
 import { render, screen, fireEvent, act } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import RecipeSearch from './RecipeSearch'
+
+const LocationDisplay = () => {
+  const location = useLocation()
+  return <div data-testid="location">{location.pathname}{location.search}</div>
+}
 
 describe('RecipeSearch', () => {
   beforeEach(() => {
@@ -46,5 +52,47 @@ describe('RecipeSearch', () => {
     })
 
     expect(onSearch).not.toHaveBeenCalled()
+  })
+})
+
+describe('RecipeSearch form semantics', () => {
+  it('renders the search input inside a form with role="search"', () => {
+    render(<RecipeSearch value="" onSearch={vi.fn()} />)
+
+    const form = screen.getByRole('search')
+    const input = screen.getByRole('searchbox', { name: /search recipes/i })
+
+    expect(form).toBeInTheDocument()
+    expect(form.tagName).toBe('FORM')
+    expect(form).toContainElement(input)
+  })
+
+  it('does not change the URL when typing in the search box', () => {
+    render(
+      <MemoryRouter initialEntries={['/recipes']}>
+        <RecipeSearch value="" onSearch={vi.fn()} />
+        <LocationDisplay />
+      </MemoryRouter>
+    )
+
+    const input = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(input, { target: { value: 'pizza' } })
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/recipes')
+    expect(screen.getByTestId('location').textContent).not.toMatch(/[?&](q|query|search)=/)
+  })
+
+  it('does not change the URL when the form is submitted', () => {
+    render(
+      <MemoryRouter initialEntries={['/recipes']}>
+        <RecipeSearch value="pasta" onSearch={vi.fn()} />
+        <LocationDisplay />
+      </MemoryRouter>
+    )
+
+    fireEvent.submit(screen.getByRole('search'))
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/recipes')
+    expect(screen.getByTestId('location').textContent).not.toMatch(/[?&](q|query|search)=/)
   })
 })

--- a/src/components/RecipeSearch/RecipeSearch.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.tsx
@@ -1,3 +1,4 @@
+import Input from '@components/Input'
 import { useState, useEffect, type FC } from 'react'
 import styles from './RecipeSearch.module.css'
 
@@ -5,6 +6,21 @@ export interface RecipeSearchProps {
   value: string
   onSearch: (query: string) => void
 }
+
+const SearchIcon: FC = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+  >
+    <circle cx="11" cy="11" r="7" />
+    <line x1="21" y1="21" x2="16.5" y2="16.5" />
+  </svg>
+)
 
 const RecipeSearch: FC<RecipeSearchProps> = ({ value: controlledValue, onSearch }) => {
   const [value, setValue] = useState(controlledValue)
@@ -23,13 +39,28 @@ const RecipeSearch: FC<RecipeSearchProps> = ({ value: controlledValue, onSearch 
 
   return (
     <form className={styles.wrapper} role="search" onSubmit={(e) => e.preventDefault()}>
-      <input
+      <Input
         type="search"
-        aria-label="Search recipes"
-        placeholder="Search recipes..."
+        ariaLabel="Search recipes"
+        placeholder="Search recipes…"
         value={value}
         onChange={(e) => setValue(e.target.value)}
         className={styles.input}
+        prefixIcon={<SearchIcon />}
+        suffix={
+          value
+            ? (
+              <button
+                type="button"
+                className={styles.clearButton}
+                aria-label="Clear search"
+                onClick={() => setValue('')}
+              >
+                <span aria-hidden="true">✕</span>
+              </button>
+            )
+            : undefined
+        }
       />
     </form>
   )

--- a/src/components/RecipeSearch/RecipeSearch.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.tsx
@@ -22,7 +22,7 @@ const RecipeSearch: FC<RecipeSearchProps> = ({ value: controlledValue, onSearch 
   }, [value, onSearch])
 
   return (
-    <div className={styles.wrapper}>
+    <form className={styles.wrapper} role="search" onSubmit={(e) => e.preventDefault()}>
       <input
         type="search"
         aria-label="Search recipes"
@@ -31,7 +31,7 @@ const RecipeSearch: FC<RecipeSearchProps> = ({ value: controlledValue, onSearch 
         onChange={(e) => setValue(e.target.value)}
         className={styles.input}
       />
-    </div>
+    </form>
   )
 }
 

--- a/src/components/RecipeSearch/RecipeSearch.tsx
+++ b/src/components/RecipeSearch/RecipeSearch.tsx
@@ -7,7 +7,7 @@ export interface RecipeSearchProps {
   onSearch: (query: string) => void
 }
 
-const SearchIcon: FC = () => (
+const searchIcon = (
   <svg
     width="16"
     height="16"
@@ -46,20 +46,18 @@ const RecipeSearch: FC<RecipeSearchProps> = ({ value: controlledValue, onSearch 
         value={value}
         onChange={(e) => setValue(e.target.value)}
         className={styles.input}
-        prefixIcon={<SearchIcon />}
+        prefixIcon={searchIcon}
         suffix={
-          value
-            ? (
-              <button
-                type="button"
-                className={styles.clearButton}
-                aria-label="Clear search"
-                onClick={() => setValue('')}
-              >
-                <span aria-hidden="true">✕</span>
-              </button>
-            )
-            : undefined
+          value && (
+            <button
+              type="button"
+              className={styles.clearButton}
+              aria-label="Clear search"
+              onClick={() => setValue('')}
+            >
+              <span aria-hidden="true">✕</span>
+            </button>
+          )
         }
       />
     </form>

--- a/src/components/RecipeTagFilter/RecipeTagFilter.module.css
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.module.css
@@ -4,21 +4,3 @@
   gap: var(--space-2);
   margin-block-end: var(--space-6);
 }
-
-.tag {
-  padding: var(--space-1) var(--space-2);
-  font-size: var(--font-size-sm);
-  font-family: var(--font-mono);
-  font-weight: var(--font-weight-normal);
-}
-
-.tag:hover {
-  background: var(--color-primary);
-  color: var(--color-on-primary);
-}
-
-.tag[aria-pressed='true'] {
-  background: var(--color-primary);
-  color: var(--color-on-primary);
-  font-weight: var(--font-weight-bold);
-}

--- a/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
@@ -1,5 +1,5 @@
 import type { Tag } from '@models/recipe'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import RecipeTagFilter from './RecipeTagFilter'
 
@@ -12,7 +12,7 @@ const mockTags: Tag[] = [
 describe('RecipeTagFilter', () => {
   it('renders tag buttons with counts', () => {
     render(
-      <RecipeTagFilter tags={mockTags} activeTag={null} onTagClick={vi.fn()} />
+      <RecipeTagFilter tags={mockTags} activeTag={null} onTagClick={vi.fn()} onClear={vi.fn()} />
     )
 
     expect(screen.getByRole('button', { name: /Italian/i })).toBeInTheDocument()
@@ -26,7 +26,7 @@ describe('RecipeTagFilter', () => {
 
   it('active tag has aria-pressed="true"', () => {
     render(
-      <RecipeTagFilter tags={mockTags} activeTag="Italian" onTagClick={vi.fn()} />
+      <RecipeTagFilter tags={mockTags} activeTag="Italian" onTagClick={vi.fn()} onClear={vi.fn()} />
     )
 
     expect(screen.getByRole('button', { name: /Italian/i })).toHaveAttribute(
@@ -37,7 +37,7 @@ describe('RecipeTagFilter', () => {
 
   it('inactive tag has aria-pressed="false"', () => {
     render(
-      <RecipeTagFilter tags={mockTags} activeTag="Italian" onTagClick={vi.fn()} />
+      <RecipeTagFilter tags={mockTags} activeTag="Italian" onTagClick={vi.fn()} onClear={vi.fn()} />
     )
 
     expect(screen.getByRole('button', { name: /Quick/i })).toHaveAttribute(
@@ -52,11 +52,56 @@ describe('RecipeTagFilter', () => {
 
   it('exposes the tag chips as an accessible group with a descriptive label', () => {
     render(
-      <RecipeTagFilter tags={mockTags} activeTag={null} onTagClick={vi.fn()} />
+      <RecipeTagFilter tags={mockTags} activeTag={null} onTagClick={vi.fn()} onClear={vi.fn()} />
     )
 
     const group = screen.getByRole('group', { name: /filter by tag/i })
     expect(group).toBeInTheDocument()
     expect(group).toContainElement(screen.getByRole('button', { name: /Italian/i }))
+  })
+
+  describe('All chip', () => {
+    it('renders an "All" chip pressed when no tag is active', () => {
+      render(
+        <RecipeTagFilter tags={mockTags} activeTag={null} onTagClick={vi.fn()} onClear={vi.fn()} />
+      )
+
+      expect(screen.getByRole('button', { name: /^all$/i })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      )
+    })
+
+    it('is not pressed once a tag is active', () => {
+      render(
+        <RecipeTagFilter
+          tags={mockTags}
+          activeTag="Italian"
+          onTagClick={vi.fn()}
+          onClear={vi.fn()}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: /^all$/i })).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      )
+    })
+
+    it('calls onClear when clicked', () => {
+      const onClear = vi.fn()
+      render(
+        <RecipeTagFilter
+          tags={mockTags}
+          activeTag="Italian"
+          onTagClick={vi.fn()}
+          onClear={onClear}
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /^all$/i }))
+
+      expect(onClear).toHaveBeenCalledOnce()
+    })
   })
 })

--- a/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.test.tsx
@@ -49,4 +49,14 @@ describe('RecipeTagFilter', () => {
       'false'
     )
   })
+
+  it('exposes the tag chips as an accessible group with a descriptive label', () => {
+    render(
+      <RecipeTagFilter tags={mockTags} activeTag={null} onTagClick={vi.fn()} />
+    )
+
+    const group = screen.getByRole('group', { name: /filter by tag/i })
+    expect(group).toBeInTheDocument()
+    expect(group).toContainElement(screen.getByRole('button', { name: /Italian/i }))
+  })
 })

--- a/src/components/RecipeTagFilter/RecipeTagFilter.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.tsx
@@ -11,7 +11,7 @@ export interface RecipeTagFilterProps {
 
 const RecipeTagFilter: FC<RecipeTagFilterProps> = ({ tags, activeTag, onTagClick }) => {
   return (
-    <div className={styles.wrapper}>
+    <div className={styles.wrapper} role="group" aria-label="Filter by tag">
       {tags.map(({ tag, count }) => (
         <Button
           key={tag}

--- a/src/components/RecipeTagFilter/RecipeTagFilter.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.tsx
@@ -1,4 +1,4 @@
-import Button from '@components/Button'
+import TagChip from '@components/Tag'
 import type { Tag } from '@models/recipe'
 import type { FC } from 'react'
 import styles from './RecipeTagFilter.module.css'
@@ -13,15 +13,14 @@ const RecipeTagFilter: FC<RecipeTagFilterProps> = ({ tags, activeTag, onTagClick
   return (
     <div className={styles.wrapper} role="group" aria-label="Filter by tag">
       {tags.map(({ tag, count }) => (
-        <Button
+        <TagChip
           key={tag}
-          variant="outline"
-          className={styles.tag}
-          ariaPressed={activeTag === tag ? 'true' : 'false'}
+          as="button"
+          active={activeTag === tag}
           onClick={() => onTagClick(tag)}
         >
           {tag} ({count})
-        </Button>
+        </TagChip>
       ))}
     </div>
   )

--- a/src/components/RecipeTagFilter/RecipeTagFilter.tsx
+++ b/src/components/RecipeTagFilter/RecipeTagFilter.tsx
@@ -7,11 +7,15 @@ export interface RecipeTagFilterProps {
   tags: Tag[]
   activeTag: string | null
   onTagClick: (tag: string) => void
+  onClear: () => void
 }
 
-const RecipeTagFilter: FC<RecipeTagFilterProps> = ({ tags, activeTag, onTagClick }) => {
+const RecipeTagFilter: FC<RecipeTagFilterProps> = ({ tags, activeTag, onTagClick, onClear }) => {
   return (
     <div className={styles.wrapper} role="group" aria-label="Filter by tag">
+      <TagChip as="button" active={activeTag === null} onClick={onClear}>
+        All
+      </TagChip>
       {tags.map(({ tag, count }) => (
         <TagChip
           key={tag}

--- a/src/components/ScrollToTop/ScrollToTop.test.tsx
+++ b/src/components/ScrollToTop/ScrollToTop.test.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, useSearchParams } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import ScrollToTop from './ScrollToTop'
 
@@ -89,6 +89,39 @@ describe('ScrollToTop', () => {
 
     expect(document.querySelector).toHaveBeenCalledWith('#nonexistent')
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0)
+  })
+
+  it('does not scroll to top when only the search string changes on the same route (e.g. a filter chip)', () => {
+    // Mirrors real router behavior: a fresh load starts as POP, and the
+    // first PUSH (e.g. a tag filter click) flips it to PUSH, where it then
+    // stays for subsequent PUSH navigations too.
+    let navType: 'POP' | 'PUSH' = 'POP'
+    mockNavigationType.mockImplementation(() => navType)
+
+    const SetTagButton = () => {
+      const [, setSearchParams] = useSearchParams()
+      return (
+        <button onClick={() => setSearchParams({ tag: 'Italian' })}>
+          set tag
+        </button>
+      )
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/recipes']}>
+        <main id="main" tabIndex={-1} />
+        <SetTagButton />
+        <ScrollToTop />
+      </MemoryRouter>
+    )
+
+    expect(window.scrollTo).not.toHaveBeenCalled()
+
+    navType = 'PUSH'
+    fireEvent.click(screen.getByRole('button', { name: 'set tag' }))
+
+    expect(window.scrollTo).not.toHaveBeenCalled()
+    expect(document.activeElement).not.toBe(document.getElementById('main'))
   })
 
   it('does not scroll to anchor on POP navigation with hash', () => {

--- a/src/components/ScrollToTop/ScrollToTop.tsx
+++ b/src/components/ScrollToTop/ScrollToTop.tsx
@@ -1,11 +1,25 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useLocation, useNavigationType } from 'react-router-dom'
 
 export default function ScrollToTop() {
   const { pathname, hash } = useLocation()
   const navigationType = useNavigationType()
+  const prevPathnameRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
+    const isInitialMount = prevPathnameRef.current === undefined
+    const pathnameChanged = !isInitialMount && prevPathnameRef.current !== pathname
+    prevPathnameRef.current = pathname
+
+    // A search-param-only change (e.g. a filter chip's ?tag=) re-fires this
+    // effect too — navigationType flips POP -> PUSH on the first such
+    // change and then stays PUSH, so relying on navigationType alone only
+    // catches this on the first occurrence. Skip anything that isn't the
+    // initial mount or an actual route (pathname) change.
+    if (!isInitialMount && !pathnameChanged) {
+      return
+    }
+
     // Only scroll to top on new navigations (link clicks), not back/forward
     if (navigationType !== 'POP') {
       if (hash) {

--- a/src/components/ScrollToTop/ScrollToTop.tsx
+++ b/src/components/ScrollToTop/ScrollToTop.tsx
@@ -1,25 +1,11 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useLocation, useNavigationType } from 'react-router-dom'
 
 export default function ScrollToTop() {
   const { pathname, hash } = useLocation()
   const navigationType = useNavigationType()
-  const prevPathnameRef = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    const isInitialMount = prevPathnameRef.current === undefined
-    const pathnameChanged = !isInitialMount && prevPathnameRef.current !== pathname
-    prevPathnameRef.current = pathname
-
-    // A search-param-only change (e.g. a filter chip's ?tag=) re-fires this
-    // effect too — navigationType flips POP -> PUSH on the first such
-    // change and then stays PUSH, so relying on navigationType alone only
-    // catches this on the first occurrence. Skip anything that isn't the
-    // initial mount or an actual route (pathname) change.
-    if (!isInitialMount && !pathnameChanged) {
-      return
-    }
-
     // Only scroll to top on new navigations (link clicks), not back/forward
     if (navigationType !== 'POP') {
       if (hash) {
@@ -45,7 +31,15 @@ export default function ScrollToTop() {
       // focus target. preventScroll avoids fighting the scrollTo above.
       document.getElementById('main')?.focus({ preventScroll: true })
     }
-  }, [pathname, hash, navigationType])
+    // navigationType is read above but deliberately left out of these deps —
+    // it's consulted, not reacted to. A search-param-only change (e.g. a
+    // filter chip's ?tag=) doesn't touch pathname/hash, so this effect
+    // correctly won't re-run for it; but navigationType itself still flips
+    // POP -> PUSH on that first such change, and if it were a dependency
+    // this effect would spuriously re-run (and scroll to top) for that one
+    // change alone, even though neither pathname nor hash actually changed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, hash])
 
   return null
 }

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -24,6 +24,11 @@
   display: flex;
   align-items: baseline;
   gap: var(--space-3);
+  /* The design's content section (below the hero) has its own non-zero
+     top padding, clamp(12px,3vw,28px) — unlike Blog's equivalent section,
+     which uses 0. Without it, the gap below the hero is just the hero's
+     own bottom padding, short of the design. */
+  margin-block-start: clamp(12px, 3vw, 28px);
   margin-block-end: var(--space-5);
 }
 

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -37,3 +37,34 @@
   text-align: center;
   padding: var(--space-12) 0;
 }
+
+/* Matches the design's noResults message exactly: mono, 13px, muted —
+   distinct from Typography's shared bodyLarge variant (sans-serif,
+   full-contrast text), which this previously relied on with no override. */
+.emptyMessage {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0 0 var(--space-3);
+}
+
+.clearLink {
+  composes: focusRing chipHover from '../../styles/interactions.module.css';
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  letter-spacing: var(--tracking-meta);
+  color: var(--color-text-muted);
+  background: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--easing-default),
+              border-color var(--duration-fast) var(--easing-default);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .clearLink {
+    transition: none;
+  }
+}

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -43,33 +43,7 @@
   padding: var(--space-12) 0;
 }
 
-/* Matches the design's noResults message exactly: mono, 13px, muted —
-   distinct from Typography's shared bodyLarge variant (sans-serif,
-   full-contrast text), which this previously relied on with no override. */
 .emptyMessage {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-  margin: 0 0 var(--space-3);
-}
-
-.clearLink {
-  composes: focusRing chipHover from '../../styles/interactions.module.css';
-  font-family: var(--font-mono);
-  font-size: var(--font-size-xs);
-  letter-spacing: var(--tracking-meta);
-  color: var(--color-text-muted);
-  background: var(--color-surface);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-sm);
-  padding: var(--space-1) var(--space-2);
-  cursor: pointer;
-  transition: color var(--duration-fast) var(--easing-default),
-              border-color var(--duration-fast) var(--easing-default);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .clearLink {
-    transition: none;
-  }
+  composes: emptyStateMessage from '../../styles/text.module.css';
+  margin-block-end: var(--space-3);
 }

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -2,12 +2,21 @@
   padding-block-end: var(--space-12);
 }
 
+.hero {
+  composes: pageHero from '../../styles/text.module.css';
+  --page-hero-pad-end: clamp(36px, 5vw, 52px);
+}
+
+.eyebrow {
+  composes: eyebrow from '../../styles/text.module.css';
+}
+
 .heading {
-  margin-block-end: var(--space-2);
+  composes: pageHeading from '../../styles/text.module.css';
 }
 
 .intro {
-  margin-block-end: var(--space-8);
+  composes: pageLead from '../../styles/text.module.css';
 }
 
 .loadingWrapper {

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -19,6 +19,14 @@
   composes: pageLead from '../../styles/text.module.css';
 }
 
+.countRow {
+  composes: metaText dividerFill from '../../styles/text.module.css';
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  margin-block-end: var(--space-5);
+}
+
 .loadingWrapper {
   display: flex;
   justify-content: center;
@@ -28,16 +36,4 @@
 .empty {
   text-align: center;
   padding: var(--space-12) 0;
-}
-
-.srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -147,7 +147,7 @@ describe('Recipes page', () => {
     })
   })
 
-  it('shows "No recipes found" with clear button when filter has no matches', async () => {
+  it('shows the no-results message with clear button when filter has no matches', async () => {
     renderRecipes()
 
     await waitFor(() => {
@@ -158,7 +158,7 @@ describe('Recipes page', () => {
     fireEvent.change(searchInput, { target: { value: 'nonexistent dish xyz' } })
 
     await waitFor(() => {
-      expect(screen.getByText(/no recipes found/i)).toBeInTheDocument()
+      expect(screen.getByText(/nothing in the kitchen matches that/i)).toBeInTheDocument()
     })
 
     expect(screen.getByRole('button', { name: /clear filter/i })).toBeInTheDocument()
@@ -208,7 +208,7 @@ describe('Recipes page', () => {
       expect(await axe(container)).toHaveNoViolations()
     })
 
-    it('renders the "no recipes found" empty state with no detectable axe violations', async () => {
+    it('renders the no-results empty state with no detectable axe violations', async () => {
       const { container } = renderRecipes()
 
       await waitFor(() => {
@@ -219,7 +219,7 @@ describe('Recipes page', () => {
       fireEvent.change(searchInput, { target: { value: 'nonexistent dish xyz' } })
 
       await waitFor(() => {
-        expect(screen.getByText(/no recipes found/i)).toBeInTheDocument()
+        expect(screen.getByText(/nothing in the kitchen matches that/i)).toBeInTheDocument()
       })
 
       expect(await axe(container)).toHaveNoViolations()

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -3,6 +3,7 @@ import type { RecipeIndex, Tag } from '@models/recipe'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { axe } from 'vitest-axe'
 import Recipes from './Recipes'
 
 vi.mock('@api/recipes', () => ({
@@ -112,6 +113,24 @@ describe('Recipes page', () => {
     })
   })
 
+  it('searches by keyword (tag match)', async () => {
+    renderRecipes()
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    // "Spicy" only appears as a tag (on Thai Green Curry), not in any title.
+    const searchInput = screen.getByRole('searchbox', { name: /search recipes/i })
+    fireEvent.change(searchInput, { target: { value: 'spicy' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('Thai Green Curry')).toBeInTheDocument()
+      expect(screen.queryByText('Classic Margherita Pizza')).not.toBeInTheDocument()
+      expect(screen.queryByText('Italian Pasta Carbonara')).not.toBeInTheDocument()
+    })
+  })
+
   it('applies combined tag + search filtering', async () => {
     renderRecipes('/recipes?tag=Italian')
 
@@ -176,5 +195,34 @@ describe('Recipes page', () => {
 
     const liveRegion = screen.getByRole('status')
     expect(liveRegion).toHaveAttribute('aria-live', 'polite')
+  })
+
+  describe('accessibility', () => {
+    it('renders the default loaded recipe grid with no detectable axe violations', async () => {
+      const { container } = renderRecipes()
+
+      await waitFor(() => {
+        expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+      })
+
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('renders the "no recipes found" empty state with no detectable axe violations', async () => {
+      const { container } = renderRecipes()
+
+      await waitFor(() => {
+        expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+      })
+
+      const searchInput = screen.getByRole('searchbox', { name: /search recipes/i })
+      fireEvent.change(searchInput, { target: { value: 'nonexistent dish xyz' } })
+
+      await waitFor(() => {
+        expect(screen.getByText(/no recipes found/i)).toBeInTheDocument()
+      })
+
+      expect(await axe(container)).toHaveNoViolations()
+    })
   })
 })

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -161,7 +161,7 @@ describe('Recipes page', () => {
       expect(screen.getByText(/no recipes found/i)).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /clear filter/i })).toBeInTheDocument()
   })
 
   it('shows "Recipes coming soon" when no recipes exist', async () => {

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -9,6 +9,7 @@ import Typography from '@components/Typography'
 import type { RecipeIndex, Tag } from '@models/recipe'
 import { useState, useEffect, useCallback, useMemo, type FC, type ReactNode } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { pluralize } from '../../utils/pluralize'
 import styles from './Recipes.module.css'
 
 const RecipesHero: FC<{ children?: ReactNode }> = ({ children }) => (
@@ -126,17 +127,18 @@ const Recipes: FC = () => {
         </Typography>
       </RecipesHero>
 
+      <div className={styles.countRow}>
+        <span role="status" aria-live="polite">
+          {pluralize(filteredRecipes.length, 'recipe')}
+        </span>
+      </div>
+
       <RecipeSearch value={searchQuery} onSearch={handleSearch} />
       <RecipeTagFilter
         tags={tags}
         activeTag={activeTag}
         onTagClick={handleTagClick}
       />
-
-      <div role="status" aria-live="polite" className={styles.srOnly}>
-        {filteredRecipes.length}{' '}
-        {filteredRecipes.length === 1 ? 'recipe' : 'recipes'} found
-      </div>
 
       {filteredRecipes.length === 0 ? (
         <div className={styles.empty}>

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -59,9 +59,11 @@ const Recipes: FC = () => {
     () =>
       (recipes ?? []).filter((recipe) => {
         const matchesTag = !activeTag || recipe.tags.includes(activeTag)
+        const query = searchQuery.toLowerCase()
         const matchesSearch =
           !searchQuery ||
-          recipe.title.toLowerCase().includes(searchQuery.toLowerCase())
+          recipe.title.toLowerCase().includes(query) ||
+          recipe.tags.some((tag) => tag.toLowerCase().includes(query))
         return matchesTag && matchesSearch
       }),
     [recipes, activeTag, searchQuery]

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -55,19 +55,17 @@ const Recipes: FC = () => {
     setSearchQuery('')
   }
 
-  const filteredRecipes = useMemo(
-    () =>
-      (recipes ?? []).filter((recipe) => {
-        const matchesTag = !activeTag || recipe.tags.includes(activeTag)
-        const query = searchQuery.toLowerCase()
-        const matchesSearch =
-          !searchQuery ||
-          recipe.title.toLowerCase().includes(query) ||
-          recipe.tags.some((tag) => tag.toLowerCase().includes(query))
-        return matchesTag && matchesSearch
-      }),
-    [recipes, activeTag, searchQuery]
-  )
+  const filteredRecipes = useMemo(() => {
+    const query = searchQuery.toLowerCase()
+    return (recipes ?? []).filter((recipe) => {
+      const matchesTag = !activeTag || recipe.tags.includes(activeTag)
+      const matchesSearch =
+        !searchQuery ||
+        recipe.title.toLowerCase().includes(query) ||
+        recipe.tags.some((tag) => tag.toLowerCase().includes(query))
+      return matchesTag && matchesSearch
+    })
+  }, [recipes, activeTag, searchQuery])
 
   if (recipes === null && !error) {
     return (

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -7,9 +7,21 @@ import RecipeSearch from '@components/RecipeSearch'
 import RecipeTagFilter from '@components/RecipeTagFilter'
 import Typography from '@components/Typography'
 import type { RecipeIndex, Tag } from '@models/recipe'
-import { useState, useEffect, useCallback, useMemo, type FC } from 'react'
+import { useState, useEffect, useCallback, useMemo, type FC, type ReactNode } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import styles from './Recipes.module.css'
+
+const RecipesHero: FC<{ children?: ReactNode }> = ({ children }) => (
+  <section className={styles.hero}>
+    <Typography variant="caption" as="p" className={styles.eyebrow}>
+      From the Kitchen
+    </Typography>
+    <Typography variant="heading1" className={styles.heading}>
+      Things I keep coming back to.
+    </Typography>
+    {children}
+  </section>
+)
 
 const Recipes: FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -70,9 +82,7 @@ const Recipes: FC = () => {
   if (recipes === null && !error) {
     return (
       <>
-        <Typography variant="heading1" className={styles.heading}>
-          Recipes
-        </Typography>
+        <RecipesHero />
         <div className={styles.loadingWrapper}>
           <Loading />
         </div>
@@ -83,9 +93,7 @@ const Recipes: FC = () => {
   if (error) {
     return (
       <>
-        <Typography variant="heading1" className={styles.heading}>
-          Recipes
-        </Typography>
+        <RecipesHero />
         <div className={styles.empty}>
           <Typography variant="bodyLarge">
             Something went wrong loading recipes.
@@ -100,23 +108,23 @@ const Recipes: FC = () => {
 
   if (recipes !== null && recipes.length === 0) {
     return (
-      <>
-        <Typography variant="heading1" className={styles.heading}>
-          Recipes
+      <RecipesHero>
+        <Typography variant="bodyLarge" className={styles.intro}>
+          Recipes coming soon.
         </Typography>
-        <Typography variant="bodyLarge">Recipes coming soon</Typography>
-      </>
+      </RecipesHero>
     )
   }
 
   return (
     <div className={styles.page}>
-      <Typography variant="heading1" className={styles.heading}>
-        Recipes
-      </Typography>
-      <Typography variant="bodyLarge" className={styles.intro}>
-        A collection of tried-and-tested recipes from my kitchen.
-      </Typography>
+      <RecipesHero>
+        <Typography variant="bodyLarge" className={styles.intro}>
+          A small, growing collection of recipes I cook on repeat — written
+          down so they&apos;re easy to make again. Tried, refined, and worth
+          the effort.
+        </Typography>
+      </RecipesHero>
 
       <RecipeSearch value={searchQuery} onSearch={handleSearch} />
       <RecipeTagFilter

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -145,10 +145,10 @@ const Recipes: FC = () => {
 
       {filteredRecipes.length === 0 ? (
         <div className={styles.empty}>
-          <Typography variant="bodyLarge">No recipes found</Typography>
-          <Button variant="outline" onClick={handleClearFilters}>
-            Clear filter
-          </Button>
+          <p className={styles.emptyMessage}>Nothing in the kitchen matches that.</p>
+          <button type="button" onClick={handleClearFilters} className={styles.clearLink}>
+            ✕ clear filters
+          </button>
         </div>
       ) : (
         <Grid columns={3}>

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -153,7 +153,7 @@ const Recipes: FC = () => {
       ) : (
         <Grid columns={3}>
           {filteredRecipes.map((recipe) => (
-            <RecipeCard key={recipe.id} recipe={recipe} />
+            <RecipeCard key={recipe.id} recipe={recipe} hideTags />
           ))}
         </Grid>
       )}

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -59,6 +59,8 @@ const Recipes: FC = () => {
     }
   }
 
+  const handleClearTag = () => setSearchParams({})
+
   const handleSearch = useCallback((query: string) => {
     setSearchQuery(query)
   }, [])
@@ -138,6 +140,7 @@ const Recipes: FC = () => {
         tags={tags}
         activeTag={activeTag}
         onTagClick={handleTagClick}
+        onClear={handleClearTag}
       />
 
       {filteredRecipes.length === 0 ? (

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -5,14 +5,15 @@ import Loading from '@components/Loading'
 import RecipeCard from '@components/RecipeCard'
 import RecipeSearch from '@components/RecipeSearch'
 import RecipeTagFilter from '@components/RecipeTagFilter'
+import Tag from '@components/Tag'
 import Typography from '@components/Typography'
-import type { RecipeIndex, Tag } from '@models/recipe'
+import type { RecipeIndex, Tag as TagModel } from '@models/recipe'
 import { useState, useEffect, useCallback, useMemo, type FC, type ReactNode } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { pluralize } from '../../utils/pluralize'
 import styles from './Recipes.module.css'
 
-const RecipesHero: FC<{ children?: ReactNode }> = ({ children }) => (
+const RecipesHero: FC<{ intro?: ReactNode }> = ({ intro }) => (
   <section className={styles.hero}>
     <Typography variant="caption" as="p" className={styles.eyebrow}>
       From the Kitchen
@@ -20,7 +21,11 @@ const RecipesHero: FC<{ children?: ReactNode }> = ({ children }) => (
     <Typography variant="heading1" className={styles.heading}>
       Things I keep coming back to.
     </Typography>
-    {children}
+    {intro && (
+      <Typography variant="bodyLarge" className={styles.intro}>
+        {intro}
+      </Typography>
+    )}
   </section>
 )
 
@@ -29,7 +34,7 @@ const Recipes: FC = () => {
   const activeTag = searchParams.get('tag')
 
   const [recipes, setRecipes] = useState<RecipeIndex[] | null>(null)
-  const [tags, setTags] = useState<Tag[]>([])
+  const [tags, setTags] = useState<TagModel[]>([])
   const [error, setError] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
 
@@ -110,24 +115,20 @@ const Recipes: FC = () => {
   }
 
   if (recipes !== null && recipes.length === 0) {
-    return (
-      <RecipesHero>
-        <Typography variant="bodyLarge" className={styles.intro}>
-          Recipes coming soon.
-        </Typography>
-      </RecipesHero>
-    )
+    return <RecipesHero intro="Recipes coming soon." />
   }
 
   return (
     <div className={styles.page}>
-      <RecipesHero>
-        <Typography variant="bodyLarge" className={styles.intro}>
-          A small, growing collection of recipes I cook on repeat — written
-          down so they&apos;re easy to make again. Tried, refined, and worth
-          the effort.
-        </Typography>
-      </RecipesHero>
+      <RecipesHero
+        intro={
+          <>
+            A small, growing collection of recipes I cook on repeat — written
+            down so they&apos;re easy to make again. Tried, refined, and worth
+            the effort.
+          </>
+        }
+      />
 
       <div className={styles.countRow}>
         <span role="status" aria-live="polite">
@@ -146,9 +147,9 @@ const Recipes: FC = () => {
       {filteredRecipes.length === 0 ? (
         <div className={styles.empty}>
           <p className={styles.emptyMessage}>Nothing in the kitchen matches that.</p>
-          <button type="button" onClick={handleClearFilters} className={styles.clearLink}>
+          <Tag as="button" onClick={handleClearFilters}>
             ✕ clear filters
-          </button>
+          </Tag>
         </div>
       ) : (
         <Grid columns={3}>

--- a/src/styles/text.module.css
+++ b/src/styles/text.module.css
@@ -56,6 +56,18 @@
   margin: 0;
 }
 
+/* Mono, muted, small — "no results" empty-state message text, matching the
+   design's noResults message exactly. Distinct from Typography's shared
+   bodyLarge variant (sans-serif, full-contrast text), which pages
+   previously relied on with no override. Margin is each consumer's own —
+   Blog's and Recipes' empty states each want a slightly different value. */
+.emptyStateMessage {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
 /* Mono, tracked, faint meta text — used for byline/count-row style labels
    (e.g. post date/reading time, item counts). */
 .metaText {


### PR DESCRIPTION
Closes #226

## What changed
- `RecipeSearch` input is now wrapped in `<form role="search">`; typing/submitting never touches the URL (verified by test).
- `RecipeTagFilter`'s chip container now exposes `role="group" aria-label="Filter by tag"`.
- `RecipeIngredients` renders ingredients as real `<input type="checkbox">` elements (wrapped in `<label>` for implicit accessible naming), with checked state persisted per recipe to `localStorage` under `recipe-ingredients:<slug>`. State correctly re-derives when the `slug` prop changes on an already-mounted instance (see Decisions made).
- `RecipeDetailView` (the existing shared view already reused by both public `RecipeDetail` and admin `RecipePreview`) now threads `recipe.slug` into `RecipeIngredients` to enable persistence.
- Recipes free-text search now also matches `recipe.tags`, not just `title` (see Decisions made re: scope).
- Added missing `axe` zero-violations test coverage for the `Recipes` page (loaded + empty state) and `RecipeDetailView`, matching the pattern already used by Blog/Home/Apps.
- `RecipeSteps` (`<ol><li>`) was already correct — untouched.

## Why
Part of the `akli.dev Warm Editorial "Paper" Redesign` milestone (`docs/prds/paper-redesign.md`). This issue covers the public Recipes index, Recipe detail page, and the shared recipe-view component reused by admin Preview.

## How to verify
- `pnpm test` — 735/735 pass.
- `pnpm exec eslint .` and `pnpm exec tsc --noEmit` — clean.
- Manually: visit `/recipes`, search by a tag name (not just title) and confirm it filters; check an ingredient on a recipe detail page, reload, confirm it's still checked; navigate to a different recipe and confirm its ingredients start unchecked.
- Manual visual sign-off against `docs/design/paper/pages/Recipes.dc.html` and `Recipe.dc.html` in both light/dark themes is still outstanding (explicitly a manual, non-CI-gated AC per the issue).

## Decisions made
- Kept the existing `RecipeDetailView` name rather than renaming to "RecipeView" — it already satisfies the "shared RecipeView" requirement (reused by both `RecipeDetail` and `RecipePreview`), and renaming working code to mirror the prototype's naming with no engineering benefit is explicitly out of scope per the PRD.
- Search AC says "filters client-side (title/desc/tags)" — narrowed to **title + tags**. `RecipeIndex` has no `description` field (only the full `Recipe` type has `intro`, not fetched for the list view), and adding one would be an API/data-model change the PRD's Non-Goals explicitly forbid. Confirmed with the repo owner before implementing.
- `RecipeIngredients`'s checked-state re-derives from `localStorage` during render (not `useEffect`) when the `slug` prop changes on an already-mounted instance — React Router reuses the same component instance across `/recipes/:slug` navigations rather than unmounting, so relying only on a mount-time `useState` initializer would leak the previous recipe's checked items onto the next one. Caught via direct testing during review; regression test added.

## Out of scope (noted, not filed as follow-ups)
- Ingredient checked-state is keyed by `${item}-${idx}` (index-based) since the data model has no stable ingredient ID. If a recipe's ingredients are ever reordered/edited in admin, a returning visitor's previously-checked items could point at the wrong ingredient. Low risk at this site's scale; flagged for awareness, not filed as a follow-up.
- `localStorage` keys for ingredient persistence are never cleaned up (unbounded growth as more recipes are visited/checked). Negligible at this site's scale.
- Extracting the localStorage-backed persisted-checkbox-state logic into a reusable `src/hooks/` hook was considered (there's exactly one call site today) — skipped as premature abstraction; no second consumer exists yet to justify the generalization.