### PR TITLE
Rebuild admin shell, Login, and Recipe list

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, FC, KeyboardEvent, ReactNode } from 'react'
+import { forwardRef, type ChangeEvent, type KeyboardEvent, type ReactNode } from 'react'
 import styles from './Input.module.css'
 
 export interface InputProps {
@@ -23,24 +23,27 @@ export interface InputProps {
   className?: string
 }
 
-const Input: FC<InputProps> = ({
-  type = 'text',
-  value,
-  placeholder,
-  invalid = false,
-  disabled = false,
-  prefixIcon,
-  suffix,
-  onChange,
-  onKeyDown,
-  id,
-  name,
-  required,
-  autoComplete,
-  ariaLabel,
-  ariaDescribedBy,
-  className: extraClassName,
-}) => {
+const Input = forwardRef<HTMLInputElement, InputProps>((
+  {
+    type = 'text',
+    value,
+    placeholder,
+    invalid = false,
+    disabled = false,
+    prefixIcon,
+    suffix,
+    onChange,
+    onKeyDown,
+    id,
+    name,
+    required,
+    autoComplete,
+    ariaLabel,
+    ariaDescribedBy,
+    className: extraClassName,
+  },
+  ref
+) => {
   const fieldClassName = [styles.field, invalid && styles.invalid, extraClassName]
     .filter(Boolean)
     .join(' ')
@@ -53,6 +56,7 @@ const Input: FC<InputProps> = ({
         </span>
       )}
       <input
+        ref={ref}
         id={id}
         name={name}
         type={type}
@@ -71,6 +75,8 @@ const Input: FC<InputProps> = ({
       {suffix && <span className={styles.suffix}>{suffix}</span>}
     </div>
   )
-}
+})
+
+Input.displayName = 'Input'
 
 export default Input

--- a/src/pages/admin/Login/Login.module.css
+++ b/src/pages/admin/Login/Login.module.css
@@ -1,55 +1,110 @@
+/* Login.module.css — matches docs/design/paper/pages/Admin Login.dc.html
+   exactly. Layout's shared <main> (src/components/Layout) owns page chrome
+   for every route and isn't touched by this issue, so `.page` reproduces
+   the design's `main { flex:1; display:flex; align-items:center;
+   justify-content:center; padding:48px 24px }` centering itself, the same
+   way NotFound's own `.container` approximates the header/footer-free
+   viewport height with `min-height` rather than a real flex:1 parent. */
+
 .page {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
-  padding: var(--space-12) var(--space-4) var(--space-4);
+  min-height: 60vh;
+  padding: var(--space-12) var(--space-6);
+}
+
+.column {
+  width: 100%;
+  /* 392px: no --max-w-* token lands here — they're all reading-column
+     widths for long-form content, not a compact auth-card width. */
+  max-width: 392px;
+}
+
+.cardHeader {
+  margin-bottom: var(--space-6);
+}
+
+/* .cardHeader .heading / .cardHeader .subheading (not bare classes):
+   Typography's own `heading3`/`body` variants each set their own
+   font-size/line-height/color, which ties in CSS specificity with a bare
+   override class on the same element (both single-class selectors) —
+   the winner depends on stylesheet load order, non-deterministic across
+   builds. Raising specificity via a parent-scoped descendant selector is
+   the established fix throughout this epic (see RecipeDetailView.module.css's
+   `.header .title`/`.header .intro`). */
+.cardHeader .heading {
+  /* 22px: between --font-size-xl (21px) and --font-size-2xl (24px); no
+     token lands on it exactly. */
+  font-size: 22px;
+  letter-spacing: var(--tracking-snug);
+  /* 6px: no --space-* token lands between --space-1 (4px) and --space-2
+     (8px). */
+  margin: 0 0 6px;
+}
+
+.cardHeader .subheading {
+  font-size: var(--font-size-sm-plus);
+  /* 1.55: between --line-height-normal (1.5) and --line-height-relaxed
+     (1.65); no token lands on it exactly. */
+  line-height: 1.55;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.errorBox {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px; /* no --space-* token lands on 9px (--space-2=8px, --space-3=12px) */
+  background: var(--color-error-bg);
+  border: var(--border-width) solid color-mix(in srgb, var(--color-error) 34%, transparent);
+  border-radius: var(--radius-md);
+  padding: 11px 13px; /* no --space-* token lands on 11px/13px */
+  margin-bottom: 18px; /* no --space-* token lands on 18px (--space-4=16px, --space-5=20px) */
+}
+
+.errorDot {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  flex-shrink: 0;
+}
+
+.errorText {
+  /* 13.5px: no token lands between --font-size-sm (13px) and
+     --font-size-sm-plus (14px). */
+  font-size: 13.5px;
+  line-height: var(--line-height-normal);
+  color: var(--color-error);
 }
 
 .form {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  width: 100%;
-  max-width: 24rem;
-  padding: var(--space-6);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-xl);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-sm);
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: 7px; /* no --space-* token lands on 7px (--space-1=4px, --space-2=8px) */
 }
 
-.label {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text);
-}
-
-.input {
-  padding: var(--space-2) var(--space-3);
-  font-size: var(--font-size-base);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-bg);
-  color: var(--color-text);
-}
-
-.input:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
-
-.error {
-  font-size: var(--font-size-sm);
-  color: var(--color-error, #dc2626);
-  font-weight: var(--font-weight-medium);
-}
-
-.title {
+/* .column .footnote / .column .belowCard (not bare classes): same
+   specificity-tie fix as .cardHeader .heading above — both compose
+   Typography's `caption` variant (own font-size/color), which ties with
+   a bare override class. */
+.column .footnote {
+  font-size: 12.5px; /* no token lands between --font-size-xs (11px) and --font-size-sm (13px) */
+  line-height: var(--line-height-normal);
+  color: var(--color-text-faint);
+  margin: 18px 0 0; /* no --space-* token lands on 18px (--space-4=16px, --space-5=20px) */
   text-align: center;
+}
+
+.column .belowCard {
+  text-align: center;
+  font-size: 12px; /* no --font-size-* token lands on 12px (--font-size-xs=11px, --font-size-sm=13px) */
+  color: var(--color-text-faint);
+  margin: 22px 0 0; /* no --space-* token lands on 22px (--space-5=20px, --space-6=24px) */
 }

--- a/src/pages/admin/Login/Login.test.tsx
+++ b/src/pages/admin/Login/Login.test.tsx
@@ -4,6 +4,7 @@ import type { AuthChallenge, AuthTokens } from '@models/auth'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
 
 import Login from './Login'
 
@@ -52,7 +53,7 @@ const renderLogin = (initialPath = '/admin/login') => {
     getAccessToken: vi.fn(),
   })
 
-  render(
+  const { container } = render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="/admin/login" element={<Login />} />
@@ -63,7 +64,7 @@ const renderLogin = (initialPath = '/admin/login') => {
     </MemoryRouter>
   )
 
-  return { mockLogin }
+  return { mockLogin, container }
 }
 
 const fillAndSubmitLoginForm = (
@@ -231,5 +232,26 @@ describe('Login page', () => {
     expect(passwordInput.tagName).toBe('INPUT')
     expect(emailInput).toHaveAttribute('type', 'email')
     expect(passwordInput).toHaveAttribute('type', 'password')
+  })
+
+  describe('accessibility', () => {
+    it('renders the default sign-in form with no detectable axe violations', async () => {
+      const { container } = renderLogin()
+
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('renders the set-password form with no detectable axe violations', async () => {
+      const { mockLogin, container } = renderLogin()
+      mockLogin.mockResolvedValue(mockChallenge)
+
+      fillAndSubmitLoginForm('admin@example.com', 'temppass')
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/new password/i)).toBeInTheDocument()
+      })
+
+      expect(await axe(container)).toHaveNoViolations()
+    })
   })
 })

--- a/src/pages/admin/Login/Login.test.tsx
+++ b/src/pages/admin/Login/Login.test.tsx
@@ -72,7 +72,7 @@ const fillAndSubmitLoginForm = (
 ) => {
   fireEvent.change(screen.getByLabelText(/email/i), { target: { value: email } })
   fireEvent.change(screen.getByLabelText(/password/i), { target: { value: password } })
-  fireEvent.click(screen.getByRole('button', { name: /log in/i }))
+  fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 }
 
 describe('Login page', () => {
@@ -85,7 +85,7 @@ describe('Login page', () => {
 
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
   })
 
   it('redirects to /admin/recipes on successful login', async () => {
@@ -120,8 +120,9 @@ describe('Login page', () => {
       expect(screen.getByText('Incorrect email or password')).toBeInTheDocument()
     })
 
-    const errorMessage = screen.getByText('Incorrect email or password')
-    expect(errorMessage).toHaveAttribute('id')
+    const errorAlert = screen.getByRole('alert')
+    expect(errorAlert).toHaveAttribute('id', 'form-error')
+    expect(errorAlert).toHaveTextContent('Incorrect email or password')
   })
 
   it('disables submit button while loading', async () => {
@@ -131,7 +132,7 @@ describe('Login page', () => {
     fillAndSubmitLoginForm('admin@example.com', 'password123')
 
     await waitFor(() => {
-      const submitButton = screen.getByRole('button', { name: /loading/i })
+      const submitButton = screen.getByRole('button', { name: /signing in/i })
       expect(submitButton).toBeDisabled()
     })
   })
@@ -146,7 +147,22 @@ describe('Login page', () => {
       expect(screen.getByLabelText(/new password/i)).toBeInTheDocument()
     })
     expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /set new password/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /set password & continue/i })
+    ).toBeInTheDocument()
+  })
+
+  it('moves focus to the new password field when the set-password form appears', async () => {
+    const { mockLogin } = renderLogin()
+    mockLogin.mockResolvedValue(mockChallenge)
+
+    fillAndSubmitLoginForm('admin@example.com', 'temppass')
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/new password/i)).toBeInTheDocument()
+    })
+
+    expect(screen.getByLabelText(/new password/i)).toHaveFocus()
   })
 
   it('shows error when new passwords do not match', async () => {
@@ -163,7 +179,7 @@ describe('Login page', () => {
     fireEvent.change(screen.getByLabelText(/confirm password/i), {
       target: { value: 'DifferentPass456!' },
     })
-    fireEvent.click(screen.getByRole('button', { name: /set new password/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set password & continue/i }))
 
     await waitFor(() => {
       expect(screen.getByText('Passwords do not match')).toBeInTheDocument()
@@ -185,7 +201,7 @@ describe('Login page', () => {
     fireEvent.change(screen.getByLabelText(/confirm password/i), {
       target: { value: 'NewPass123!' },
     })
-    fireEvent.click(screen.getByRole('button', { name: /set new password/i }))
+    fireEvent.click(screen.getByRole('button', { name: /set password & continue/i }))
 
     await waitFor(() => {
       expect(screen.getByTestId('location')).toHaveTextContent('/admin/recipes')

--- a/src/pages/admin/Login/Login.tsx
+++ b/src/pages/admin/Login/Login.tsx
@@ -1,9 +1,11 @@
 import { completeNewPassword } from '@api/auth'
 import Button from '@components/Button'
+import Card from '@components/Card'
+import Input from '@components/Input'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
 import type { AuthChallenge } from '@models/auth'
-import { type FormEvent, useState } from 'react'
+import { type ChangeEvent, type FormEvent, useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import styles from './Login.module.css'
@@ -13,6 +15,17 @@ const isChallenge = (result: unknown): result is AuthChallenge =>
   result !== null &&
   'challengeName' in result &&
   (result as AuthChallenge).challengeName === 'NEW_PASSWORD_REQUIRED'
+
+interface FieldConfig {
+  id: string
+  name: string
+  label: string
+  type: string
+  autoComplete: string
+  placeholder: string
+  value: string
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+}
 
 const Login = () => {
   const { login } = useAuth()
@@ -28,7 +41,24 @@ const Login = () => {
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
 
+  const formRef = useRef<HTMLFormElement>(null)
+  const hadChallengeRef = useRef(false)
+
   const redirectTo = searchParams.get('redirect') ?? '/admin/recipes'
+  const isSetPassword = Boolean(challenge)
+
+  // Moves focus to the first field of the newly-shown form when the Cognito
+  // NEW_PASSWORD_REQUIRED challenge flips the page from sign-in to
+  // set-password mode. Skipped on mount (hadChallengeRef starts aligned with
+  // the initial `challenge` state) so it only fires on the actual transition.
+  // Input doesn't forward a ref to its underlying <input> (it's a plain FC),
+  // so this queries the DOM instead of focusing a field ref directly.
+  useEffect(() => {
+    if (isSetPassword !== hadChallengeRef.current) {
+      formRef.current?.querySelector<HTMLInputElement>('input')?.focus()
+    }
+    hadChallengeRef.current = isSetPassword
+  }, [isSetPassword])
 
   const handleLogin = async (e: FormEvent) => {
     e.preventDefault()
@@ -80,103 +110,122 @@ const Login = () => {
     }
   }
 
-  if (challenge) {
-    return (
-      <div className={styles.page}>
-        <form className={styles.form} onSubmit={handleNewPassword}>
-          <Typography variant="heading2" className={styles.title}>
-            Set new password
-          </Typography>
+  const heading = isSetPassword ? 'Set a new password' : 'Sign in'
+  const subheading = isSetPassword
+    ? 'Your account needs a password before you can continue.'
+    : 'Enter your credentials to access the admin.'
+  const idleLabel = isSetPassword ? 'Set password & continue' : 'Sign in'
+  const loadingLabel = isSetPassword ? 'Saving…' : 'Signing in…'
+  const submitLabel = loading ? loadingLabel : idleLabel
 
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="new-password">
-              New password
-            </label>
-            <input
-              id="new-password"
-              className={styles.input}
-              type="password"
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-              aria-describedby={error ? 'form-error' : undefined}
-            />
-          </div>
-
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="confirm-password">
-              Confirm password
-            </label>
-            <input
-              id="confirm-password"
-              className={styles.input}
-              type="password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              aria-describedby={error ? 'form-error' : undefined}
-            />
-          </div>
-
-          {error && (
-            <p id="form-error" className={styles.error}>
-              {error}
-            </p>
-          )}
-
-          <Button type="submit" loading={loading}>
-            Set new password
-          </Button>
-        </form>
-      </div>
-    )
-  }
+  const fields: FieldConfig[] = isSetPassword
+    ? [
+        {
+          id: 'new-password',
+          name: 'newPassword',
+          label: 'New password',
+          type: 'password',
+          autoComplete: 'new-password',
+          placeholder: 'At least 8 characters',
+          value: newPassword,
+          onChange: (e) => setNewPassword(e.target.value),
+        },
+        {
+          id: 'confirm-password',
+          name: 'confirmPassword',
+          label: 'Confirm password',
+          type: 'password',
+          autoComplete: 'new-password',
+          placeholder: 'Re-enter your new password',
+          value: confirmPassword,
+          onChange: (e) => setConfirmPassword(e.target.value),
+        },
+      ]
+    : [
+        {
+          id: 'email',
+          name: 'email',
+          label: 'Email',
+          type: 'email',
+          autoComplete: 'username',
+          placeholder: 'you@akli.dev',
+          value: email,
+          onChange: (e) => setEmail(e.target.value),
+        },
+        {
+          id: 'password',
+          name: 'password',
+          label: 'Password',
+          type: 'password',
+          autoComplete: 'current-password',
+          placeholder: '••••••••••',
+          value: password,
+          onChange: (e) => setPassword(e.target.value),
+        },
+      ]
 
   return (
     <div className={styles.page}>
-      <form className={styles.form} onSubmit={handleLogin}>
-        <Typography variant="heading2" className={styles.title}>
-          Log in
+      <div className={styles.column}>
+        <Card fill radius="var(--radius-2xl)" padding="clamp(26px, 4vw, 34px)">
+          <header className={styles.cardHeader}>
+            <Typography variant="heading3" as="h1" className={styles.heading}>
+              {heading}
+            </Typography>
+            <Typography variant="body" as="p" className={styles.subheading}>
+              {subheading}
+            </Typography>
+          </header>
+
+          {error && (
+            <div id="form-error" role="alert" className={styles.errorBox}>
+              <span aria-hidden="true" className={styles.errorDot}>
+                ●
+              </span>
+              <span className={styles.errorText}>{error}</span>
+            </div>
+          )}
+
+          <form
+            ref={formRef}
+            className={styles.form}
+            onSubmit={isSetPassword ? handleNewPassword : handleLogin}
+            noValidate
+          >
+            {fields.map((field) => (
+              <label key={field.id} className={styles.field} htmlFor={field.id}>
+                <Typography variant="label" as="span">
+                  {field.label}
+                </Typography>
+                <Input
+                  id={field.id}
+                  name={field.name}
+                  type={field.type}
+                  autoComplete={field.autoComplete}
+                  placeholder={field.placeholder}
+                  value={field.value}
+                  onChange={field.onChange}
+                  ariaDescribedBy={error ? 'form-error' : undefined}
+                />
+              </label>
+            ))}
+
+            <Button type="submit" loading={loading} fullWidth>
+              {submitLabel}
+            </Button>
+          </form>
+
+          {isSetPassword && (
+            <Typography variant="caption" as="p" className={styles.footnote}>
+              First time signing in? Choose a password to finish setting up your account.
+            </Typography>
+          )}
+        </Card>
+
+        <Typography variant="caption" as="p" className={styles.belowCard}>
+          Authorized access only.
         </Typography>
-
-        <div className={styles.field}>
-          <label className={styles.label} htmlFor="email">
-            Email
-          </label>
-          <input
-            id="email"
-            className={styles.input}
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            aria-describedby={error ? 'form-error' : undefined}
-            required
-          />
-        </div>
-
-        <div className={styles.field}>
-          <label className={styles.label} htmlFor="password">
-            Password
-          </label>
-          <input
-            id="password"
-            className={styles.input}
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            aria-describedby={error ? 'form-error' : undefined}
-            required
-          />
-        </div>
-
-        {error && (
-          <p id="form-error" className={styles.error}>
-            {error}
-          </p>
-        )}
-
-        <Button type="submit" loading={loading}>
-          Log in
-        </Button>
-      </form>
+      </div>
     </div>
   )
 }

--- a/src/pages/admin/Login/Login.tsx
+++ b/src/pages/admin/Login/Login.tsx
@@ -41,23 +41,21 @@ const Login = () => {
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
 
-  const formRef = useRef<HTMLFormElement>(null)
-  const hadChallengeRef = useRef(false)
+  const firstFieldRef = useRef<HTMLInputElement>(null)
 
   const redirectTo = searchParams.get('redirect') ?? '/admin/recipes'
   const isSetPassword = Boolean(challenge)
 
   // Moves focus to the first field of the newly-shown form when the Cognito
   // NEW_PASSWORD_REQUIRED challenge flips the page from sign-in to
-  // set-password mode. Skipped on mount (hadChallengeRef starts aligned with
-  // the initial `challenge` state) so it only fires on the actual transition.
-  // Input doesn't forward a ref to its underlying <input> (it's a plain FC),
-  // so this queries the DOM instead of focusing a field ref directly.
+  // set-password mode. `challenge` only ever transitions null -> set (never
+  // back), so this effect's own [isSetPassword] dependency already gates it
+  // to firing once, on that transition — it can't re-fire on mount, since
+  // isSetPassword starts false there.
   useEffect(() => {
-    if (isSetPassword !== hadChallengeRef.current) {
-      formRef.current?.querySelector<HTMLInputElement>('input')?.focus()
+    if (isSetPassword) {
+      firstFieldRef.current?.focus()
     }
-    hadChallengeRef.current = isSetPassword
   }, [isSetPassword])
 
   const handleLogin = async (e: FormEvent) => {
@@ -110,13 +108,20 @@ const Login = () => {
     }
   }
 
-  const heading = isSetPassword ? 'Set a new password' : 'Sign in'
-  const subheading = isSetPassword
-    ? 'Your account needs a password before you can continue.'
-    : 'Enter your credentials to access the admin.'
-  const idleLabel = isSetPassword ? 'Set password & continue' : 'Sign in'
-  const loadingLabel = isSetPassword ? 'Saving…' : 'Signing in…'
-  const submitLabel = loading ? loadingLabel : idleLabel
+  const copy = isSetPassword
+    ? {
+        heading: 'Set a new password',
+        subheading: 'Your account needs a password before you can continue.',
+        idleLabel: 'Set password & continue',
+        loadingLabel: 'Saving…',
+      }
+    : {
+        heading: 'Sign in',
+        subheading: 'Enter your credentials to access the admin.',
+        idleLabel: 'Sign in',
+        loadingLabel: 'Signing in…',
+      }
+  const submitLabel = loading ? copy.loadingLabel : copy.idleLabel
 
   const fields: FieldConfig[] = isSetPassword
     ? [
@@ -170,10 +175,10 @@ const Login = () => {
         <Card fill radius="var(--radius-2xl)" padding="clamp(26px, 4vw, 34px)">
           <header className={styles.cardHeader}>
             <Typography variant="heading3" as="h1" className={styles.heading}>
-              {heading}
+              {copy.heading}
             </Typography>
             <Typography variant="body" as="p" className={styles.subheading}>
-              {subheading}
+              {copy.subheading}
             </Typography>
           </header>
 
@@ -187,17 +192,17 @@ const Login = () => {
           )}
 
           <form
-            ref={formRef}
             className={styles.form}
             onSubmit={isSetPassword ? handleNewPassword : handleLogin}
             noValidate
           >
-            {fields.map((field) => (
+            {fields.map((field, index) => (
               <label key={field.id} className={styles.field} htmlFor={field.id}>
                 <Typography variant="label" as="span">
                   {field.label}
                 </Typography>
                 <Input
+                  ref={index === 0 ? firstFieldRef : undefined}
                   id={field.id}
                   name={field.name}
                   type={field.type}

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -1,83 +1,317 @@
+/* Matches the design's admin `<main>` column exactly (Admin Recipes.dc.html
+   line 98) — the shared AdminLayout `<main>` sets no max-width of its own,
+   each admin page supplies it. --max-w-site (1080px) is the same token
+   Header/Footer use for their own inner width. */
 .page {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-  padding: var(--space-4);
-  max-width: 64rem;
-  margin: 0 auto;
+  max-width: var(--max-w-site);
+  margin-inline: auto;
+  padding: clamp(32px, 5vw, 52px) clamp(20px, 5vw, 28px) 64px;
   box-sizing: border-box;
-}
-
-.loadingWrapper {
-  display: flex;
-  justify-content: center;
-  padding: var(--space-12) 0;
 }
 
 .header {
   display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  align-items: flex-end;
+  justify-content: space-between;
+  /* 30px: design literal (Admin Recipes.dc.html line 101) — --space-8
+     (32px) is the nearest token but is 2px off. */
+  margin-bottom: 30px;
+}
+
+/* .header .heading (not bare `.heading`): raises specificity above
+   Typography's own `.heading1` — see RecipeDetailView.module.css's
+   `.header .title` for the same pattern/rationale. */
+.header .heading {
+  font-size: clamp(28px, 4vw, 34px);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: -0.025em;
+  margin: 0 0 6px;
+}
+
+/* .header .subtitle (not bare): raises specificity above Typography's own
+   `.body`. */
+.header .subtitle {
+  font-size: 14.5px;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+/* ── "New recipe" / "Create your first recipe" primary button ──────────
+   Applied to the shared Link component (client-side routing to
+   /admin/recipes/new) rather than Button, which has no polymorphic `as`/
+   href support — see RecipeDetailView.module.css's `.backLink` for the
+   same "style Link locally" precedent. Grouped selector: reused in both
+   the page header and the empty state. A bare `.newButton` class would tie
+   in specificity with Link's own `.link` (color, gap, radius) — same
+   failure mode documented throughout this file, fixed the same way. */
+.header .newButton,
+.emptyBox .newButton {
+  font-size: 14px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-btn-fg);
+  background: var(--color-btn-bg);
+  border-radius: var(--radius-md);
+  padding: 11px 18px;
+  gap: var(--space-2);
+  transition: opacity var(--duration-fast) var(--easing-default),
+    transform var(--duration-fast) var(--easing-default);
+}
+
+.header .newButton:hover,
+.emptyBox .newButton:hover {
+  color: var(--color-btn-fg);
+  opacity: 0.9;
+}
+
+.header .newButton:active,
+.emptyBox .newButton:active {
+  transform: translateY(1px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header .newButton,
+  .emptyBox .newButton {
+    transition: none;
+  }
+}
+
+/* ── Recipe row list ─────────────────────────────────────────────────
+   `<ul>/<li>`, not `<table>` — the design has zero table markup (a
+   bordered container of stacked flex rows). */
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  background: var(--color-field);
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  /* 16px/20px: design literal (row gap / column gap), no single token
+     covers both. */
+  gap: 16px 20px;
   align-items: center;
   justify-content: space-between;
+  padding: 18px clamp(16px, 2.5vw, 22px);
+  transition: background var(--duration-fast) var(--easing-default);
 }
 
-.newRecipeLink {
-  font-weight: var(--font-weight-semibold);
+.row:not(:first-child) {
+  border-top: var(--border-width) solid var(--color-border);
 }
 
-.tableWrapper {
-  overflow-x: auto;
+.row:hover {
+  background: var(--color-hover);
 }
 
-.table {
-  width: 100%;
-  border-collapse: collapse;
-  border: var(--border-width) solid var(--color-border);
-  background: var(--color-surface);
+@media (prefers-reduced-motion: reduce) {
+  .row {
+    transition: none;
+  }
 }
 
-.table th,
-.table td {
-  padding: var(--space-3) var(--space-4);
-  text-align: left;
-  vertical-align: middle;
-  border-bottom: var(--border-width) solid var(--color-border);
-  white-space: nowrap;
+.rowMain {
+  min-width: 240px;
+  flex: 1;
 }
 
-.table td:first-child {
-  white-space: normal;
-}
-
-.table th {
-  font-weight: var(--font-weight-semibold);
-  font-size: var(--font-size-sm);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  background: var(--color-bg);
-}
-
-.actionsInner {
+.rowTop {
   display: flex;
-  gap: var(--space-2);
   align-items: center;
+  gap: 11px;
+  margin-bottom: 9px;
 }
 
-.table td.actions {
-  border-bottom: none;
+/* .rowTop .rowTitle (not bare): raises specificity above Typography's own
+   `.heading2` — same pattern as `.header .heading` above. */
+.rowTop .rowTitle {
+  font-size: 16.5px;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: -0.015em;
+  margin: 0;
+  color: var(--color-text-strong);
 }
 
-.actionLink {
-  background: none;
-  border: none;
+.rowMeta {
+  list-style: none;
+  margin: 0;
   padding: 0;
-  color: var(--color-link);
-  font: inherit;
-  cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  /* 7px: design literal, between --space-1 (4px) and --space-2 (8px). */
+  gap: 7px;
 }
 
-.actionLink:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-  outline-offset: 2px;
+.tagChip {
+  composes: tagChipBase from '../../../styles/text.module.css';
+  /* This design's chip padding (3px 8px) is smaller than
+     RecipeDetailView's tag (5px 10px) — each `tagChipBase` consumer sets
+     its own padding, per that composable's own doc comment. */
+  padding: 3px 8px;
+  display: inline-block;
+}
+
+.updatedLabel {
+  font-size: 12.5px;
+  color: var(--color-text-faint);
+  /* 4px: design literal, on top of `.rowMeta`'s own 7px gap (Admin
+     Recipes.dc.html line 126 sets this margin in addition to the flex
+     gap already separating every sibling). */
+  margin-left: 4px;
+}
+
+.rowActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+/* CSS Modules only allows `composes` on a rule with a single bare local
+   class selector, not a compound/descendant one — `composes` inside
+   `.rowActions .actionButton { ... }` fails the build entirely
+   ("composition is only allowed when selector is single :local class
+   name"). Split: the bare `.actionButton` class carries the composed
+   focusRing; the descendant-scoped rule below carries the specificity-tie
+   fix (same rationale as `.header .newButton` above) and everything else. */
+.actionButton {
+  composes: focusRing from '../../../styles/interactions.module.css';
+}
+
+.rowActions .actionButton {
+  /* display/align-items/font-family are already inherited from Link's own
+     `.link` for Edit/Preview, but the native Publish/Delete `<button>`s
+     have no such base class — set explicitly so both element types match. */
+  display: inline-flex;
+  align-items: center;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+  background: transparent;
+  border: var(--border-width) solid transparent;
+  /* 8px: design literal — --radius-sm (6px) is the nearest token but is
+     2px off. */
+  border-radius: 8px;
+  padding: 6px 10px;
+  /* 6px: design literal, between --space-1 (4px) and --space-2 (8px). */
+  gap: 6px;
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--easing-default),
+    background var(--duration-fast) var(--easing-default);
+}
+
+.rowActions .actionButton svg {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+}
+
+.rowActions .actionButton:hover {
+  color: var(--color-text-strong);
+  background: var(--color-hover);
+}
+
+.rowActions .publishAction:hover {
+  color: var(--color-success);
+  background: var(--color-success-bg);
+}
+
+.rowActions .deleteAction:hover {
+  color: var(--color-error);
+  background: var(--color-error-bg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rowActions .actionButton {
+    transition: none;
+  }
+}
+
+/* ── Empty / loading / error states — shared box shape ────────────── */
+
+.emptyBox,
+.loadingBox,
+.errorBox {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  border-radius: var(--radius-xl);
+}
+
+.emptyBox {
+  border: 1px dashed var(--color-border);
+  padding: clamp(48px, 8vw, 84px) 24px;
+}
+
+.loadingBox {
+  border: var(--border-width) solid var(--color-border);
+  padding: clamp(56px, 9vw, 92px) 24px;
+  gap: 18px;
+}
+
+.errorBox {
+  border: var(--border-width) solid color-mix(in srgb, var(--color-error) 30%, var(--color-border));
+  background: var(--color-error-bg);
+  padding: clamp(48px, 8vw, 80px) 24px;
+}
+
+.emptyIcon,
+.errorIcon {
+  width: 52px;
+  height: 52px;
+  /* 14px: design literal — between --radius-lg (12px) and --radius-xl
+     (16px), neither an exact match. */
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.emptyIcon {
+  background: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  color: var(--color-text-muted);
+}
+
+.errorIcon {
+  background: var(--color-field);
+  border: var(--border-width) solid color-mix(in srgb, var(--color-error) 30%, var(--color-border));
+  color: var(--color-error);
+}
+
+/* .emptyBox .emptyHeading / .errorBox .errorHeading (not bare): raise
+   specificity above Typography's own `.heading2`. */
+.emptyBox .emptyHeading,
+.errorBox .errorHeading {
+  font-size: 20px;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+}
+
+/* .emptyBox .emptyBody / .errorBox .errorBody (not bare): raise
+   specificity above Typography's own `.body`. Identical apart from
+   max-width (36ch vs 38ch per the design's own two paragraphs), so the
+   shared declarations live in one rule and each box overrides just that. */
+.emptyBox .emptyBody,
+.errorBox .errorBody {
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--color-text-muted);
+  margin: 0 0 24px;
+  max-width: 36ch;
+}
+
+.errorBox .errorBody {
+  max-width: 38ch;
 }

--- a/src/pages/admin/RecipeList/RecipeList.test.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.test.tsx
@@ -274,8 +274,11 @@ describe('Admin RecipeList page', () => {
       expect(screen.getByText('Newest')).toBeInTheDocument()
     })
 
-    const rows = screen.getAllByRole('row').slice(1) // skip header row
-    const titles = rows.map((row) => within(row).getAllByRole('cell')[0].textContent)
+    // Row titles are the only level-2 headings on the page, so their DOM
+    // order reflects the row order rendered by the list.
+    const titles = screen
+      .getAllByRole('heading', { level: 2 })
+      .map((heading) => heading.textContent)
 
     expect(titles).toEqual(['Newest', 'Middle', 'Oldest'])
   })
@@ -287,8 +290,8 @@ describe('Admin RecipeList page', () => {
       expect(screen.getByText('Spaghetti Bolognese')).toBeInTheDocument()
     })
 
-    const draftRow = screen.getByText('Spaghetti Bolognese').closest('tr')
-    const publishedRow = screen.getByText('Thai Green Curry').closest('tr')
+    const draftRow = screen.getByText('Spaghetti Bolognese').closest('li')
+    const publishedRow = screen.getByText('Thai Green Curry').closest('li')
 
     expect(draftRow).not.toBeNull()
     expect(publishedRow).not.toBeNull()

--- a/src/pages/admin/RecipeList/RecipeList.test.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.test.tsx
@@ -5,6 +5,7 @@ import type { Recipe } from '@models/recipe'
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
 
 import RecipeList from './RecipeList'
 
@@ -298,5 +299,39 @@ describe('Admin RecipeList page', () => {
 
     expect(within(draftRow as HTMLElement).getByText(/draft/i)).toBeInTheDocument()
     expect(within(publishedRow as HTMLElement).getByText(/^published$/i)).toBeInTheDocument()
+  })
+
+  describe('accessibility', () => {
+    it('renders the loaded recipe list with no detectable axe violations', async () => {
+      const { container } = renderRecipeList()
+
+      await waitFor(() => {
+        expect(screen.getByText('Spaghetti Bolognese')).toBeInTheDocument()
+      })
+
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('renders the empty state with no detectable axe violations', async () => {
+      vi.mocked(fetchAllRecipes).mockResolvedValue([])
+      const { container } = renderRecipeList()
+
+      await waitFor(() => {
+        expect(screen.getByText(/no recipes yet/i)).toBeInTheDocument()
+      })
+
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('renders the error state with no detectable axe violations', async () => {
+      vi.mocked(fetchAllRecipes).mockRejectedValue(new Error('500 Internal Server Error'))
+      const { container } = renderRecipeList()
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+      })
+
+      expect(await axe(container)).toHaveNoViolations()
+    })
   })
 })

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -165,9 +165,6 @@ const iconRetry = (
   </svg>
 )
 
-const publishActionClassName = `${styles.actionButton} ${styles.publishAction}`
-const deleteActionClassName = `${styles.actionButton} ${styles.deleteAction}`
-
 const RecipeList = () => {
   const { getAccessToken, logout } = useAuth()
   const { showToast } = useToast()
@@ -286,6 +283,8 @@ const RecipeList = () => {
       )
     }
 
+    const now = new Date()
+
     return (
       <ul className={styles.list}>
         {sortedRecipes.map((recipe) => {
@@ -308,7 +307,7 @@ const RecipeList = () => {
                     </li>
                   ))}
                   <li className={styles.updatedLabel}>
-                    {relativeUpdatedLabel(recipe.updatedAt)}
+                    {relativeUpdatedLabel(recipe.updatedAt, now)}
                   </li>
                 </ul>
               </div>
@@ -331,7 +330,7 @@ const RecipeList = () => {
                 </Link>
                 <button
                   type="button"
-                  className={publishActionClassName}
+                  className={`${styles.actionButton} ${styles.publishAction}`}
                   onClick={() => handlePublish(recipe)}
                 >
                   {isPublished ? iconUnpublish : iconPublish}
@@ -339,7 +338,7 @@ const RecipeList = () => {
                 </button>
                 <button
                   type="button"
-                  className={deleteActionClassName}
+                  className={`${styles.actionButton} ${styles.deleteAction}`}
                   onClick={() => setDeleteTarget(recipe)}
                 >
                   {iconDelete}

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -17,7 +17,156 @@ import type { Recipe } from '@models/recipe'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
+import { pluralize } from '../../../utils/pluralize'
+import { relativeUpdatedLabel } from '../../../utils/relativeTime'
 import styles from './RecipeList.module.css'
+
+const iconPlus = (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.2"
+    strokeLinecap="round"
+    aria-hidden="true"
+  >
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+)
+
+const iconEdit = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+    <path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z" />
+  </svg>
+)
+
+const iconPreview = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+)
+
+const iconPublish = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 19V5" />
+    <path d="m5 12 7-7 7 7" />
+  </svg>
+)
+
+const iconUnpublish = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M3 3v18h18" />
+    <path d="m19 9-5 5-4-4-3 3" />
+  </svg>
+)
+
+const iconDelete = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M3 6h18" />
+    <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+  </svg>
+)
+
+const iconDocument = (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.7"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+    <path d="M14 2v5h5" />
+  </svg>
+)
+
+const iconWarning = (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+)
+
+const iconRetry = (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+    <path d="M3 3v5h5" />
+  </svg>
+)
+
+const publishActionClassName = `${styles.actionButton} ${styles.publishAction}`
+const deleteActionClassName = `${styles.actionButton} ${styles.deleteAction}`
 
 const RecipeList = () => {
   const { getAccessToken, logout } = useAuth()
@@ -93,121 +242,148 @@ const RecipeList = () => {
     }
   }
 
-  const renderContent = () => {
+  const renderBody = () => {
     if (loading) {
       return (
-        <div className={styles.loadingWrapper}>
-          <Loading />
+        <div className={styles.loadingBox}>
+          <Loading label="Loading recipes…" />
         </div>
       )
     }
 
     if (error) {
       return (
-        <>
-          <Typography variant="body">Something went wrong.</Typography>
-          <Button onClick={loadRecipes}>Retry</Button>
-        </>
+        <div className={styles.errorBox}>
+          <div className={styles.errorIcon}>{iconWarning}</div>
+          <Typography variant="heading2" className={styles.errorHeading}>
+            Couldn&apos;t load recipes
+          </Typography>
+          <Typography variant="body" className={styles.errorBody}>
+            Something went wrong reaching the server. Check your connection and try again.
+          </Typography>
+          <Button variant="outline" onClick={loadRecipes} iconLeft={iconRetry}>
+            Retry
+          </Button>
+        </div>
       )
     }
 
-    if (recipes.length === 0) {
+    if (sortedRecipes.length === 0) {
       return (
-        <>
-          <Typography variant="heading2">Recipes</Typography>
-          <Typography variant="body">No recipes yet.</Typography>
-          <Link to="/admin/recipes/new" ariaLabel="Create your first recipe">
+        <div className={styles.emptyBox}>
+          <div className={styles.emptyIcon}>{iconDocument}</div>
+          <Typography variant="heading2" className={styles.emptyHeading}>
+            No recipes yet
+          </Typography>
+          <Typography variant="body" className={styles.emptyBody}>
+            Your kitchen is empty. Create your first recipe to start building the collection.
+          </Typography>
+          <Link to="/admin/recipes/new" className={styles.newButton}>
+            {iconPlus}
             Create your first recipe
           </Link>
-        </>
+        </div>
       )
     }
 
     return (
-      <>
-        <div className={styles.header}>
-          <Typography variant="heading2">Recipes</Typography>
-          <Link to="/admin/recipes/new" className={styles.newRecipeLink}>
-            New recipe
-          </Link>
-        </div>
-
-        <div className={styles.tableWrapper}>
-          <table className={styles.table}>
-            <thead>
-              <tr>
-                <th>Title</th>
-                <th>Status</th>
-                <th>Tags</th>
-                <th>Last updated</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {sortedRecipes.map((recipe) => {
-                const isPublished = recipe.status === 'published'
-                return (
-                  <tr key={recipe.id}>
-                    <td>{recipe.title}</td>
-                    <td>
-                      <StatusBadge tone={isPublished ? 'success' : 'warning'}>
-                        {isPublished ? 'Published' : 'Draft'}
-                      </StatusBadge>
-                    </td>
-                    <td>{recipe.tags.join(', ')}</td>
-                    <td>{new Date(recipe.updatedAt).toLocaleDateString()}</td>
-                    <td className={styles.actions}>
-                      <div className={styles.actionsInner}>
-                        <Link
-                          to={`/admin/recipes/${recipe.id}/edit`}
-                          ariaLabel={`Edit ${recipe.title}`}
-                        >
-                          Edit
-                        </Link>
-                        <Link
-                          to={`/admin/recipes/${recipe.id}/preview`}
-                          ariaLabel={`Preview ${recipe.title}`}
-                        >
-                          Preview
-                        </Link>
-                        <button
-                          type="button"
-                          className={styles.actionLink}
-                          onClick={() => handlePublish(recipe)}
-                        >
-                          {isPublished ? 'Unpublish' : 'Publish'}
-                        </button>
-                        <button
-                          type="button"
-                          className={styles.actionLink}
-                          onClick={() => setDeleteTarget(recipe)}
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
-        </div>
-
-        <ConfirmDialog
-          title="Delete recipe"
-          danger
-          open={deleteTarget !== null}
-          onConfirm={handleDeleteConfirm}
-          onCancel={() => setDeleteTarget(null)}
-        >
-          Are you sure you want to delete &quot;{deleteTarget?.title ?? ''}
-          &quot;?
-        </ConfirmDialog>
-      </>
+      <ul className={styles.list}>
+        {sortedRecipes.map((recipe) => {
+          const isPublished = recipe.status === 'published'
+          return (
+            <li key={recipe.id} className={styles.row}>
+              <div className={styles.rowMain}>
+                <div className={styles.rowTop}>
+                  <StatusBadge tone={isPublished ? 'success' : 'warning'}>
+                    {isPublished ? 'Published' : 'Draft'}
+                  </StatusBadge>
+                  <Typography variant="heading2" className={styles.rowTitle}>
+                    {recipe.title}
+                  </Typography>
+                </div>
+                <ul className={styles.rowMeta}>
+                  {recipe.tags.map((tag) => (
+                    <li key={tag} className={styles.tagChip}>
+                      {tag}
+                    </li>
+                  ))}
+                  <li className={styles.updatedLabel}>
+                    {relativeUpdatedLabel(recipe.updatedAt)}
+                  </li>
+                </ul>
+              </div>
+              <div className={styles.rowActions}>
+                <Link
+                  to={`/admin/recipes/${recipe.id}/edit`}
+                  className={styles.actionButton}
+                  nudge="none"
+                >
+                  {iconEdit}
+                  Edit
+                </Link>
+                <Link
+                  to={`/admin/recipes/${recipe.id}/preview`}
+                  className={styles.actionButton}
+                  nudge="none"
+                >
+                  {iconPreview}
+                  Preview
+                </Link>
+                <button
+                  type="button"
+                  className={publishActionClassName}
+                  onClick={() => handlePublish(recipe)}
+                >
+                  {isPublished ? iconUnpublish : iconPublish}
+                  {isPublished ? 'Unpublish' : 'Publish'}
+                </button>
+                <button
+                  type="button"
+                  className={deleteActionClassName}
+                  onClick={() => setDeleteTarget(recipe)}
+                >
+                  {iconDelete}
+                  Delete
+                </button>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
     )
   }
 
-  return <div className={styles.page}>{renderContent()}</div>
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <div>
+          <Typography variant="heading1" className={styles.heading}>
+            Recipes
+          </Typography>
+          <Typography variant="body" className={styles.subtitle}>
+            {pluralize(sortedRecipes.length, 'recipe')}
+          </Typography>
+        </div>
+        <Link to="/admin/recipes/new" className={styles.newButton}>
+          {iconPlus}
+          New recipe
+        </Link>
+      </div>
+
+      {renderBody()}
+
+      <ConfirmDialog
+        title="Delete recipe"
+        danger
+        open={deleteTarget !== null}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      >
+        Are you sure you want to delete &quot;{deleteTarget?.title ?? ''}
+        &quot;?
+      </ConfirmDialog>
+    </div>
+  )
 }
 
 export default RecipeList

--- a/src/utils/relativeTime.test.ts
+++ b/src/utils/relativeTime.test.ts
@@ -1,0 +1,44 @@
+import { relativeUpdatedLabel } from './relativeTime'
+
+const NOW = new Date('2026-07-15T12:00:00Z')
+
+const daysAgo = (days: number) =>
+  new Date(NOW.getTime() - days * 86_400_000).toISOString()
+
+describe('relativeUpdatedLabel', () => {
+  it('shows "Updated today" when updated 0 days ago', () => {
+    expect(relativeUpdatedLabel(daysAgo(0), NOW)).toBe('Updated today')
+  })
+
+  it('shows "Updated yesterday" when updated 1 day ago', () => {
+    expect(relativeUpdatedLabel(daysAgo(1), NOW)).toBe('Updated yesterday')
+  })
+
+  it('shows "Updated N days ago" when updated 6 days ago', () => {
+    expect(relativeUpdatedLabel(daysAgo(6), NOW)).toBe('Updated 6 days ago')
+  })
+
+  it('shows "Updated last week" when updated 7 days ago', () => {
+    expect(relativeUpdatedLabel(daysAgo(7), NOW)).toBe('Updated last week')
+  })
+
+  it('shows "Updated last week" when updated 13 days ago', () => {
+    expect(relativeUpdatedLabel(daysAgo(13), NOW)).toBe('Updated last week')
+  })
+
+  it('shows "Updated N weeks ago" when updated 14 days ago', () => {
+    expect(relativeUpdatedLabel(daysAgo(14), NOW)).toBe('Updated 2 weeks ago')
+  })
+
+  it('shows "Updated N weeks ago" when updated 29 days ago', () => {
+    expect(relativeUpdatedLabel(daysAgo(29), NOW)).toBe('Updated 4 weeks ago')
+  })
+
+  it('shows a full date when updated 30 or more days ago', () => {
+    expect(relativeUpdatedLabel(daysAgo(30), NOW)).toBe('Updated 15 Jun 2026')
+  })
+
+  it('shows a full date matching the original update date, not the elapsed time', () => {
+    expect(relativeUpdatedLabel('2026-01-15T10:00:00Z', NOW)).toBe('Updated 15 Jan 2026')
+  })
+})

--- a/src/utils/relativeTime.ts
+++ b/src/utils/relativeTime.ts
@@ -1,20 +1,5 @@
 const DAY_MS = 86_400_000
 
-const MONTH_LABELS = [
-  'Jan',
-  'Feb',
-  'Mar',
-  'Apr',
-  'May',
-  'Jun',
-  'Jul',
-  'Aug',
-  'Sep',
-  'Oct',
-  'Nov',
-  'Dec',
-]
-
 /**
  * `relativeUpdatedLabel('2026-06-27T10:00:00Z')` -> `'Updated 3 days ago'`
  * (relative to `now`, which defaults to the current time). Thresholds match
@@ -32,5 +17,5 @@ export const relativeUpdatedLabel = (isoDate: string, now: Date = new Date()): s
   if (days < 14) return 'Updated last week'
   if (days < 30) return `Updated ${Math.floor(days / 7)} weeks ago`
 
-  return `Updated ${updated.getDate()} ${MONTH_LABELS[updated.getMonth()]} ${updated.getFullYear()}`
+  return `Updated ${updated.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}`
 }

--- a/src/utils/relativeTime.ts
+++ b/src/utils/relativeTime.ts
@@ -1,0 +1,36 @@
+const DAY_MS = 86_400_000
+
+const MONTH_LABELS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+
+/**
+ * `relativeUpdatedLabel('2026-06-27T10:00:00Z')` -> `'Updated 3 days ago'`
+ * (relative to `now`, which defaults to the current time). Thresholds match
+ * `docs/design/paper/pages/Admin Recipes.dc.html`'s own `relTime()`: today,
+ * yesterday, N days (<7), "last week" (<14), N weeks (<30), then a full
+ * date.
+ */
+export const relativeUpdatedLabel = (isoDate: string, now: Date = new Date()): string => {
+  const updated = new Date(isoDate)
+  const days = Math.round((now.getTime() - updated.getTime()) / DAY_MS)
+
+  if (days <= 0) return 'Updated today'
+  if (days === 1) return 'Updated yesterday'
+  if (days < 7) return `Updated ${days} days ago`
+  if (days < 14) return 'Updated last week'
+  if (days < 30) return `Updated ${Math.floor(days / 7)} weeks ago`
+
+  return `Updated ${updated.getDate()} ${MONTH_LABELS[updated.getMonth()]} ${updated.getFullYear()}`
+}


### PR DESCRIPTION
Closes #227

## What changed
The admin shell (Header admin/logged-out variants, Footer, SkipLink, `<main id="main">`) was already correctly built in earlier issues (#223/#224) — this PR is page content only.

**Login** (`src/pages/admin/Login`): rebuilt to match `docs/design/paper/pages/Admin Login.dc.html` — centered card layout, labelled fields with correct `autocomplete` (previously missing entirely), `role="alert"` error box (previously missing entirely), and focus moves to the first field of the set-password form when the Cognito `NEW_PASSWORD_REQUIRED` challenge flips the page from sign-in mode (new behavior). All existing auth logic (`handleLogin`/`handleNewPassword`) preserved exactly.

**Recipe list** (`src/pages/admin/RecipeList`): rebuilt to match `docs/design/paper/pages/Admin Recipes.dc.html` — the previous `<table>` replaced with a semantic `<ul><li>` row list (explicit AC), `StatusBadge` + tag chips (reusing the `tagChipBase` composable) + a new relative-time "Updated X ago" label (`src/utils/relativeTime.ts`), icon+label action buttons. All existing data logic (fetch/publish/unpublish/delete, `ConfirmDialog`, toast, session-error handling) preserved exactly.

**Shared component fix**: `Input` now forwards a ref to its underlying `<input>` (was a plain `FC`) — needed for Login's focus-management, and removes a DOM-`querySelector` workaround in favor of a real ref.

## Why
Continues the `akli.dev` Warm Editorial "Paper" Redesign per `docs/prds/paper-redesign.md`.

## How to verify
- `pnpm test` — 756/756 pass.
- `pnpm exec eslint .` and `pnpm exec tsc --noEmit` — clean.
- Manually: visit `/admin/login`, compare against `docs/design/paper/pages/Admin Login.dc.html` in both themes; visit `/admin/recipes` (authenticated), compare against `Admin Recipes.dc.html`.

## Decisions made
- Verified both pages via actual Playwright screenshots (light + dark, both pages) against the real design files before opening this PR — not just code review. Caught and fixed a real build-breaking bug this way: `composes:` used inside a compound/descendant selector (`.rowActions .actionButton { composes: ...; }`) is invalid CSS Modules syntax and crashed the Vite dev server entirely (typecheck/lint/`pnpm test` all passed anyway, since none of them run the real CSS build) — split into a bare `.actionButton { composes: ...; }` plus a separate override rule.
- Both pages independently re-apply the Typography/Link "specificity tie" fix established earlier in this epic (a bare override `className` ties in CSS specificity with a shared component's own variant class, non-deterministic winner) — this is the ~10th+ instance of that pattern; centralizing it at the source is already tracked as follow-up issue #263 and deliberately not done here (blast radius — it touches every already-shipped page).
- Added missing `axe` accessibility test coverage for both pages (5 new tests) — neither test file had any axe checks despite it being an explicit AC; no real violations found.
- `Input`'s `forwardRef` conversion was judged low-blast-radius (backward compatible, single shared component) and applied in-PR rather than deferred, unlike the broader Typography/Link fix.