### PR TITLE
Rebuild admin Recipe Editor

### DIFF
--- a/src/components/AdminLayout/AdminLayout.module.css
+++ b/src/components/AdminLayout/AdminLayout.module.css
@@ -2,13 +2,13 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 .content {
   flex: 1;
   min-width: 0;
-  overflow-x: hidden;
+  overflow-x: clip;
   /* SC 2.4.11: reserves room above the main landmark roughly equal to a
      single-row sticky header's height, so the header — pinned via
      position: sticky — never fully covers focus/scroll landing here or

--- a/src/components/AutosaveStatus/AutosaveStatus.module.css
+++ b/src/components/AutosaveStatus/AutosaveStatus.module.css
@@ -1,46 +1,48 @@
+/* Matches docs/design/paper/pages/Admin Recipe Editor.dc.html's rail
+   autosave-indicator exactly (sticky rail row, min-height:20px). */
+
 .container {
-  display: inline-flex;
+  display: flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--space-2);
+  /* 9px: design literal (--space-2=8px, --space-3=12px — neither lands). */
+  gap: 9px;
+  min-height: 20px;
+  width: 100%;
   font-family: var(--font-sans);
-  font-size: var(--font-size-sm);
-  line-height: var(--line-height-normal);
   color: var(--color-text);
-}
-
-.icon {
-  display: inline-block;
-  flex-shrink: 0;
-  inline-size: 0.5rem;
-  block-size: 0.5rem;
-  border-radius: var(--radius-full);
-  background-color: var(--color-text-muted);
-}
-
-.iconSaving {
-  background-color: var(--color-text-muted);
-  animation: autosaveStatusPulse 1.2s ease-in-out infinite;
-}
-
-.iconSaved {
-  background-color: var(--color-success);
-}
-
-.iconError {
-  background-color: var(--color-error);
 }
 
 .liveRegion {
   display: inline-flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--space-2);
+  gap: 9px;
+}
+
+/* ── Saving — shared spinner composable, small size ───────────────
+   Composes both `spinner` (rotation/border/color) and `spinnerSm` (the
+   15px/2px-border size override) from interactions.module.css — see that
+   file's own comment for why the keyframe needs `global(...)` and why
+   prefers-reduced-motion needs no local override (handled at the
+   `spin`/`shimmerSweep` keyframe level in animations.css). */
+.spinner {
+  composes: spinner spinnerSm from '../../styles/interactions.module.css';
+}
+
+.iconSaved {
+  display: inline-flex;
+  color: var(--color-success);
+}
+
+.iconError {
+  display: inline-flex;
+  color: var(--color-error);
 }
 
 .text {
   font-size: var(--font-size-sm);
-  color: var(--color-text);
+  color: var(--color-text-muted);
 }
 
 .relativeTime {
@@ -50,25 +52,22 @@
 
 .retryButton {
   composes: focusRing from '../../styles/interactions.module.css';
+  margin-left: auto;
   padding: 0;
-  font: inherit;
+  /* 12.5px: design literal (--font-size-sm=13px is the nearest token). */
+  font-size: 12.5px;
+  font-family: inherit;
+  font-weight: var(--font-weight-medium);
   color: var(--color-primary);
   background: transparent;
   border: 0;
   border-radius: var(--radius-sm);
-  text-decoration: underline;
   cursor: pointer;
 }
 
-@keyframes autosaveStatusPulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .iconSaving {
-    animation: none;
-  }
+.retryButton:hover,
+.retryButton:focus-visible {
+  text-decoration: underline;
 }
 
 @media (max-width: 640px) {

--- a/src/components/AutosaveStatus/AutosaveStatus.test.tsx
+++ b/src/components/AutosaveStatus/AutosaveStatus.test.tsx
@@ -111,10 +111,10 @@ describe('AutosaveStatus', () => {
   })
 
   describe('error state', () => {
-    it('renders "Failed to save" text', () => {
+    it('renders "Couldn\'t save" text', () => {
       render(<AutosaveStatus status="error" lastSavedAt={null} onRetry={noop} />)
 
-      expect(screen.getByText(/failed to save/i)).toBeInTheDocument()
+      expect(screen.getByText(/couldn.t save/i)).toBeInTheDocument()
     })
 
     it('renders a Retry button with accessible name', () => {

--- a/src/components/AutosaveStatus/AutosaveStatus.tsx
+++ b/src/components/AutosaveStatus/AutosaveStatus.tsx
@@ -20,22 +20,52 @@ const formatRelativeTime = (date: Date, now: Date): string => {
   return `${Math.floor(diffSeconds / 86_400)}d ago`
 }
 
-const cx = (...classNames: Array<string | false | undefined>): string =>
-  classNames.filter(Boolean).join(' ')
-
 const TRANSITION_TEXT: Record<AutosaveStatusValue, string> = {
   idle: '',
   saving: 'Saving…',
   saved: 'Saved',
-  error: 'Failed to save',
+  error: "Couldn't save",
 }
 
-const ICON_CLASS: Record<AutosaveStatusValue, string | undefined> = {
-  idle: undefined,
-  saving: styles.iconSaving,
-  saved: styles.iconSaved,
-  error: styles.iconError,
-}
+// Hoisted elements, not components — these never take props, so there's no
+// need to re-invoke a function (and rebuild the tree) on every render; see
+// `iconRetry` in src/pages/admin/RecipeList/RecipeList.tsx for the same
+// established pattern.
+//
+// Design: docs/design/paper/pages/Admin Recipe Editor.dc.html's rail
+// autosave-indicator markup (checkmark polyline, 15x15, stroke-width 2.4).
+const iconCheck = (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2.4}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+)
+
+// Design: same markup's error icon (circle + exclamation, 15x15, stroke-width 2).
+const iconWarning = (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="8" x2="12" y2="12" />
+    <line x1="12" y1="16" x2="12.01" y2="16" />
+  </svg>
+)
 
 const AutosaveStatus: FC<AutosaveStatusProps> = ({ status, lastSavedAt, onRetry }) => {
   const [now, setNow] = useState<number>(() => Date.now())
@@ -54,21 +84,28 @@ const AutosaveStatus: FC<AutosaveStatusProps> = ({ status, lastSavedAt, onRetry 
 
   const ariaLive = status === 'error' ? 'assertive' : 'polite'
   const transitionText = TRANSITION_TEXT[status]
-  const iconClass = ICON_CLASS[status]
 
   return (
     <span className={styles.container}>
       <span role="status" aria-live={ariaLive} className={styles.liveRegion}>
-        {status !== 'idle' && (
-          <>
-            <span aria-hidden="true" className={cx(styles.icon, iconClass)} />
-            <span className={styles.text}>{transitionText}</span>
-          </>
+        {status === 'saving' && (
+          <span aria-hidden="true" className={styles.spinner} />
         )}
+        {status === 'saved' && (
+          <span aria-hidden="true" className={styles.iconSaved}>
+            {iconCheck}
+          </span>
+        )}
+        {status === 'error' && (
+          <span aria-hidden="true" className={styles.iconError}>
+            {iconWarning}
+          </span>
+        )}
+        {status !== 'idle' && <span className={styles.text}>{transitionText}</span>}
       </span>
       {status === 'saved' && lastSavedAt !== null && (
         <span aria-hidden="true" className={styles.relativeTime}>
-          {`· ${formatRelativeTime(lastSavedAt, new Date(now))}`}
+          {formatRelativeTime(lastSavedAt, new Date(now))}
         </span>
       )}
       {status === 'error' && (

--- a/src/components/AutosaveStatus/AutosaveStatus.tsx
+++ b/src/components/AutosaveStatus/AutosaveStatus.tsx
@@ -1,5 +1,6 @@
+import { IconAlertCircle } from '@components/icons'
 import type { AutosaveStatus as AutosaveStatusValue } from '@hooks/useAutosave'
-import type { FC } from 'react'
+import type { FC, ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 import styles from './AutosaveStatus.module.css'
 
@@ -49,23 +50,18 @@ const iconCheck = (
   </svg>
 )
 
-// Design: same markup's error icon (circle + exclamation, 15x15, stroke-width 2).
-const iconWarning = (
-  <svg
-    width="15"
-    height="15"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="12" cy="12" r="10" />
-    <line x1="12" y1="8" x2="12" y2="12" />
-    <line x1="12" y1="16" x2="12.01" y2="16" />
-  </svg>
-)
+// `saving` has no entry — it renders the CSS-only spinner span, which has no
+// child icon, so it stays a distinct render branch rather than joining this
+// lookup. `idle` has no entry either — it renders nothing.
+const STATUS_ICON: Partial<Record<AutosaveStatusValue, ReactNode>> = {
+  saved: iconCheck,
+  error: <IconAlertCircle size={15} />,
+}
+
+const ICON_CLASS: Partial<Record<AutosaveStatusValue, string>> = {
+  saved: styles.iconSaved,
+  error: styles.iconError,
+}
 
 const AutosaveStatus: FC<AutosaveStatusProps> = ({ status, lastSavedAt, onRetry }) => {
   const [now, setNow] = useState<number>(() => Date.now())
@@ -84,6 +80,7 @@ const AutosaveStatus: FC<AutosaveStatusProps> = ({ status, lastSavedAt, onRetry 
 
   const ariaLive = status === 'error' ? 'assertive' : 'polite'
   const transitionText = TRANSITION_TEXT[status]
+  const statusIcon = STATUS_ICON[status]
 
   return (
     <span className={styles.container}>
@@ -91,14 +88,9 @@ const AutosaveStatus: FC<AutosaveStatusProps> = ({ status, lastSavedAt, onRetry 
         {status === 'saving' && (
           <span aria-hidden="true" className={styles.spinner} />
         )}
-        {status === 'saved' && (
-          <span aria-hidden="true" className={styles.iconSaved}>
-            {iconCheck}
-          </span>
-        )}
-        {status === 'error' && (
-          <span aria-hidden="true" className={styles.iconError}>
-            {iconWarning}
+        {statusIcon && (
+          <span aria-hidden="true" className={ICON_CLASS[status]}>
+            {statusIcon}
           </span>
         )}
         {status !== 'idle' && <span className={styles.text}>{transitionText}</span>}

--- a/src/components/ImageUpload/ImageUpload.module.css
+++ b/src/components/ImageUpload/ImageUpload.module.css
@@ -1,29 +1,156 @@
+/* Matches docs/design/paper/pages/Admin Recipe Editor.dc.html's COVER and
+   STEPS image sections (empty dropzone / processing shimmer / ready image
+   with an overlaid replace control). */
+
 .container {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
   align-items: flex-start;
+  width: 100%;
 }
 
-/* Matches ImageUpload.jsx's `ready`-state frame (1px border, radius-lg,
-   overflow hidden) — the empty/processing states are ProcessingPlaceholder's
-   own frame (already ported to the design's shimmer treatment). */
-.preview {
+/* ── Empty state — cover (large dropzone) ─────────────────────── */
+.dropzone {
+  composes: focusRing from '../../styles/interactions.module.css';
+  composes: uploadHover from '../../styles/interactions.module.css';
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  /* 10px: design literal (--space-2=8px, --space-3=12px — neither lands). */
+  gap: 10px;
+  width: 100%;
+  /* 22px: design literal (--space-5=20px, --space-6=24px — neither lands). */
+  padding: 22px;
+  font-family: inherit;
+  color: inherit;
+  text-align: center;
+  cursor: pointer;
+  background: var(--color-surface);
+  border: var(--border-width) dashed var(--color-border-strong);
+  border-radius: var(--radius-lg);
+  transition:
+    border-color var(--duration-base) var(--easing-default),
+    background-color var(--duration-base) var(--easing-default);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dropzone {
+    transition: none;
+  }
+}
+
+.dropzoneIcon {
+  display: inline-flex;
+  color: var(--color-text-muted);
+}
+
+.dropzoneLabel {
+  font-size: var(--font-size-sm-plus);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.dropzoneHint {
+  /* 12.5px: design literal (--font-size-xs=11px, --font-size-sm=13px —
+     neither lands). */
+  font-size: 12.5px;
+  line-height: var(--line-height-normal);
+  color: var(--color-text-faint);
+}
+
+/* ── Processing state — step thumbnail width cap ──────────────────
+   Matches the ready-state step thumbnail's own maxWidth (128px, ~96px
+   tall at the 4/3 aspect ratio below) so the shimmer placeholder doesn't
+   jump in size once the image finishes processing. Cover has no
+   equivalent — it's full-width in both states. */
+.stepProcessing {
+  max-width: 128px;
+}
+
+/* ── Ready state — image + overlaid replace control ───────────────── */
+.frame {
+  position: relative;
+}
+
+.coverFrame {
+  width: 100%;
+}
+
+/* Matches ImageUpload.jsx's ready-state frame (1px border, radius-lg,
+   object-fit cover) — the empty/processing states are the dropzone's own
+   or ProcessingPlaceholder's own frame respectively. */
+.previewImage {
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-lg);
   object-fit: cover;
 }
 
-/* No error-state visual exists in the design's ImageUpload.jsx — styled
-   as a small alert chip using the existing error-tint token, consistent
-   with `role="alert"` treatment elsewhere in the app. */
+/* No standalone "remove image" callback exists on this component (see
+   ReplaceIcon's comment in ImageUpload.tsx) — this restyles the previous
+   below-image "Replace" text button into the design's overlaid
+   top-right icon-button position/shape, kept non-destructive in tone
+   (not the design's literal danger/trash treatment, since it doesn't
+   delete anything). */
+.replaceButton {
+  composes: focusRing from '../../styles/interactions.module.css';
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--easing-default),
+    border-color var(--duration-fast) var(--easing-default),
+    background-color var(--duration-fast) var(--easing-default);
+}
+
+.replaceButton:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-strong);
+  background-color: var(--color-hover);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .replaceButton {
+    transition: none;
+  }
+}
+
+/* ── Error — Login's `.errorBox`/`.errorDot`/`.errorText` pattern
+   (src/pages/admin/Login/Login.module.css), extended with a Retry
+   action since, unlike Login's static message, this error is
+   recoverable in place. */
 .error {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-3);
-  color: var(--color-error);
-  background-color: var(--color-error-bg);
-  font-size: var(--font-size-sm);
-  padding: var(--space-2) var(--space-3);
+  gap: 9px; /* no --space-* token lands on 9px (--space-2=8px, --space-3=12px) */
+  width: 100%;
+  background: var(--color-error-bg);
+  border: var(--border-width) solid color-mix(in srgb, var(--color-error) 34%, transparent);
   border-radius: var(--radius-md);
+  padding: 11px 13px; /* no --space-* token lands on 11px/13px */
+}
+
+.errorDot {
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  flex-shrink: 0;
+}
+
+.errorText {
+  flex: 1;
+  font-size: 13.5px; /* no token lands between --font-size-sm (13px) and --font-size-sm-plus (14px) */
+  line-height: var(--line-height-normal);
+  color: var(--color-error);
 }

--- a/src/components/ImageUpload/ImageUpload.test.tsx
+++ b/src/components/ImageUpload/ImageUpload.test.tsx
@@ -259,7 +259,12 @@ describe('ImageUpload', () => {
   })
 
   describe('render branches (preview / processing / ready)', () => {
-    it('renders the processing placeholder when processedAt is not set', () => {
+    // NEW (#228): on a fresh mount with no prior upload attempt in this
+    // session, `processedAt` being unset now means "never uploaded" (empty
+    // dropzone), not "processing" — the processing placeholder is reserved
+    // for an upload actually in flight (see "shows local preview after file
+    // selection" below, which covers that in-flight case).
+    it('renders the empty dropzone (not the processing placeholder) on mount when no upload has been attempted', () => {
       render(
         <ImageUpload
           slug="beans-on-toast"
@@ -269,7 +274,8 @@ describe('ImageUpload', () => {
         />
       )
 
-      expect(screen.getByText(/processing image/i)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /upload a cover image/i })).toBeInTheDocument()
+      expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
       expect(screen.queryByRole('img')).not.toBeInTheDocument()
     })
 

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -21,6 +21,70 @@ export interface ImageUploadProps {
 
 const MAX_SIZE = 10 * 1024 * 1024
 
+// Hoisted elements, not components — these never take props, so there's no
+// need to re-invoke a function (and rebuild the tree) on every render; see
+// `iconRetry` in src/pages/admin/RecipeList/RecipeList.tsx for the same
+// established pattern.
+//
+// Design: docs/design/paper/pages/Admin Recipe Editor.dc.html's `.upload`
+// dropzone icon (upload-cloud, stroke-width 1.6).
+const iconUploadCloud = (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.6}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="17 8 12 3 7 8" />
+    <line x1="12" y1="3" x2="12" y2="15" />
+  </svg>
+)
+
+// Design: same doc's STEPS section "+ Add step image" ghost-button icon.
+const iconAddImage = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <circle cx="9" cy="9" r="2" />
+    <path d="m21 15-3.1-3.1a2 2 0 0 0-2.8 0L6 21" />
+  </svg>
+)
+
+// Design's overlaid icon-button is a trash glyph (it deletes the image
+// outright in the design's simulated backend). This component only has a
+// replace-via-re-upload callback surface (see the "Ready state" note in
+// the PR description), so a pencil/replace glyph is used instead of the
+// literal trash icon to avoid implying a destructive delete that doesn't
+// exist here.
+const iconReplace = (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 20h9" />
+    <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+  </svg>
+)
+
 const ImageUpload: FC<ImageUploadProps> = ({
   slug,
   imageType,
@@ -35,7 +99,25 @@ const ImageUpload: FC<ImageUploadProps> = ({
   const [preview, setPreview] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [lastFile, setLastFile] = useState<File | null>(null)
+  // Local, session-only signal distinguishing "never uploaded" (empty
+  // dropzone) from "uploaded, awaiting the server's processedAt" (shimmer
+  // placeholder) — the props contract alone (`processedAt`/`preview`)
+  // can't tell those apart, since both start out undefined/null. See the
+  // "Empty vs. processing" note in the PR description for the one edge
+  // case this doesn't cover (a page reload mid-processing from a prior
+  // session) and why fixing that would need a new prop wired up by the
+  // parent, out of scope here.
+  const [hasAttemptedUpload, setHasAttemptedUpload] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
+
+  // Direct equality rather than `parseImageType(imageType).kind === 'cover'`
+  // — parseImageType unconditionally calls `.slice()` on the non-cover
+  // branch, which throws if `imageType` is ever undefined at runtime (the
+  // "requires ... props (compile-time check)" test renders with it
+  // omitted, via `@ts-expect-error`, specifically to exercise this). This
+  // stays evaluated only where actually needed (`uploadParams`, still
+  // called lazily on upload) for anything beyond this cover/step branch.
+  const isCover = imageType === 'cover'
 
   useEffect(() => {
     return () => {
@@ -68,6 +150,7 @@ const ImageUpload: FC<ImageUploadProps> = ({
       return
     }
 
+    setHasAttemptedUpload(true)
     setPreview(URL.createObjectURL(file))
 
     try {
@@ -94,34 +177,69 @@ const ImageUpload: FC<ImageUploadProps> = ({
     if (lastFile) upload(lastFile)
   }
 
-  const renderPreview = () => {
+  const previewAspectRatio = isCover ? '16 / 9' : '4 / 3'
+  const previewMaxWidth = isCover ? undefined : '128px'
+
+  const renderContent = () => {
     if (preview) {
       return (
         <Image
           key="preview"
           src={preview}
           alt="Upload preview"
-          className={styles.preview}
-          aspectRatio="1 / 1"
-          maxWidth="200px"
+          className={styles.previewImage}
+          aspectRatio={previewAspectRatio}
+          maxWidth={previewMaxWidth}
           lazy={false}
         />
       )
     }
-    if (!processedAt) return <ProcessingPlaceholder aspectRatio="1 / 1" />
-    return (
-      <Image
-        key="processed"
-        src={recipeImageUrl(slug, imageType, 'medium')}
-        alt={currentAlt ?? 'Current image'}
-        className={styles.preview}
-        aspectRatio="1 / 1"
-        maxWidth="200px"
-      />
+
+    if (processedAt !== undefined) {
+      return (
+        <div className={isCover ? `${styles.frame} ${styles.coverFrame}` : styles.frame}>
+          <Image
+            key="processed"
+            src={recipeImageUrl(slug, imageType, 'medium')}
+            alt={currentAlt ?? 'Current image'}
+            className={styles.previewImage}
+            aspectRatio={previewAspectRatio}
+            maxWidth={previewMaxWidth}
+          />
+          <button
+            type="button"
+            className={styles.replaceButton}
+            onClick={handleClick}
+            aria-label="Replace image"
+          >
+            {iconReplace}
+          </button>
+        </div>
+      )
+    }
+
+    if (hasAttemptedUpload) {
+      return isCover ? (
+        <ProcessingPlaceholder aspectRatio="16 / 9" />
+      ) : (
+        <ProcessingPlaceholder height="96px" caption="Processing…" className={styles.stepProcessing} />
+      )
+    }
+
+    return isCover ? (
+      <button type="button" className={styles.dropzone} onClick={handleClick}>
+        <span aria-hidden="true" className={styles.dropzoneIcon}>
+          {iconUploadCloud}
+        </span>
+        <span className={styles.dropzoneLabel}>Upload a cover image</span>
+        <span className={styles.dropzoneHint}>JPG, PNG or WebP — landscape works best.</span>
+      </button>
+    ) : (
+      <Button onClick={handleClick} variant="outline" size="sm" iconLeft={iconAddImage}>
+        Add step image
+      </Button>
     )
   }
-
-  const hasCurrentImage = processedAt !== undefined
 
   return (
     <div className={styles.container}>
@@ -135,25 +253,18 @@ const ImageUpload: FC<ImageUploadProps> = ({
         aria-label="Upload image"
       />
 
-      {renderPreview()}
+      {renderContent()}
 
       {error && (
         <div className={styles.error} role="alert">
-          <span>{error}</span>
-          <Button onClick={handleRetry} variant="outline" ariaLabel="Retry">
+          <span aria-hidden="true" className={styles.errorDot}>
+            ●
+          </span>
+          <span className={styles.errorText}>{error}</span>
+          <Button onClick={handleRetry} variant="outline" size="sm" ariaLabel="Retry">
             Retry
           </Button>
         </div>
-      )}
-
-      {hasCurrentImage && !preview ? (
-        <Button onClick={handleClick} ariaLabel="Replace image" variant="outline">
-          Replace
-        </Button>
-      ) : (
-        <Button onClick={handleClick} variant="solid">
-          Upload
-        </Button>
       )}
 
       <div aria-live="polite" className="sr-only" />

--- a/src/components/IngredientList/IngredientList.module.css
+++ b/src/components/IngredientList/IngredientList.module.css
@@ -6,6 +6,9 @@
    footprint instead of literally matching the single-field width. */
 
 .container {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
@@ -92,9 +95,16 @@
   cursor: not-allowed;
 }
 
-.container .addButton {
+/* `button.addButton` (element + class, not `.container .addButton`): the
+   button is now a sibling after the `<ul>` rather than a flex child of it
+   — a `<ul>` can only contain `<li>` rows per HTML list semantics. The
+   element qualifier keeps specificity above Button's own bare `.button`/
+   `.outline` regardless of CSS import order (same fix as Tag.module.css's
+   `button.tag`). margin-top reproduces the gap the flex column used to
+   provide between the last row and this button. */
+button.addButton {
   width: auto;
-  align-self: flex-start;
+  margin-top: var(--space-3);
   padding: 9px var(--space-4);
   font-size: 13.5px;
   font-weight: var(--font-weight-medium);

--- a/src/components/IngredientList/IngredientList.module.css
+++ b/src/components/IngredientList/IngredientList.module.css
@@ -1,3 +1,10 @@
+/* IngredientList.module.css — restyled per docs/design/paper/pages/
+   Admin Recipe Editor.dc.html's ingredient row (Qty + Name fields, 3
+   square icon-buttons). The design's mock only shows a single "Qty"
+   field (96px) — this codebase's Ingredient model splits that into
+   `quantity`/`unit`, so those two share roughly the same combined
+   footprint instead of literally matching the single-field width. */
+
 .container {
   display: flex;
   flex-direction: column;
@@ -8,55 +15,87 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-areas:
-    "item item"
-    "quantity unit"
-    "actions actions";
+    'item item'
+    'quantity unit'
+    'actions actions';
   gap: var(--space-2);
   align-items: center;
 }
 
-.input {
-  width: 100%;
-  box-sizing: border-box;
-  padding: var(--space-2) var(--space-3);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-  color: var(--color-text);
-  font-size: var(--font-size-base);
-  font-family: var(--font-sans);
-}
-
-.input:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-}
-
-.quantityInput {
+.quantityField {
   grid-area: quantity;
 }
 
-.unitInput {
+.unitField {
   grid-area: unit;
 }
 
-.itemInput {
+.itemField {
   grid-area: item;
+}
+
+@media (min-width: 768px) {
+  .row {
+    grid-template-columns: 4.5rem 4.5rem 1fr auto;
+    grid-template-areas: 'quantity unit item actions';
+  }
 }
 
 .actions {
   grid-area: actions;
   display: flex;
-  gap: var(--space-1);
+  gap: var(--space-2);
 }
 
-.actionButton {
-  min-width: 44px;
-  min-height: 44px;
+/* Bare single-class rules carrying `composes` — CSS Modules only allows
+   `composes` on a plain single local-class selector, not a compound/
+   descendant one. `.moveAction`/`.removeAction` are additive classes
+   (joined with `.actionButton` in the component) so each icon button
+   picks up exactly one hover treatment: reordering buttons get the
+   neutral hover, remove gets the danger hover — never both on the same
+   element, so there's no same-specificity `:hover` rule to referee. */
+.moveAction {
+  composes: iconButtonHover from '../../styles/interactions.module.css';
 }
 
-@media (min-width: 768px) {
-  .row {
-    grid-template-columns: 5rem 5rem 1fr auto;
-    grid-template-areas: "quantity unit item actions";
-  }
+.removeAction {
+  composes: dangerIconButtonHover from '../../styles/interactions.module.css';
+}
+
+/* Descendant-scoped (not a bare `.actionButton` rule) to safely out-rank
+   Button's own `.button`/`.outline` single-class selectors regardless of
+   CSS import order — same specificity-tie fix as RecipeList.module.css's
+   `.rowActions .actionButton`. */
+.actions .actionButton {
+  width: 30px;
+  height: 30px;
+  min-width: 0;
+  min-height: 0;
+  flex-shrink: 0;
+  padding: 0;
+  /* 8px: design literal (Admin Recipe Editor.dc.html `.iconbtn`) —
+     --radius-sm (6px) is the nearest token but is 2px off. */
+  border-radius: 8px;
+  border-color: var(--color-border);
+  background: var(--color-field);
+  color: var(--color-text-muted);
+}
+
+.actions .actionButton svg {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+}
+
+.actions .actionButton:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.container .addButton {
+  width: auto;
+  align-self: flex-start;
+  padding: 9px var(--space-4);
+  font-size: 13.5px;
+  font-weight: var(--font-weight-medium);
 }

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -99,68 +99,70 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
   }
 
   return (
-    <div className={styles.container}>
-      {ingredients.map((ingredient, index) => (
-        <div key={index} className={styles.row}>
-          <div className={styles.quantityField}>
-            <Input
-              ariaLabel={`Ingredient ${index + 1} quantity`}
-              placeholder="Qty"
-              value={ingredient.quantity}
-              onChange={(e) => handleFieldChange(index, 'quantity', e.target.value)}
-            />
-          </div>
-          <div className={styles.unitField}>
-            <Input
-              ariaLabel={`Ingredient ${index + 1} unit`}
-              placeholder="Unit"
-              value={ingredient.unit}
-              onChange={(e) => handleFieldChange(index, 'unit', e.target.value)}
-            />
-          </div>
-          <div className={styles.itemField}>
-            <Input
-              ariaLabel={`Ingredient ${index + 1} item`}
-              placeholder="Ingredient"
-              value={ingredient.item}
-              onChange={(e) => handleFieldChange(index, 'item', e.target.value)}
-            />
-          </div>
-          <div className={styles.actions}>
-            <Button
-              onClick={() => handleMoveUp(index)}
-              ariaLabel={`Move up ingredient ${index + 1}`}
-              variant="outline"
-              disabled={index === 0}
-              className={`${styles.actionButton} ${styles.moveAction}`}
-            >
-              {iconChevronUp}
-            </Button>
-            <Button
-              onClick={() => handleMoveDown(index)}
-              ariaLabel={`Move down ingredient ${index + 1}`}
-              variant="outline"
-              disabled={index === ingredients.length - 1}
-              className={`${styles.actionButton} ${styles.moveAction}`}
-            >
-              {iconChevronDown}
-            </Button>
-            <Button
-              onClick={() => handleRemove(index)}
-              ariaLabel={`Remove ingredient ${index + 1}`}
-              variant="outline"
-              disabled={ingredients.length <= 1}
-              className={`${styles.actionButton} ${styles.removeAction}`}
-            >
-              {iconRemove}
-            </Button>
-          </div>
-        </div>
-      ))}
+    <>
+      <ul className={styles.container}>
+        {ingredients.map((ingredient, index) => (
+          <li key={index} className={styles.row}>
+            <div className={styles.quantityField}>
+              <Input
+                ariaLabel={`Ingredient ${index + 1} quantity`}
+                placeholder="Qty"
+                value={ingredient.quantity}
+                onChange={(e) => handleFieldChange(index, 'quantity', e.target.value)}
+              />
+            </div>
+            <div className={styles.unitField}>
+              <Input
+                ariaLabel={`Ingredient ${index + 1} unit`}
+                placeholder="Unit"
+                value={ingredient.unit}
+                onChange={(e) => handleFieldChange(index, 'unit', e.target.value)}
+              />
+            </div>
+            <div className={styles.itemField}>
+              <Input
+                ariaLabel={`Ingredient ${index + 1} item`}
+                placeholder="Ingredient"
+                value={ingredient.item}
+                onChange={(e) => handleFieldChange(index, 'item', e.target.value)}
+              />
+            </div>
+            <div className={styles.actions}>
+              <Button
+                onClick={() => handleMoveUp(index)}
+                ariaLabel={`Move up ingredient ${index + 1}`}
+                variant="outline"
+                disabled={index === 0}
+                className={`${styles.actionButton} ${styles.moveAction}`}
+              >
+                {iconChevronUp}
+              </Button>
+              <Button
+                onClick={() => handleMoveDown(index)}
+                ariaLabel={`Move down ingredient ${index + 1}`}
+                variant="outline"
+                disabled={index === ingredients.length - 1}
+                className={`${styles.actionButton} ${styles.moveAction}`}
+              >
+                {iconChevronDown}
+              </Button>
+              <Button
+                onClick={() => handleRemove(index)}
+                ariaLabel={`Remove ingredient ${index + 1}`}
+                variant="outline"
+                disabled={ingredients.length <= 1}
+                className={`${styles.actionButton} ${styles.removeAction}`}
+              >
+                {iconRemove}
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
       <Button onClick={handleAdd} variant="outline" iconLeft={iconPlus} className={styles.addButton}>
         Add ingredient
       </Button>
-    </div>
+    </>
   )
 }
 

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -1,4 +1,5 @@
 import Button from '@components/Button'
+import Input from '@components/Input'
 import { useReorderableList } from '@hooks/useReorderableList'
 import type { Ingredient } from '@models/recipe'
 import type { FC } from 'react'
@@ -10,6 +11,65 @@ export interface IngredientListProps {
   onChange: (ingredients: Ingredient[]) => void
   onAnnounce?: (message: string) => void
 }
+
+const iconChevronUp = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="m18 15-6-6-6 6" />
+  </svg>
+)
+
+const iconChevronDown = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="m6 9 6 6 6-6" />
+  </svg>
+)
+
+const iconRemove = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </svg>
+)
+
+const iconPlus = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.2"
+    strokeLinecap="round"
+    aria-hidden="true"
+  >
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+)
 
 const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnnounce }) => {
   const { add, remove, update, moveUp, moveDown } = useReorderableList(ingredients, onChange)
@@ -42,71 +102,62 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
     <div className={styles.container}>
       {ingredients.map((ingredient, index) => (
         <div key={index} className={styles.row}>
-          <label className={styles.quantityInput}>
-            <span className="sr-only">Quantity</span>
-            <input
-              type="text"
-              aria-label={`Ingredient ${index + 1} quantity`}
+          <div className={styles.quantityField}>
+            <Input
+              ariaLabel={`Ingredient ${index + 1} quantity`}
               placeholder="Qty"
               value={ingredient.quantity}
               onChange={(e) => handleFieldChange(index, 'quantity', e.target.value)}
-              className={[styles.input, styles.quantityInput].join(' ')}
             />
-          </label>
-          <label className={styles.unitInput}>
-            <span className="sr-only">Unit</span>
-            <input
-              type="text"
-              aria-label={`Ingredient ${index + 1} unit`}
+          </div>
+          <div className={styles.unitField}>
+            <Input
+              ariaLabel={`Ingredient ${index + 1} unit`}
               placeholder="Unit"
               value={ingredient.unit}
               onChange={(e) => handleFieldChange(index, 'unit', e.target.value)}
-              className={[styles.input, styles.unitInput].join(' ')}
             />
-          </label>
-          <label className={styles.itemInput}>
-            <span className="sr-only">Item</span>
-            <input
-              type="text"
-              aria-label={`Ingredient ${index + 1} item`}
+          </div>
+          <div className={styles.itemField}>
+            <Input
+              ariaLabel={`Ingredient ${index + 1} item`}
               placeholder="Ingredient"
               value={ingredient.item}
               onChange={(e) => handleFieldChange(index, 'item', e.target.value)}
-              className={[styles.input, styles.itemInput].join(' ')}
             />
-          </label>
+          </div>
           <div className={styles.actions}>
             <Button
               onClick={() => handleMoveUp(index)}
               ariaLabel={`Move up ingredient ${index + 1}`}
               variant="outline"
               disabled={index === 0}
-              className={styles.actionButton}
+              className={`${styles.actionButton} ${styles.moveAction}`}
             >
-              ↑
+              {iconChevronUp}
             </Button>
             <Button
               onClick={() => handleMoveDown(index)}
               ariaLabel={`Move down ingredient ${index + 1}`}
               variant="outline"
               disabled={index === ingredients.length - 1}
-              className={styles.actionButton}
+              className={`${styles.actionButton} ${styles.moveAction}`}
             >
-              ↓
+              {iconChevronDown}
             </Button>
             <Button
               onClick={() => handleRemove(index)}
               ariaLabel={`Remove ingredient ${index + 1}`}
               variant="outline"
               disabled={ingredients.length <= 1}
-              className={styles.actionButton}
+              className={`${styles.actionButton} ${styles.removeAction}`}
             >
-              Remove
+              {iconRemove}
             </Button>
           </div>
         </div>
       ))}
-      <Button onClick={handleAdd} variant="outline">
+      <Button onClick={handleAdd} variant="outline" iconLeft={iconPlus} className={styles.addButton}>
         Add ingredient
       </Button>
     </div>

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -1,4 +1,5 @@
 import Button from '@components/Button'
+import { iconChevronDown, iconChevronUp, iconPlus, iconRemove } from '@components/icons'
 import Input from '@components/Input'
 import { useReorderableList } from '@hooks/useReorderableList'
 import type { Ingredient } from '@models/recipe'
@@ -11,65 +12,6 @@ export interface IngredientListProps {
   onChange: (ingredients: Ingredient[]) => void
   onAnnounce?: (message: string) => void
 }
-
-const iconChevronUp = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="m18 15-6-6-6 6" />
-  </svg>
-)
-
-const iconChevronDown = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="m6 9 6 6 6-6" />
-  </svg>
-)
-
-const iconRemove = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M18 6 6 18" />
-    <path d="m6 6 12 12" />
-  </svg>
-)
-
-const iconPlus = (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2.2"
-    strokeLinecap="round"
-    aria-hidden="true"
-  >
-    <line x1="12" y1="5" x2="12" y2="19" />
-    <line x1="5" y1="12" x2="19" y2="12" />
-  </svg>
-)
 
 const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnnounce }) => {
   const { add, remove, update, moveUp, moveDown } = useReorderableList(ingredients, onChange)

--- a/src/components/StepList/StepList.module.css
+++ b/src/components/StepList/StepList.module.css
@@ -1,94 +1,109 @@
+/* StepList.module.css — restyled per docs/design/paper/pages/Admin Recipe
+   Editor.dc.html's step card: bordered card, circular step-number badge
+   (mirrors RecipeSteps.module.css's `.number`, sized down for the denser
+   editor context), and the same 30x30 icon-button trio as
+   IngredientList.module.css. The icon-button geometry (~15 lines) is
+   duplicated rather than shared as a composable — only two consumers
+   exist today, each with its own `.actions` layout root, and the hover
+   *behaviors* (the part that actually risked drifting) already live in
+   the shared `iconButtonHover`/`dangerIconButtonHover` composables. */
+
 .container {
   display: flex;
   flex-direction: column;
-  gap: var(--space-12);
+  /* 14px: design literal (Admin Recipe Editor.dc.html's step list gap) —
+     no token lands exactly on it (--space-3 12px / --space-4 16px). */
+  gap: 14px;
 }
 
 .row {
-  display: grid;
-  grid-template-columns: 1.5rem 1fr;
-  grid-template-areas:
-    "number body"
-    ".      actions";
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  background: var(--color-field);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: var(--space-2);
-  align-items: flex-start;
+  /* 10px: design literal, between --space-2 (8px) and --space-3 (12px). */
+  margin-bottom: 10px;
 }
 
 .stepNumber {
-  grid-area: number;
-  font-weight: var(--font-weight-bold);
-  padding-top: var(--space-2);
-  text-align: center;
-}
-
-.body {
-  grid-area: body;
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
   display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  min-width: 0;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-primary);
 }
 
-@media (min-width: 768px) {
-  .row {
-    grid-template-columns: 1.5rem 1fr auto;
-    grid-template-areas: "number body actions";
-  }
+.actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.moveAction {
+  composes: iconButtonHover from '../../styles/interactions.module.css';
+}
+
+.removeAction {
+  composes: dangerIconButtonHover from '../../styles/interactions.module.css';
+}
+
+.actions .actionButton {
+  width: 30px;
+  height: 30px;
+  min-width: 0;
+  min-height: 0;
+  flex-shrink: 0;
+  padding: 0;
+  /* 8px: design literal — --radius-sm (6px) is the nearest token but is
+     2px off. */
+  border-radius: 8px;
+  border-color: var(--color-border);
+  background: var(--color-field);
+  color: var(--color-text-muted);
+}
+
+.actions .actionButton svg {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+}
+
+.actions .actionButton:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.row .textarea {
+  /* 8rem: design/product literal carried over from #198's "taller default
+     step textareas" fix — taller than Textarea's own 5rem default so a
+     multi-sentence step doesn't scroll internally. */
+  min-height: 8rem;
 }
 
 .imageBlock {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  margin-top: 10px;
 }
 
-.altInput {
-  width: 100%;
-  box-sizing: border-box;
-  padding: var(--space-2) var(--space-3);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-  color: var(--color-text);
-  font-size: var(--font-size-base);
-  font-family: var(--font-sans);
-}
-
-.altInput:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-}
-
-.textarea {
-  width: 100%;
-  box-sizing: border-box;
-  padding: var(--space-2) var(--space-3);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-  color: var(--color-text);
-  font-size: var(--font-size-base);
-  font-family: var(--font-sans);
-  resize: vertical;
-  min-height: 8rem;
-}
-
-.textarea:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-}
-
-.actions {
-  grid-area: actions;
-  display: flex;
-  gap: var(--space-1);
-}
-
-@media (min-width: 768px) {
-  .actions {
-    padding-top: var(--space-2);
-  }
-}
-
-.actionButton {
-  min-width: 44px;
-  min-height: 44px;
+.container .addButton {
+  width: auto;
+  align-self: flex-start;
+  padding: 9px var(--space-4);
+  font-size: 13.5px;
+  font-weight: var(--font-weight-medium);
 }

--- a/src/components/StepList/StepList.module.css
+++ b/src/components/StepList/StepList.module.css
@@ -9,6 +9,9 @@
    the shared `iconButtonHover`/`dangerIconButtonHover` composables. */
 
 .container {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   /* 14px: design literal (Admin Recipe Editor.dc.html's step list gap) —
@@ -100,9 +103,17 @@
   margin-top: 10px;
 }
 
-.container .addButton {
+/* `button.addButton` (element + class, not `.container .addButton`): the
+   button is now a sibling after the `<ul>` rather than a flex child of it
+   — a `<ul>` can only contain `<li>` rows per HTML list semantics. The
+   element qualifier keeps specificity above Button's own bare `.button`/
+   `.outline` regardless of CSS import order (same fix as Tag.module.css's
+   `button.tag`, see IngredientList.module.css's identical `.addButton`
+   for the sibling component). margin-top reproduces the gap the flex
+   column used to provide between the last row and this button. */
+button.addButton {
   width: auto;
-  align-self: flex-start;
+  margin-top: 14px;
   padding: 9px var(--space-4);
   font-size: 13.5px;
   font-weight: var(--font-weight-medium);

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -85,7 +85,10 @@ describe('StepList', () => {
         />
       )
 
-      await user.click(screen.getByRole('button', { name: /add step/i }))
+      // Tightened to an exact match: with a getToken prop, each row also
+      // renders ImageUpload's own "+ Add step image" button, whose
+      // accessible name is otherwise also matched by a loose /add step/i.
+      await user.click(screen.getByRole('button', { name: /^add step$/i }))
 
       expect(onChange).toHaveBeenCalledWith([
         ...twoSteps,
@@ -194,7 +197,9 @@ describe('StepList', () => {
         />
       )
 
-      const uploadButtons = screen.getAllByRole('button', { name: /^upload$/i })
+      // ImageUpload's step-image control now has an accessible name of
+      // "Add step image" rather than a generic "Upload".
+      const uploadButtons = screen.getAllByRole('button', { name: /^add step image$/i })
       expect(uploadButtons).toHaveLength(2)
 
       expect(screen.getByLabelText('Step 1 image alt text')).toBeInTheDocument()
@@ -234,7 +239,12 @@ describe('StepList', () => {
         />
       )
 
-      expect(screen.getByText(/processing image/i)).toBeInTheDocument()
+      // NEW (#228): without a prior upload attempt in this session, an
+      // unset processedAt now renders the empty "Add step image" control
+      // rather than the processing placeholder — see ImageUpload's own
+      // render-branch tests for the case where the placeholder legitimately
+      // shows (an upload genuinely in flight).
+      expect(screen.getByRole('button', { name: /^add step image$/i })).toBeInTheDocument()
       expect(screen.queryByRole('img')).not.toBeInTheDocument()
 
       const readyStep: Step = {
@@ -254,7 +264,9 @@ describe('StepList', () => {
       )
 
       expect(screen.getByRole('img')).toBeInTheDocument()
-      expect(screen.queryByText(/processing image/i)).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: /^add step image$/i })
+      ).not.toBeInTheDocument()
     })
 
     it('typing in the alt-text input calls onChange with the updated step (no key field)', async () => {

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -185,7 +185,7 @@ describe('StepList', () => {
   })
 
   describe('per-step image upload (when getToken is provided)', () => {
-    it('renders an image upload control and an alt-text input per step', () => {
+    it('renders an image upload control per step, with no alt-text input until the image is ready', () => {
       const onChange = vi.fn()
       render(
         <StepList
@@ -201,6 +201,29 @@ describe('StepList', () => {
       // "Add step image" rather than a generic "Upload".
       const uploadButtons = screen.getAllByRole('button', { name: /^add step image$/i })
       expect(uploadButtons).toHaveLength(2)
+
+      // NEW (#228): mirrors the cover image's alt field — the alt-text input
+      // only appears once the step image has finished processing (imgReady),
+      // never alongside the "Add step image" ghost button (imgEmpty).
+      expect(screen.queryByLabelText('Step 1 image alt text')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Step 2 image alt text')).not.toBeInTheDocument()
+    })
+
+    it('renders the alt-text input per step once each step image is ready', () => {
+      const onChange = vi.fn()
+      const readySteps: Step[] = [
+        { stepId: STEP_ID_1, order: 1, text: 'Preheat oven', image: { alt: '', processedAt: 111 } },
+        { stepId: STEP_ID_2, order: 2, text: 'Mix ingredients', image: { alt: '', processedAt: 222 } },
+      ]
+      render(
+        <StepList
+          steps={readySteps}
+          onChange={onChange}
+          getToken={mockGetToken}
+          recipeId="test-recipe-id"
+          slug="beans-on-toast"
+        />
+      )
 
       expect(screen.getByLabelText('Step 1 image alt text')).toBeInTheDocument()
       expect(screen.getByLabelText('Step 2 image alt text')).toBeInTheDocument()
@@ -272,9 +295,15 @@ describe('StepList', () => {
     it('typing in the alt-text input calls onChange with the updated step (no key field)', async () => {
       const user = userEvent.setup()
       const onChange = vi.fn()
+      const step: Step = {
+        stepId: STEP_ID_1,
+        order: 1,
+        text: 'Preheat oven',
+        image: { alt: '', processedAt: 111 },
+      }
       render(
         <StepList
-          steps={[makeStep(STEP_ID_1, 1, 'Preheat oven')]}
+          steps={[step]}
           onChange={onChange}
           getToken={mockGetToken}
           recipeId="test-recipe-id"

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -292,7 +292,7 @@ describe('StepList', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('typing in the alt-text input calls onChange with the updated step (no key field)', async () => {
+    it('typing in the alt-text input calls onChange with the updated step, preserving processedAt', async () => {
       const user = userEvent.setup()
       const onChange = vi.fn()
       const step: Step = {
@@ -315,7 +315,7 @@ describe('StepList', () => {
       await user.type(altInput, 'A')
 
       expect(onChange).toHaveBeenCalledWith([
-        { stepId: STEP_ID_1, order: 1, text: 'Preheat oven', image: { alt: 'A' } },
+        { stepId: STEP_ID_1, order: 1, text: 'Preheat oven', image: { alt: 'A', processedAt: 111 } },
       ])
     })
   })

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -1,4 +1,5 @@
 import Button from '@components/Button'
+import { iconChevronDown, iconChevronUp, iconPlus, iconRemove } from '@components/icons'
 import ImageUpload from '@components/ImageUpload'
 import Input from '@components/Input'
 import Textarea from '@components/Textarea'
@@ -18,65 +19,6 @@ export interface StepListProps {
   onStepUploadStarted?: (stepId: string) => void
   onStepUploadCompleted?: (stepId: string) => void
 }
-
-const iconChevronUp = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="m18 15-6-6-6 6" />
-  </svg>
-)
-
-const iconChevronDown = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="m6 9 6 6 6-6" />
-  </svg>
-)
-
-const iconRemove = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M18 6 6 18" />
-    <path d="m6 6 12 12" />
-  </svg>
-)
-
-const iconPlus = (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2.2"
-    strokeLinecap="round"
-    aria-hidden="true"
-  >
-    <line x1="12" y1="5" x2="12" y2="19" />
-    <line x1="5" y1="12" x2="19" y2="12" />
-  </svg>
-)
 
 const renumber = (steps: Step[]): Step[] =>
   steps.map((step, i) => ({ ...step, order: i + 1 }))

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -194,12 +194,14 @@ const StepList: FC<StepListProps> = ({
                   onUploadStarted={() => onStepUploadStarted?.(step.stepId)}
                   onUploadCompleted={() => handleStepImageUploaded(index)}
                 />
-                <Input
-                  ariaLabel={`Step ${index + 1} image alt text`}
-                  placeholder="Alt text for this image"
-                  value={step.image?.alt ?? ''}
-                  onChange={(e) => updateImage(index, { alt: e.target.value })}
-                />
+                {step.image?.processedAt !== undefined && (
+                  <Input
+                    ariaLabel={`Step ${index + 1} image alt text`}
+                    placeholder="Alt text for this image"
+                    value={step.image?.alt ?? ''}
+                    onChange={(e) => updateImage(index, { alt: e.target.value })}
+                  />
+                )}
               </div>
             )}
           </li>

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -139,74 +139,76 @@ const StepList: FC<StepListProps> = ({
   }
 
   return (
-    <div className={styles.container}>
-      {steps.map((step, index) => (
-        <div key={step.stepId} className={styles.row}>
-          <div className={styles.header}>
-            <span className={styles.stepNumber}>{index + 1}</span>
-            <div className={styles.actions}>
-              <Button
-                onClick={() => handleMoveUp(index)}
-                ariaLabel={`Move up step ${index + 1}`}
-                variant="outline"
-                disabled={index === 0}
-                className={`${styles.actionButton} ${styles.moveAction}`}
-              >
-                {iconChevronUp}
-              </Button>
-              <Button
-                onClick={() => handleMoveDown(index)}
-                ariaLabel={`Move down step ${index + 1}`}
-                variant="outline"
-                disabled={index === steps.length - 1}
-                className={`${styles.actionButton} ${styles.moveAction}`}
-              >
-                {iconChevronDown}
-              </Button>
-              <Button
-                onClick={() => handleRemove(index)}
-                ariaLabel={`Remove step ${index + 1}`}
-                variant="outline"
-                disabled={steps.length <= 1}
-                className={`${styles.actionButton} ${styles.removeAction}`}
-              >
-                {iconRemove}
-              </Button>
+    <>
+      <ul className={styles.container}>
+        {steps.map((step, index) => (
+          <li key={step.stepId} className={styles.row}>
+            <div className={styles.header}>
+              <span className={styles.stepNumber}>{index + 1}</span>
+              <div className={styles.actions}>
+                <Button
+                  onClick={() => handleMoveUp(index)}
+                  ariaLabel={`Move up step ${index + 1}`}
+                  variant="outline"
+                  disabled={index === 0}
+                  className={`${styles.actionButton} ${styles.moveAction}`}
+                >
+                  {iconChevronUp}
+                </Button>
+                <Button
+                  onClick={() => handleMoveDown(index)}
+                  ariaLabel={`Move down step ${index + 1}`}
+                  variant="outline"
+                  disabled={index === steps.length - 1}
+                  className={`${styles.actionButton} ${styles.moveAction}`}
+                >
+                  {iconChevronDown}
+                </Button>
+                <Button
+                  onClick={() => handleRemove(index)}
+                  ariaLabel={`Remove step ${index + 1}`}
+                  variant="outline"
+                  disabled={steps.length <= 1}
+                  className={`${styles.actionButton} ${styles.removeAction}`}
+                >
+                  {iconRemove}
+                </Button>
+              </div>
             </div>
-          </div>
-          <Textarea
-            ariaLabel={`Step ${index + 1} text`}
-            placeholder="Describe this step…"
-            value={step.text}
-            onChange={(e) => handleTextChange(index, e.target.value)}
-            className={styles.textarea}
-          />
-          {getToken && (
-            <div className={styles.imageBlock}>
-              <ImageUpload
-                recipeId={recipeId}
-                slug={slug}
-                imageType={stepImageType(step.stepId)}
-                currentAlt={step.image?.alt}
-                processedAt={step.image?.processedAt}
-                getToken={getToken}
-                onUploadStarted={() => onStepUploadStarted?.(step.stepId)}
-                onUploadCompleted={() => handleStepImageUploaded(index)}
-              />
-              <Input
-                ariaLabel={`Step ${index + 1} image alt text`}
-                placeholder="Alt text for this image"
-                value={step.image?.alt ?? ''}
-                onChange={(e) => updateImage(index, { alt: e.target.value })}
-              />
-            </div>
-          )}
-        </div>
-      ))}
+            <Textarea
+              ariaLabel={`Step ${index + 1} text`}
+              placeholder="Describe this step…"
+              value={step.text}
+              onChange={(e) => handleTextChange(index, e.target.value)}
+              className={styles.textarea}
+            />
+            {getToken && (
+              <div className={styles.imageBlock}>
+                <ImageUpload
+                  recipeId={recipeId}
+                  slug={slug}
+                  imageType={stepImageType(step.stepId)}
+                  currentAlt={step.image?.alt}
+                  processedAt={step.image?.processedAt}
+                  getToken={getToken}
+                  onUploadStarted={() => onStepUploadStarted?.(step.stepId)}
+                  onUploadCompleted={() => handleStepImageUploaded(index)}
+                />
+                <Input
+                  ariaLabel={`Step ${index + 1} image alt text`}
+                  placeholder="Alt text for this image"
+                  value={step.image?.alt ?? ''}
+                  onChange={(e) => updateImage(index, { alt: e.target.value })}
+                />
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
       <Button onClick={handleAdd} variant="outline" iconLeft={iconPlus} className={styles.addButton}>
         Add step
       </Button>
-    </div>
+    </>
   )
 }
 

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -105,7 +105,7 @@ const StepList: FC<StepListProps> = ({
     const existing = steps[index].image
     update(index, {
       ...steps[index],
-      image: { alt: existing?.alt ?? '', ...patch },
+      image: { ...existing, alt: existing?.alt ?? '', ...patch },
     })
   }
 

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -1,5 +1,7 @@
 import Button from '@components/Button'
 import ImageUpload from '@components/ImageUpload'
+import Input from '@components/Input'
+import Textarea from '@components/Textarea'
 import { useReorderableList } from '@hooks/useReorderableList'
 import { stepImageType, type RecipeImage, type Step } from '@models/recipe'
 import { useCallback, type FC } from 'react'
@@ -16,6 +18,65 @@ export interface StepListProps {
   onStepUploadStarted?: (stepId: string) => void
   onStepUploadCompleted?: (stepId: string) => void
 }
+
+const iconChevronUp = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="m18 15-6-6-6 6" />
+  </svg>
+)
+
+const iconChevronDown = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="m6 9 6 6 6-6" />
+  </svg>
+)
+
+const iconRemove = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </svg>
+)
+
+const iconPlus = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.2"
+    strokeLinecap="round"
+    aria-hidden="true"
+  >
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+)
 
 const renumber = (steps: Step[]): Step[] =>
   steps.map((step, i) => ({ ...step, order: i + 1 }))
@@ -81,69 +142,68 @@ const StepList: FC<StepListProps> = ({
     <div className={styles.container}>
       {steps.map((step, index) => (
         <div key={step.stepId} className={styles.row}>
-          <span className={styles.stepNumber}>{index + 1}</span>
-          <div className={styles.body}>
-            <textarea
-              aria-label={`Step ${index + 1} text`}
-              value={step.text}
-              onChange={(e) => handleTextChange(index, e.target.value)}
-              className={styles.textarea}
-            />
-            {getToken && (
-              <div className={styles.imageBlock}>
-                <ImageUpload
-                  recipeId={recipeId}
-                  slug={slug}
-                  imageType={stepImageType(step.stepId)}
-                  currentAlt={step.image?.alt}
-                  processedAt={step.image?.processedAt}
-                  getToken={getToken}
-                  onUploadStarted={() => onStepUploadStarted?.(step.stepId)}
-                  onUploadCompleted={() => handleStepImageUploaded(index)}
-                />
-                <input
-                  type="text"
-                  aria-label={`Step ${index + 1} image alt text`}
-                  placeholder="Image alt text"
-                  value={step.image?.alt ?? ''}
-                  onChange={(e) => updateImage(index, { alt: e.target.value })}
-                  className={styles.altInput}
-                />
-              </div>
-            )}
+          <div className={styles.header}>
+            <span className={styles.stepNumber}>{index + 1}</span>
+            <div className={styles.actions}>
+              <Button
+                onClick={() => handleMoveUp(index)}
+                ariaLabel={`Move up step ${index + 1}`}
+                variant="outline"
+                disabled={index === 0}
+                className={`${styles.actionButton} ${styles.moveAction}`}
+              >
+                {iconChevronUp}
+              </Button>
+              <Button
+                onClick={() => handleMoveDown(index)}
+                ariaLabel={`Move down step ${index + 1}`}
+                variant="outline"
+                disabled={index === steps.length - 1}
+                className={`${styles.actionButton} ${styles.moveAction}`}
+              >
+                {iconChevronDown}
+              </Button>
+              <Button
+                onClick={() => handleRemove(index)}
+                ariaLabel={`Remove step ${index + 1}`}
+                variant="outline"
+                disabled={steps.length <= 1}
+                className={`${styles.actionButton} ${styles.removeAction}`}
+              >
+                {iconRemove}
+              </Button>
+            </div>
           </div>
-          <div className={styles.actions}>
-            <Button
-              onClick={() => handleMoveUp(index)}
-              ariaLabel={`Move up step ${index + 1}`}
-              variant="outline"
-              disabled={index === 0}
-              className={styles.actionButton}
-            >
-              ↑
-            </Button>
-            <Button
-              onClick={() => handleMoveDown(index)}
-              ariaLabel={`Move down step ${index + 1}`}
-              variant="outline"
-              disabled={index === steps.length - 1}
-              className={styles.actionButton}
-            >
-              ↓
-            </Button>
-            <Button
-              onClick={() => handleRemove(index)}
-              ariaLabel={`Remove step ${index + 1}`}
-              variant="outline"
-              disabled={steps.length <= 1}
-              className={styles.actionButton}
-            >
-              Remove
-            </Button>
-          </div>
+          <Textarea
+            ariaLabel={`Step ${index + 1} text`}
+            placeholder="Describe this step…"
+            value={step.text}
+            onChange={(e) => handleTextChange(index, e.target.value)}
+            className={styles.textarea}
+          />
+          {getToken && (
+            <div className={styles.imageBlock}>
+              <ImageUpload
+                recipeId={recipeId}
+                slug={slug}
+                imageType={stepImageType(step.stepId)}
+                currentAlt={step.image?.alt}
+                processedAt={step.image?.processedAt}
+                getToken={getToken}
+                onUploadStarted={() => onStepUploadStarted?.(step.stepId)}
+                onUploadCompleted={() => handleStepImageUploaded(index)}
+              />
+              <Input
+                ariaLabel={`Step ${index + 1} image alt text`}
+                placeholder="Alt text for this image"
+                value={step.image?.alt ?? ''}
+                onChange={(e) => updateImage(index, { alt: e.target.value })}
+              />
+            </div>
+          )}
         </div>
       ))}
-      <Button onClick={handleAdd} variant="outline">
+      <Button onClick={handleAdd} variant="outline" iconLeft={iconPlus} className={styles.addButton}>
         Add step
       </Button>
     </div>

--- a/src/components/TagInput/TagInput.module.css
+++ b/src/components/TagInput/TagInput.module.css
@@ -1,13 +1,13 @@
-/* TagInput.module.css — chips reuse the shipped Tag component's chip look
-   (composes, rather than duplicating its declarations); the field row
-   shares Input's `.ds-field` treatment; suggestions restyle to the
-   design's dashed mono pill row. The suggestion list keeps its existing
-   `role="listbox"`/`role="option"` markup (TagInput.tsx is out of scope
-   to restructure) but renders as a static inline-flow row rather than an
-   absolutely-positioned popup — that's a pure CSS layout choice (ARIA
-   listbox semantics don't require a floating popup) and matches the
-   design's inline suggestion-chips row (TagInput.jsx), rather than the
-   dropdown look this stub previously had. */
+/* TagInput.module.css — chips now render via the actual shared `Tag`
+   component (`as="span" removable`) rather than hand-rolled chip markup,
+   so Tag owns the base look; the field row shares Input's `.ds-field`
+   treatment; suggestions restyle to the design's dashed mono pill row.
+   The suggestion list keeps its existing `role="listbox"`/`role="option"`
+   markup (TagInput.tsx is out of scope to restructure) but renders as a
+   static inline-flow row rather than an absolutely-positioned popup —
+   that's a pure CSS layout choice (ARIA listbox semantics don't require
+   a floating popup) and matches the design's inline suggestion-chips row
+   (TagInput.jsx), rather than the dropdown look this stub previously had. */
 
 .container {
   display: flex;
@@ -21,30 +21,32 @@
   gap: var(--space-2);
 }
 
-.chip {
-  composes: tag from '../Tag/Tag.module.css';
+/* Tag's own padding (--space-1/--space-3, symmetric) and radius
+   (--radius-sm, 6px) are close but not an exact match for this design's
+   literal chip shape (5px 7px 5px 11px asymmetric padding, 8px radius) —
+   scoped under `.chips` so it reliably outranks Tag's own bare `.tag`
+   class regardless of CSS import order, same specificity-tie fix used
+   throughout this epic. */
+.chips .chip {
+  padding: 5px 7px 5px 11px;
+  border-radius: 8px;
 }
 
-/* Overrides the Button component's `.button`/`.outline` styles (border,
-   padding, radius-md) to match Tag's own borderless `.remove` control —
-   descendant selector beats Button's single-class selectors on
-   specificity alone, so this doesn't depend on CSS import order or need
-   `!important`. */
-.chip .removeBtn {
-  border: none;
-  background: transparent;
+/* Targets Tag's internally-rendered remove `<button>` by element type,
+   not by class — Tag.module.css's `.remove` class name is scoped to that
+   module and isn't reachable from here, but plain type selectors aren't
+   hashed by CSS Modules. Mirrors the design's own `.chip button` /
+   `.chip button:hover` rules exactly (Admin Recipe Editor.dc.html's
+   `.chip` styles). Tag's default `.remove { color: inherit }` has no
+   hover treatment of its own (most Tag consumers don't want a red tint),
+   so both the faint resting color and the hover-to-error tint are
+   supplied here. */
+.chips .chip button {
   color: var(--color-text-faint);
-  min-width: 24px;
-  min-height: 24px;
-  padding: 0;
-  font-size: var(--font-size-sm);
-  line-height: 1;
 }
 
-.chip .removeBtn:hover {
-  border: none;
-  background: transparent;
-  color: var(--color-text-muted);
+.chips .chip button:hover {
+  color: var(--color-error);
 }
 
 .inputWrapper {

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -1,6 +1,5 @@
-import Button from '@components/Button'
+import Tag from '@components/Tag'
 import { useId, useState, type FC, type KeyboardEvent } from 'react'
-
 
 import styles from './TagInput.module.css'
 
@@ -54,17 +53,9 @@ const TagInput: FC<TagInputProps> = ({
     <div className={styles.container}>
       <div className={styles.chips}>
         {tags.map((tag, i) => (
-          <span key={tag} className={styles.chip}>
+          <Tag key={tag} removable onRemove={() => removeTag(i)} className={styles.chip}>
             {tag}
-            <Button
-              onClick={() => removeTag(i)}
-              ariaLabel={`Remove ${tag}`}
-              variant="outline"
-              className={styles.removeBtn}
-            >
-              &times;
-            </Button>
-          </span>
+          </Tag>
         ))}
       </div>
 

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,87 @@
+import type { FC } from 'react'
+
+export const iconChevronUp = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="m18 15-6-6-6 6" />
+  </svg>
+)
+
+export const iconChevronDown = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="m6 9 6 6 6-6" />
+  </svg>
+)
+
+export const iconRemove = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M18 6 6 18" />
+    <path d="m6 6 12 12" />
+  </svg>
+)
+
+export const iconPlus = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.2"
+    strokeLinecap="round"
+    aria-hidden="true"
+  >
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+)
+
+export interface IconAlertCircleProps {
+  size: number
+  // Optional because one caller (AutosaveStatus) already wraps this icon in
+  // an `aria-hidden="true"` span, so the svg itself carried no attribute;
+  // the other (RecipeEditor) set it directly on the svg. Preserved per call
+  // site rather than defaulted so neither render output changes.
+  ariaHidden?: boolean
+}
+
+export const IconAlertCircle: FC<IconAlertCircleProps> = ({ size, ariaHidden }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden={ariaHidden || undefined}
+  >
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="8" x2="12" y2="12" />
+    <line x1="12" y1="16" x2="12.01" y2="16" />
+  </svg>
+)

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -1,153 +1,436 @@
-.loadingWrapper {
-  display: flex;
-  justify-content: center;
-  padding: var(--space-12) 0;
-}
-
+/* Matches the design's admin `<main>` column exactly (Admin Recipe
+   Editor.dc.html line 112) — the shared AdminLayout `<main>` sets no
+   max-width of its own, each admin page supplies it, same as
+   RecipeList.module.css's `.page`. */
 .container {
-  max-width: 48rem;
-  margin: 0 auto;
-  padding: var(--space-6);
+  max-width: var(--max-w-site);
+  margin-inline: auto;
+  padding: clamp(22px, 4vw, 36px) clamp(20px, 5vw, 28px) 72px;
+  box-sizing: border-box;
 }
 
-.form {
+.loadingBox {
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: clamp(64px, 12vw, 120px) 24px;
+  text-align: center;
   display: flex;
   flex-direction: column;
-  gap: var(--space-10);
-}
-
-.section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-6);
-}
-
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-.input {
-  padding: var(--space-2) var(--space-3);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-  color: var(--color-text);
-  font-size: var(--font-size-base);
-  font-family: var(--font-sans);
-}
-
-.input:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-}
-
-.textarea {
-  padding: var(--space-2) var(--space-3);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-  color: var(--color-text);
-  font-size: var(--font-size-base);
-  font-family: var(--font-sans);
-  resize: vertical;
-  min-height: 6rem;
-}
-
-.textarea:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-}
-
-.metadataRow {
-  display: flex;
-  gap: var(--space-4);
-}
-
-.numberInput {
-  width: 6rem;
-  padding: var(--space-2) var(--space-3);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-  color: var(--color-text);
-  font-size: var(--font-size-base);
-  font-family: var(--font-sans);
-}
-
-.numberInput:focus-visible {
-  outline: var(--border-width) solid var(--color-primary);
-}
-
-.error {
-  color: var(--color-error);
-  font-size: var(--font-size-sm);
-}
-
-.slugPreview {
-  margin: 0;
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-}
-
-.slugLockHint {
-  margin: 0;
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-  font-style: italic;
-}
-
-.slugError {
-  margin: 0;
-  color: var(--color-error);
-  font-size: var(--font-size-sm);
-}
-
-.actions {
-  display: flex;
-  gap: var(--space-3);
-  padding: var(--space-6) 0;
-}
-
-.header {
-  display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: var(--space-3);
-  margin-bottom: var(--space-4);
 }
 
-.backLink {
-  font-size: var(--font-size-sm);
-}
-
-.missingFieldsList {
-  margin: var(--space-2) 0 0;
-  padding-left: var(--space-6);
-}
+/* ── Banners ─────────────────────────────────────────────────────── */
 
 .sessionBanner {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  gap: 12px;
   justify-content: space-between;
-  gap: var(--space-4);
-  margin-bottom: var(--space-6);
-  padding: var(--space-4);
-  border: var(--border-width) solid var(--color-border);
   border-radius: var(--radius-lg);
-  background: var(--color-warning, var(--color-surface));
-  color: var(--color-text);
-  box-shadow: var(--shadow-sm);
+  /* 13px/16px: design literal, no --space-* pairing lands on 13px. */
+  padding: 13px 16px;
+  margin-bottom: var(--space-4);
+  background: var(--color-error-bg);
+  border: var(--border-width) solid color-mix(in srgb, var(--color-error) 34%, var(--color-border));
 }
 
 .timeoutBanner {
   display: flex;
   align-items: center;
-  gap: var(--space-4);
-  margin-bottom: var(--space-6);
-  padding: var(--space-4);
-  border: var(--border-width) solid var(--color-border);
+  gap: 10px;
   border-radius: var(--radius-lg);
-  background: var(--color-warning, var(--color-surface));
+  padding: 13px 16px;
+  margin-bottom: var(--space-4);
+  background: var(--color-warning-bg);
+  border: var(--border-width) solid color-mix(in srgb, var(--color-warning) 32%, var(--color-border));
+  font-size: 13.5px;
   color: var(--color-text);
-  box-shadow: var(--shadow-sm);
+}
+
+.bannerMessage {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13.5px;
+  color: var(--color-text);
+}
+
+.bannerIcon {
+  color: var(--color-error);
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.timeoutSpinner {
+  composes: spinner spinnerSm from '../../../styles/interactions.module.css';
+  flex-shrink: 0;
+  border-top-color: var(--color-warning);
+}
+
+/* .sessionBanner .bannerAction (not bare `.bannerAction`): raises
+   specificity above the shared Link component's own `.link` — same
+   specificity-tie fix documented throughout this epic (see
+   RecipeDetailView.module.css's `.article .backLink`). Styled to look
+   like the design's small ghost button, same "style Link locally"
+   precedent as RecipeList's `.newButton`. */
+.sessionBanner .bannerAction {
+  flex-shrink: 0;
+  width: auto;
+  font-size: 13px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  border: var(--border-width) solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  padding: 7px 14px;
+  transition: border-color var(--duration-fast) var(--easing-default),
+    color var(--duration-fast) var(--easing-default);
+}
+
+.sessionBanner .bannerAction:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-hover);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sessionBanner .bannerAction {
+    transition: none;
+  }
+}
+
+/* ── Back link ───────────────────────────────────────────────────── */
+
+.backLink {
+  composes: focusRing from '../../../styles/interactions.module.css';
+  composes: metaText from '../../../styles/text.module.css';
+  margin-bottom: 20px;
+}
+
+/* .container .backLink (not bare): raises specificity above the shared
+   Link component's own `.link` — see RecipeDetailView.module.css's
+   `.article .backLink` for the same pattern/rationale. */
+.container .backLink {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+/* ── Title bar ───────────────────────────────────────────────────── */
+
+.titleBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 26px;
+}
+
+/* .titleBar .pageHeading (not bare): raises specificity above
+   Typography's own `.heading1`. */
+.titleBar .pageHeading {
+  font-size: clamp(24px, 3.4vw, 30px);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: -0.025em;
+  margin: 0;
+}
+
+/* ── Two-column grid ─────────────────────────────────────────────── */
+
+.editorGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(28px, 4vw, 44px);
+}
+
+@media (min-width: 880px) {
+  .editorGrid {
+    grid-template-columns: minmax(0, 1fr) 296px;
+    align-items: start;
+  }
+
+  .rail {
+    position: sticky;
+    top: 84px;
+  }
+}
+
+.formColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  min-width: 0;
+}
+
+/* ── Fields ──────────────────────────────────────────────────────── */
+
+.field {
+  display: flex;
+  flex-direction: column;
+}
+
+.fieldLabel {
+  font-size: 13px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  margin-bottom: 7px;
+  display: block;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  color: var(--color-text-strong);
+  background: var(--color-field);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-md);
+  /* 12px/13px: design literal, no --space-* pairing lands on 13px. */
+  padding: 12px 13px;
+  outline: none;
+  transition: border-color var(--duration-fast) var(--easing-default),
+    box-shadow var(--duration-fast) var(--easing-default);
+}
+
+.input {
+  composes: fieldFocusRing from '../../../styles/interactions.module.css';
+}
+
+.textarea {
+  composes: fieldFocusRing from '../../../styles/interactions.module.css';
+  resize: vertical;
+  line-height: var(--line-height-relaxed);
+  /* 84px: design literal, no --space-* token lands on it. */
+  min-height: 84px;
+}
+
+.input::placeholder,
+.textarea::placeholder {
+  color: var(--color-text-faint);
+}
+
+.input[readonly] {
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .input,
+  .textarea {
+    transition: none;
+  }
+}
+
+.hint {
+  /* 12.5px: design literal (.fhint) — --font-size-sm (13px) is the
+     nearest token but is 0.5px off. */
+  font-size: 12.5px;
+  color: var(--color-text-faint);
+  line-height: var(--line-height-normal);
+  margin: 0;
+}
+
+.slugHintRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px var(--space-3);
+  margin-top: var(--space-2);
+}
+
+/* Text-link-styled action button — mirrors AutosaveStatus.module.css's
+   own `.retryButton` (the established "native button styled as a plain
+   text link" pattern in this codebase), not the shared Button component,
+   which always carries border/padding chrome the design's inline
+   `.lnk`-style actions don't want here. */
+.textButton {
+  composes: focusRing from '../../../styles/interactions.module.css';
+  padding: 0;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: var(--font-weight-medium);
+  color: var(--color-primary);
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.slugLockHint {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: var(--space-2) 0 0;
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+}
+
+.slugLockIcon {
+  color: var(--color-warning);
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.slugError {
+  margin: var(--space-2) 0 0;
+  color: var(--color-error);
+  font-size: 12.5px;
+}
+
+/* ── Sections (fieldset groups) ─────────────────────────────────── */
+
+.basics {
+  display: flex;
+  flex-direction: column;
+  /* 18px: design literal — --space-5 (20px) is the nearest token but is
+     2px off. */
+  gap: 18px;
+}
+
+/* `all: unset` resets the UA fieldset default chrome (border/padding/
+   min-width) reliably across browsers before reapplying the design's own
+   border-top divider — a plain `border:0;padding:0` reset alone leaves
+   Firefox's `min-width: min-content` in place, which can force the
+   fieldset wider than its grid track. */
+.section,
+.sectionTight {
+  all: unset;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: 100%;
+  border-top: var(--border-width) solid var(--color-border);
+  padding-top: 26px;
+}
+
+.section {
+  gap: var(--space-4);
+}
+
+.sectionTight {
+  /* 14px: design literal — --space-4 (16px) is the nearest token but is
+     2px off (matches Cover/Timing's own 16px gap instead). */
+  gap: 14px;
+}
+
+.sectionLabel {
+  all: unset;
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  /* 0.14em: no --tracking-* token matches (eyebrow is 0.16em, meta is
+     0.04em) — this is the design's own distinct "section label" tracking. */
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text-faint);
+}
+
+/* Wraps both the label and a trailing item-count hint inside the same
+   <legend> (Ingredients/Method) — the count has to live inside the
+   legend, not a sibling wrapper div, or it stops being part of the
+   fieldset's accessible name. */
+.sectionLabelRow {
+  all: unset;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  width: 100%;
+}
+
+.metadataRow {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+
+/* ── Sticky rail ─────────────────────────────────────────────────── */
+
+.railCard {
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-xl);
+  background: var(--color-surface);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.autosaveRow {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 20px;
+}
+
+.divider {
+  height: var(--border-width);
+  background: var(--color-border);
+}
+
+.actionsCol {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* .actionsCol .discardButton (not bare): raises specificity above
+   Button's own `.outline` hover — the design's "Discard draft" ghost
+   button tints red on hover (`.ghost-btn.danger:hover`), Button's shared
+   outline variant tints accent-blue instead. */
+.actionsCol .discardButton:hover:not(:disabled) {
+  border-color: var(--color-error);
+  color: var(--color-error);
+  background: var(--color-error-bg);
+}
+
+.checklistWrap {
+  border-top: var(--border-width) solid var(--color-border);
+  padding-top: 14px;
+}
+
+.checklistLabel {
+  composes: sectionLabel;
+  margin-bottom: var(--space-2);
+}
+
+.checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+.checklistItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  font-size: 13px;
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text);
+}
+
+.checklistIcon {
+  flex-shrink: 0;
+  margin-top: 1px;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-full);
+  border: var(--border-width-thick) solid var(--color-border);
+}
+
+.previewWrap {
+  border-top: var(--border-width) solid var(--color-border);
+  padding-top: 14px;
+}
+
+/* .previewWrap .previewLink (not bare): raises specificity above Link's
+   own `.link` — see `.container .backLink` above for the same pattern. */
+.previewWrap .previewLink {
+  font-size: 13px;
+  color: var(--color-text-muted);
 }

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -1051,6 +1051,25 @@ describe('RecipeEditor page', () => {
       ],
     }
 
+    // A recipe where the step image has finished processing (ready) but the
+    // user never filled in alt text — the readiness gate and the alt-text
+    // gate are independent checks, so this must trip the latter even though
+    // the former is satisfied.
+    const recipeWithStepImageMissingAlt: Recipe = {
+      ...draftRecipe,
+      steps: [
+        {
+          stepId: STEP_ID,
+          order: 1,
+          text: 'Boil pasta',
+          image: {
+            alt: '   ',
+            processedAt: 1_700_000_000_000,
+          },
+        },
+      ],
+    }
+
     it('disables Publish when the cover image is not yet processed (no processedAt) (AC 6, 7)', async () => {
       vi.mocked(fetchMyRecipes).mockResolvedValue([recipeWithUnreadyCover])
       vi.mocked(fetchAllRecipes).mockResolvedValue([recipeWithUnreadyCover])
@@ -1106,6 +1125,47 @@ describe('RecipeEditor page', () => {
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /^publish$/i })).not.toBeDisabled()
       })
+    })
+
+    it('disables Publish when a step image is ready but its alt text is empty', async () => {
+      vi.mocked(fetchMyRecipes).mockResolvedValue([recipeWithStepImageMissingAlt])
+      vi.mocked(fetchAllRecipes).mockResolvedValue([recipeWithStepImageMissingAlt])
+
+      renderEditor('/admin/recipes/rec-001/edit')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+      })
+
+      const publishButton = screen.getByRole('button', { name: /^publish$/i })
+      expect(publishButton).toBeDisabled()
+
+      const describedBy = publishButton.getAttribute('aria-describedby')
+      const missingList = document.getElementById(describedBy as string)
+      expect(missingList?.textContent ?? '').toMatch(/step 1 image alt text/i)
+    })
+
+    it('re-enables Publish once the step image alt text is filled in', async () => {
+      const user = userEvent.setup()
+      vi.mocked(fetchMyRecipes).mockResolvedValue([recipeWithStepImageMissingAlt])
+      vi.mocked(fetchAllRecipes).mockResolvedValue([recipeWithStepImageMissingAlt])
+
+      renderEditor('/admin/recipes/rec-001/edit')
+
+      await waitFor(() => {
+        expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
+      })
+
+      const publishButton = screen.getByRole('button', { name: /^publish$/i })
+      expect(publishButton).toBeDisabled()
+
+      await user.type(screen.getByLabelText('Step 1 image alt text'), 'Boiling pasta')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /^publish$/i })).not.toBeDisabled()
+      })
+
+      expect(document.getElementById('publish-missing-fields')).not.toBeInTheDocument()
     })
 
     it('flips the publish gate when onReady reports the matching key is ready (AC 4, 1, 5)', async () => {
@@ -1378,6 +1438,62 @@ describe('RecipeEditor page', () => {
       await waitFor(() => {
         expect(screen.getByLabelText('URL slug')).toHaveValue('beans-on-toast-deluxe')
       })
+    })
+
+    it('does not show "Reset to title" while the slug is still auto-deriving from the title', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(createDraft).toHaveBeenCalled()
+      })
+
+      // Slug auto-follows the title — resetting it would be a no-op, so the
+      // button has nothing useful to do yet.
+      await user.type(screen.getByRole('textbox', { name: /title/i }), 'Beans on Toast')
+      await waitFor(() => {
+        expect(screen.getByLabelText('URL slug')).toHaveValue('beans-on-toast')
+      })
+
+      expect(screen.queryByRole('button', { name: /^reset to title$/i })).not.toBeInTheDocument()
+    })
+
+    it('shows "Reset to title" once a manual slug edit diverges from sluggify(title)', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(createDraft).toHaveBeenCalled()
+      })
+
+      await user.type(screen.getByRole('textbox', { name: /title/i }), 'Beans on Toast')
+      const slugInput = screen.getByLabelText('URL slug')
+      await user.clear(slugInput)
+      await user.type(slugInput, 'bot')
+
+      expect(screen.getByRole('button', { name: /^reset to title$/i })).toBeInTheDocument()
+    })
+
+    it('hides "Reset to title" again once a manual edit happens to match sluggify(title)', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(createDraft).toHaveBeenCalled()
+      })
+
+      await user.type(screen.getByRole('textbox', { name: /title/i }), 'Beans on Toast')
+      const slugInput = screen.getByLabelText('URL slug')
+      await user.clear(slugInput)
+      await user.type(slugInput, 'bot')
+      expect(screen.getByRole('button', { name: /^reset to title$/i })).toBeInTheDocument()
+
+      // Manually retyping the exact auto-derived value makes resetting a
+      // no-op again, even though the edit was manual (slugManuallyEdited).
+      await user.clear(slugInput)
+      await user.type(slugInput, 'beans-on-toast')
+
+      expect(screen.queryByRole('button', { name: /^reset to title$/i })).not.toBeInTheDocument()
     })
 
     it('renders a live URL preview containing akli.dev/recipes/<slug>', async () => {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -200,13 +200,16 @@ vi.mock('@components/ImageUpload', () => ({
 }))
 
 const fillValidCoverImage = async (user: UserEvent) => {
-  await user.type(screen.getByLabelText(/cover image alt text/i), 'Cover alt text')
-  // Simulate the image processing poll detecting the uploaded cover as ready.
-  // Without this, the publish gate would consider the cover image absent
-  // (no processedAt) and Publish stays disabled.
+  // Simulate the image processing poll detecting the uploaded cover as ready
+  // first — the cover alt-text field only renders once
+  // `form.coverImageProcessedAt` is set (#228), so readiness must be
+  // signalled before the "Alt text" input exists to type into. Without this,
+  // the publish gate would also consider the cover image absent (no
+  // processedAt) and Publish would stay disabled.
   pollControls.triggerReady([
     { imageType: 'cover', processedAt: 1_700_000_000_000 },
   ])
+  await user.type(screen.getByLabelText(/^alt text$/i), 'Cover alt text')
 }
 
 const fillAllRequired = async (user: UserEvent) => {
@@ -718,7 +721,8 @@ describe('RecipeEditor page', () => {
       await user.click(screen.getByRole('button', { name: /discard draft/i }))
 
       const dialog = await screen.findByRole('dialog')
-      const cancelButton = within(dialog).getByRole('button', { name: /cancel|stay/i })
+      // Cancel label reads "Keep editing" in the paper redesign (#228).
+      const cancelButton = within(dialog).getByRole('button', { name: /cancel|stay|keep editing/i })
       await user.click(cancelButton)
 
       await waitFor(() => {
@@ -737,7 +741,13 @@ describe('RecipeEditor page', () => {
       })
 
       expect(screen.getByRole('textbox', { name: /intro/i })).toBeInTheDocument()
-      expect(screen.getByLabelText(/cover image alt text/i)).toBeInTheDocument()
+
+      // The cover alt-text field only renders once the cover image has a
+      // processedAt (#228) — simulate the poll reporting the cover ready
+      // before asserting the field appears.
+      pollControls.triggerReady([{ imageType: 'cover', processedAt: 1_700_000_000_000 }])
+
+      expect(screen.getByLabelText(/^alt text$/i)).toBeInTheDocument()
     })
 
     it('populates form from fetched recipe on edit mount', async () => {
@@ -993,7 +1003,7 @@ describe('RecipeEditor page', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(/session expired.*please log in again/i)
+          screen.getByText(/your session has expired\. log in again to keep editing/i)
         ).toBeInTheDocument()
       })
 
@@ -1302,7 +1312,7 @@ describe('RecipeEditor page', () => {
         expect(createDraft).toHaveBeenCalled()
       })
 
-      expect(screen.getByLabelText('Slug')).toBeInTheDocument()
+      expect(screen.getByLabelText('URL slug')).toBeInTheDocument()
     })
 
     it('auto-fills the slug as sluggify(title) while typing the title', async () => {
@@ -1316,7 +1326,7 @@ describe('RecipeEditor page', () => {
       await user.type(screen.getByRole('textbox', { name: /title/i }), 'Beans on Toast')
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Slug')).toHaveValue('beans-on-toast')
+        expect(screen.getByLabelText('URL slug')).toHaveValue('beans-on-toast')
       })
     })
 
@@ -1330,21 +1340,21 @@ describe('RecipeEditor page', () => {
 
       await user.type(screen.getByRole('textbox', { name: /title/i }), 'Beans on Toast')
       await waitFor(() => {
-        expect(screen.getByLabelText('Slug')).toHaveValue('beans-on-toast')
+        expect(screen.getByLabelText('URL slug')).toHaveValue('beans-on-toast')
       })
 
       // User overrides the slug.
-      const slugInput = screen.getByLabelText('Slug')
+      const slugInput = screen.getByLabelText('URL slug')
       await user.clear(slugInput)
       await user.type(slugInput, 'bot')
 
       // Further title edits must NOT touch the slug.
       await user.type(screen.getByRole('textbox', { name: /title/i }), ' Deluxe')
 
-      expect(screen.getByLabelText('Slug')).toHaveValue('bot')
+      expect(screen.getByLabelText('URL slug')).toHaveValue('bot')
     })
 
-    it('"Reset to title slug" re-derives the slug from the title and re-enables auto-fill', async () => {
+    it('"Reset to title" re-derives the slug from the title and re-enables auto-fill', async () => {
       const user = userEvent.setup()
       renderEditor('/admin/recipes/new')
 
@@ -1353,20 +1363,20 @@ describe('RecipeEditor page', () => {
       })
 
       await user.type(screen.getByRole('textbox', { name: /title/i }), 'Beans on Toast')
-      const slugInput = screen.getByLabelText('Slug')
+      const slugInput = screen.getByLabelText('URL slug')
       await user.clear(slugInput)
       await user.type(slugInput, 'bot')
 
-      await user.click(screen.getByRole('button', { name: /reset to title slug/i }))
+      await user.click(screen.getByRole('button', { name: /^reset to title$/i }))
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Slug')).toHaveValue('beans-on-toast')
+        expect(screen.getByLabelText('URL slug')).toHaveValue('beans-on-toast')
       })
 
       // Auto-fill is re-enabled: a further title edit updates the slug again.
       await user.type(screen.getByRole('textbox', { name: /title/i }), ' Deluxe')
       await waitFor(() => {
-        expect(screen.getByLabelText('Slug')).toHaveValue('beans-on-toast-deluxe')
+        expect(screen.getByLabelText('URL slug')).toHaveValue('beans-on-toast-deluxe')
       })
     })
 
@@ -1395,14 +1405,14 @@ describe('RecipeEditor page', () => {
         expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
       })
 
-      const slugInput = screen.getByLabelText('Slug')
+      const slugInput = screen.getByLabelText('URL slug')
       // draftRecipe's cover has processedAt → slug is locked.
       expect(slugInput).toHaveAttribute('readonly')
       expect(slugInput).toHaveAttribute('aria-disabled', 'true')
 
       // A visible lock hint is shown, and the reset button is hidden.
-      expect(screen.getByText(/slug is locked/i)).toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: /reset to title slug/i })).not.toBeInTheDocument()
+      expect(screen.getByText(/images reference this url/i)).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /^reset to title$/i })).not.toBeInTheDocument()
     })
 
     it('locks the slug input while an image upload is in flight (uploadingStepIds / cover)', async () => {
@@ -1416,21 +1426,21 @@ describe('RecipeEditor page', () => {
       })
 
       // Not locked initially.
-      expect(screen.getByLabelText('Slug')).not.toHaveAttribute('readonly')
+      expect(screen.getByLabelText('URL slug')).not.toHaveAttribute('readonly')
 
       // Fire the cover upload-started callback through the ImageUpload stub.
       await user.click(screen.getByRole('button', { name: /start upload cover image/i }))
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Slug')).toHaveAttribute('aria-disabled', 'true')
+        expect(screen.getByLabelText('URL slug')).toHaveAttribute('aria-disabled', 'true')
       })
-      expect(screen.getByLabelText('Slug')).toHaveAttribute('readonly')
+      expect(screen.getByLabelText('URL slug')).toHaveAttribute('readonly')
 
       // Completing the upload clears the in-flight lock.
       await user.click(screen.getByRole('button', { name: /complete upload cover image/i }))
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Slug')).not.toHaveAttribute('readonly')
+        expect(screen.getByLabelText('URL slug')).not.toHaveAttribute('readonly')
       })
     })
 
@@ -1449,7 +1459,7 @@ describe('RecipeEditor page', () => {
       })
 
       // Type an invalid slug (leading hyphen fails ^[a-z0-9]...).
-      const slugInput = screen.getByLabelText('Slug')
+      const slugInput = screen.getByLabelText('URL slug')
       await user.clear(slugInput)
       await user.type(slugInput, '-bad-slug')
 
@@ -1477,7 +1487,7 @@ describe('RecipeEditor page', () => {
       // The server's slug_taken message is surfaced INLINE, associated with the
       // slug field via aria-describedby (not merely as a transient toast).
       await waitFor(() => {
-        const slugInput = screen.getByLabelText('Slug')
+        const slugInput = screen.getByLabelText('URL slug')
         const describedBy = slugInput.getAttribute('aria-describedby') ?? ''
         const describerText = describedBy
           .split(/\s+/)
@@ -1520,7 +1530,7 @@ describe('RecipeEditor page', () => {
         expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
       })
 
-      const slugInput = screen.getByLabelText('Slug')
+      const slugInput = screen.getByLabelText('URL slug')
       await user.clear(slugInput)
       await user.type(slugInput, 'spaghetti-supreme')
 
@@ -1550,7 +1560,7 @@ describe('RecipeEditor page', () => {
         expect(screen.getByRole('textbox', { name: /title/i })).toHaveValue('Spaghetti Bolognese')
       })
 
-      const slugInput = screen.getByLabelText('Slug')
+      const slugInput = screen.getByLabelText('URL slug')
       await user.clear(slugInput)
       await user.type(slugInput, 'Bad Slug!')
 

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -10,14 +10,15 @@ import {
 } from '@api/recipes'
 import AutosaveStatus from '@components/AutosaveStatus'
 import Button from '@components/Button'
-import Callout from '@components/Callout'
 import ConfirmDialog from '@components/ConfirmDialog'
 import ImageUpload from '@components/ImageUpload'
 import IngredientList from '@components/IngredientList'
 import Link from '@components/Link'
 import Loading from '@components/Loading'
+import StatusBadge from '@components/StatusBadge'
 import StepList from '@components/StepList'
 import TagInput from '@components/TagInput'
+import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
 import { useToast } from '@contexts/ToastContext'
 import { useAutosave } from '@hooks/useAutosave'
@@ -30,6 +31,7 @@ import type { Ingredient, Recipe, Step, Tag } from '@models/recipe'
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type FC } from 'react'
 import { useBlocker, useLocation, useNavigate, useParams } from 'react-router-dom'
 
+import { pluralize } from '../../../utils/pluralize'
 import styles from './RecipeEditor.module.css'
 
 type EditorMode = Recipe['status']
@@ -228,6 +230,58 @@ const draftFromCreated = (id: string, slug: string): Recipe => ({
 })
 
 const NEW_PATH = '/admin/recipes/new'
+
+const iconAlertCircle = (
+  <svg
+    width="17"
+    height="17"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <line x1="12" y1="8" x2="12" y2="12" />
+    <line x1="12" y1="16" x2="12.01" y2="16" />
+  </svg>
+)
+
+const iconLock = (
+  <svg
+    width="13"
+    height="13"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="3" y="11" width="18" height="11" rx="2" />
+    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+  </svg>
+)
+
+const iconPreview = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+)
 
 const RecipeEditor: FC = () => {
   const { id: routeId } = useParams<{ id: string }>()
@@ -520,178 +574,214 @@ const RecipeEditor: FC = () => {
   // typing into a form whose autosave cannot yet PATCH (no id).
   if (loading || (isNewPath && !form.id && !sessionExpired)) {
     return (
-      <div className={styles.loadingWrapper}>
-        <Loading />
+      <div className={styles.container}>
+        <div className={styles.loadingBox}>
+          <Loading label="Loading recipe…" />
+        </div>
       </div>
     )
   }
 
   const loginHref = `/admin/login?redirect=${encodeURIComponent(location.pathname)}`
   const recipeId = form.id || routeId
+  const isPublished = form.mode === 'published'
+  const slugResettable = !slugLocked && form.slugManuallyEdited && sluggify(form.title) !== form.slug
 
   return (
     <div className={styles.container}>
       {sessionExpired && (
         <div className={styles.sessionBanner} role="alert">
-          <span>Session expired — please log in again</span>
-          <Link to={loginHref}>Log in again</Link>
+          <span className={styles.bannerMessage}>
+            <span className={styles.bannerIcon} aria-hidden="true">
+              {iconAlertCircle}
+            </span>
+            <span>Your session has expired. Log in again to keep editing — your latest changes are saved.</span>
+          </span>
+          <Link to={loginHref} className={styles.bannerAction}>
+            Log in again
+          </Link>
         </div>
       )}
 
       {timedOut && (
         <div role="status" aria-live="polite" className={styles.timeoutBanner}>
-          Processing is taking longer than expected — try refreshing the page.
+          <span className={styles.timeoutSpinner} aria-hidden="true" />
+          <span>Processing is taking longer than expected — try refreshing the page.</span>
         </div>
       )}
 
-      <div className={styles.header}>
-        <Link to="/admin/recipes" className={styles.backLink}>
-          ← Back to recipes
-        </Link>
-        <AutosaveStatus
-          status={autosaveStatus}
-          lastSavedAt={lastSavedAt}
-          onRetry={retry}
-        />
+      <Link to="/admin/recipes" icon="←" iconSide="left" nudge="left" className={styles.backLink}>
+        Back to recipes
+      </Link>
+
+      <div className={styles.titleBar}>
+        <Typography variant="heading1" className={styles.pageHeading}>
+          {isPublished ? 'Edit recipe' : 'New recipe'}
+        </Typography>
+        <StatusBadge tone={isPublished ? 'success' : 'warning'}>
+          {isPublished ? 'Published' : 'Draft'}
+        </StatusBadge>
       </div>
 
-      <form
-        className={styles.form}
-        onSubmit={(e) => {
-          e.preventDefault()
-        }}
-      >
-        <div className={styles.section}>
-          <div className={styles.field}>
-            <label htmlFor="recipe-title">Title</label>
-            <input
-              id="recipe-title"
-              type="text"
-              value={form.title}
-              onChange={(e) => setField('title', e.target.value)}
-              className={styles.input}
-            />
-          </div>
-
-          <div className={styles.field}>
-            <label htmlFor="recipe-slug">Slug</label>
-            <input
-              id="recipe-slug"
-              type="text"
-              value={form.slug}
-              readOnly={slugLocked}
-              aria-disabled={slugLocked || undefined}
-              aria-describedby={
-                slugError ? 'recipe-slug-preview recipe-slug-error' : 'recipe-slug-preview'
-              }
-              onChange={(e) => {
-                setSlugError(null)
-                setField('slug', e.target.value)
-              }}
-              className={styles.input}
-            />
-            <p id="recipe-slug-preview" className={styles.slugPreview}>
-              Public URL: akli.dev/recipes/{form.slug}
-            </p>
-            {!slugLocked && (
-              <Button
-                onClick={() => dispatch({ type: 'RESET_SLUG_TO_TITLE' })}
-                type="button"
-                variant="outline"
-              >
-                Reset to title slug
-              </Button>
-            )}
-            {slugLocked && (
-              <p className={styles.slugLockHint}>
-                Slug is locked because images are stored under it. To use a different slug,
-                recreate the recipe and set the slug before uploading images.
-              </p>
-            )}
-            {slugError && (
-              <p id="recipe-slug-error" role="alert" className={styles.slugError}>
-                {slugError}
-              </p>
-            )}
-          </div>
-
-          <div className={styles.field}>
-            <label htmlFor="recipe-intro">Intro</label>
-            <textarea
-              id="recipe-intro"
-              value={form.intro}
-              onChange={(e) => setField('intro', e.target.value)}
-              className={styles.textarea}
-            />
-          </div>
-        </div>
-
-        <div className={styles.section}>
-          <div className={styles.field}>
-            {recipeId && (
-              <ImageUpload
-                slug={form.slug}
-                imageType="cover"
-                currentAlt={form.coverImageAlt || undefined}
-                processedAt={form.coverImageProcessedAt}
-                getToken={getAccessToken}
-                recipeId={recipeId}
-                onUploadStarted={handleCoverUploadStarted}
-                onUploadCompleted={handleCoverUploadCompleted}
-              />
-            )}
-          </div>
-
-          <div className={styles.field}>
-            <label htmlFor="recipe-cover-alt">Cover image alt text</label>
-            <input
-              id="recipe-cover-alt"
-              type="text"
-              value={form.coverImageAlt}
-              onChange={(e) => setField('coverImageAlt', e.target.value)}
-              className={styles.input}
-            />
-          </div>
-        </div>
-
-        <div className={styles.section}>
-          <div className={styles.metadataRow}>
+      <div className={styles.editorGrid}>
+        <form
+          className={styles.formColumn}
+          onSubmit={(e) => {
+            e.preventDefault()
+          }}
+        >
+          <section className={styles.basics}>
             <div className={styles.field}>
-              <label htmlFor="recipe-prep-time">Prep time (min)</label>
+              <label htmlFor="recipe-title" className={styles.fieldLabel}>
+                Title
+              </label>
               <input
-                id="recipe-prep-time"
-                type="number"
-                value={form.prepTime}
-                onChange={(e) => setField('prepTime', Number(e.target.value))}
-                className={styles.numberInput}
+                id="recipe-title"
+                type="text"
+                value={form.title}
+                onChange={(e) => setField('title', e.target.value)}
+                className={styles.input}
               />
             </div>
-            <div className={styles.field}>
-              <label htmlFor="recipe-cook-time">Cook time (min)</label>
-              <input
-                id="recipe-cook-time"
-                type="number"
-                value={form.cookTime}
-                onChange={(e) => setField('cookTime', Number(e.target.value))}
-                className={styles.numberInput}
-              />
-            </div>
-            <div className={styles.field}>
-              <label htmlFor="recipe-servings">Servings</label>
-              <input
-                id="recipe-servings"
-                type="number"
-                value={form.servings}
-                onChange={(e) => setField('servings', Number(e.target.value))}
-                className={styles.numberInput}
-              />
-            </div>
-          </div>
-        </div>
 
-        <div className={styles.section}>
-          <div className={styles.field}>
-            <label htmlFor="recipe-tags">Tags</label>
+            <div className={styles.field}>
+              <label htmlFor="recipe-slug" className={styles.fieldLabel}>
+                URL slug
+              </label>
+              <input
+                id="recipe-slug"
+                type="text"
+                value={form.slug}
+                readOnly={slugLocked}
+                aria-disabled={slugLocked || undefined}
+                aria-describedby={
+                  slugError ? 'recipe-slug-preview recipe-slug-error' : 'recipe-slug-preview'
+                }
+                onChange={(e) => {
+                  setSlugError(null)
+                  setField('slug', e.target.value)
+                }}
+                className={styles.input}
+              />
+              <div className={styles.slugHintRow}>
+                <p id="recipe-slug-preview" className={styles.hint}>
+                  Public URL: akli.dev/recipes/{form.slug}
+                </p>
+                {slugResettable && (
+                  <button
+                    type="button"
+                    onClick={() => dispatch({ type: 'RESET_SLUG_TO_TITLE' })}
+                    className={styles.textButton}
+                  >
+                    Reset to title
+                  </button>
+                )}
+              </div>
+              {slugLocked && (
+                <p className={styles.slugLockHint}>
+                  <span className={styles.slugLockIcon} aria-hidden="true">
+                    {iconLock}
+                  </span>
+                  <span>Locked — images reference this URL. Remove all images to change it.</span>
+                </p>
+              )}
+              {slugError && (
+                <p id="recipe-slug-error" role="alert" className={styles.slugError}>
+                  {slugError}
+                </p>
+              )}
+            </div>
+
+            <div className={styles.field}>
+              <label htmlFor="recipe-intro" className={styles.fieldLabel}>
+                Intro
+              </label>
+              <textarea
+                id="recipe-intro"
+                value={form.intro}
+                onChange={(e) => setField('intro', e.target.value)}
+                className={styles.textarea}
+              />
+            </div>
+          </section>
+
+          <fieldset className={styles.section}>
+            <legend className={styles.sectionLabel}>Cover image</legend>
+            <div className={styles.field}>
+              {recipeId && (
+                <ImageUpload
+                  slug={form.slug}
+                  imageType="cover"
+                  currentAlt={form.coverImageAlt || undefined}
+                  processedAt={form.coverImageProcessedAt}
+                  getToken={getAccessToken}
+                  recipeId={recipeId}
+                  onUploadStarted={handleCoverUploadStarted}
+                  onUploadCompleted={handleCoverUploadCompleted}
+                />
+              )}
+            </div>
+
+            {form.coverImageProcessedAt !== undefined && (
+              <div className={styles.field}>
+                <label htmlFor="recipe-cover-alt" className={styles.fieldLabel}>
+                  Alt text
+                </label>
+                <input
+                  id="recipe-cover-alt"
+                  type="text"
+                  value={form.coverImageAlt}
+                  onChange={(e) => setField('coverImageAlt', e.target.value)}
+                  className={styles.input}
+                />
+              </div>
+            )}
+          </fieldset>
+
+          <fieldset className={styles.sectionTight}>
+            <legend className={styles.sectionLabel}>Timing &amp; servings</legend>
+            <div className={styles.metadataRow}>
+              <div className={styles.field}>
+                <label htmlFor="recipe-prep-time" className={styles.fieldLabel}>
+                  Prep (min)
+                </label>
+                <input
+                  id="recipe-prep-time"
+                  type="number"
+                  value={form.prepTime}
+                  onChange={(e) => setField('prepTime', Number(e.target.value))}
+                  className={styles.input}
+                />
+              </div>
+              <div className={styles.field}>
+                <label htmlFor="recipe-cook-time" className={styles.fieldLabel}>
+                  Cook (min)
+                </label>
+                <input
+                  id="recipe-cook-time"
+                  type="number"
+                  value={form.cookTime}
+                  onChange={(e) => setField('cookTime', Number(e.target.value))}
+                  className={styles.input}
+                />
+              </div>
+              <div className={styles.field}>
+                <label htmlFor="recipe-servings" className={styles.fieldLabel}>
+                  Servings
+                </label>
+                <input
+                  id="recipe-servings"
+                  type="number"
+                  value={form.servings}
+                  onChange={(e) => setField('servings', Number(e.target.value))}
+                  className={styles.input}
+                />
+              </div>
+            </div>
+          </fieldset>
+
+          <fieldset className={styles.sectionTight}>
+            <legend className={styles.sectionLabel}>Tags</legend>
             <TagInput
               inputId="recipe-tags"
               tags={form.tags}
@@ -699,112 +789,156 @@ const RecipeEditor: FC = () => {
               existingTags={existingTags}
               placeholder="Add a tag and press Enter"
             />
-          </div>
-        </div>
+          </fieldset>
 
-        <div className={styles.section}>
-          <IngredientList
-            ingredients={form.ingredients}
-            onChange={setIngredients}
-            onAnnounce={announce}
-          />
-        </div>
-
-        <div className={styles.section}>
-          {recipeId && (
-            <StepList
-              steps={form.steps}
-              onChange={setSteps}
-              recipeId={recipeId}
-              slug={form.slug}
-              getToken={getAccessToken}
+          <fieldset className={styles.sectionTight}>
+            <legend className={styles.sectionLabelRow}>
+              <span className={styles.sectionLabel}>Ingredients</span>
+              <span className={styles.hint}>{pluralize(form.ingredients.length, 'item')}</span>
+            </legend>
+            <IngredientList
+              ingredients={form.ingredients}
+              onChange={setIngredients}
               onAnnounce={announce}
-              onStepUploadStarted={handleStepUploadStarted}
-              onStepUploadCompleted={handleStepUploadCompleted}
             />
-          )}
-        </div>
+          </fieldset>
 
-        <div className={styles.actions}>
-          {form.mode === 'draft' ? (
-            <>
-              <Button
-                onClick={handlePublish}
-                type="button"
-                loading={submitting}
-                disabled={!canPublish}
-                ariaDescribedBy={!canPublish ? MISSING_FIELDS_ID : undefined}
-              >
-                Publish
-              </Button>
-              <Button
-                onClick={() => setDiscardDialogOpen(true)}
-                type="button"
-                variant="outline"
-                disabled={submitting}
-              >
-                Discard draft
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button onClick={handleUpdate} type="button" loading={submitting}>
-                Update
-              </Button>
-              <Button
-                onClick={handleUnpublish}
-                type="button"
-                variant="outline"
-                disabled={submitting}
-              >
-                Unpublish
-              </Button>
-            </>
-          )}
-        </div>
+          <fieldset className={styles.sectionTight}>
+            <legend className={styles.sectionLabelRow}>
+              <span className={styles.sectionLabel}>Method</span>
+              <span className={styles.hint}>{pluralize(form.steps.length, 'step')}</span>
+            </legend>
+            {recipeId && (
+              <StepList
+                steps={form.steps}
+                onChange={setSteps}
+                recipeId={recipeId}
+                slug={form.slug}
+                getToken={getAccessToken}
+                onAnnounce={announce}
+                onStepUploadStarted={handleStepUploadStarted}
+                onStepUploadCompleted={handleStepUploadCompleted}
+              />
+            )}
+          </fieldset>
+        </form>
 
-        {form.mode === 'draft' && !canPublish && (
-          <Callout type="warning">
-            <p id={`${MISSING_FIELDS_ID}-label`}>Add the following before publishing:</p>
-            <ul
-              id={MISSING_FIELDS_ID}
-              aria-labelledby={`${MISSING_FIELDS_ID}-label`}
-              className={styles.missingFieldsList}
-            >
-              {missingFields.map((field) => (
-                <li key={field}>{field}</li>
-              ))}
-            </ul>
-          </Callout>
-        )}
-      </form>
+        <aside className={styles.rail}>
+          <div className={styles.railCard}>
+            <div className={styles.autosaveRow}>
+              <AutosaveStatus
+                status={autosaveStatus}
+                lastSavedAt={lastSavedAt}
+                onRetry={retry}
+              />
+            </div>
+
+            <div className={styles.divider} aria-hidden="true" />
+
+            {!isPublished ? (
+              <>
+                <div className={styles.actionsCol}>
+                  <Button
+                    onClick={handlePublish}
+                    type="button"
+                    loading={submitting}
+                    disabled={!canPublish}
+                    fullWidth
+                    ariaDescribedBy={!canPublish ? MISSING_FIELDS_ID : undefined}
+                  >
+                    Publish
+                  </Button>
+                  <Button
+                    onClick={() => setDiscardDialogOpen(true)}
+                    type="button"
+                    variant="outline"
+                    disabled={submitting}
+                    fullWidth
+                    className={styles.discardButton}
+                  >
+                    Discard draft
+                  </Button>
+                </div>
+
+                {!canPublish && (
+                  <div className={styles.checklistWrap}>
+                    <p id={`${MISSING_FIELDS_ID}-label`} className={styles.checklistLabel}>
+                      Before publishing
+                    </p>
+                    <ul
+                      id={MISSING_FIELDS_ID}
+                      aria-labelledby={`${MISSING_FIELDS_ID}-label`}
+                      className={styles.checklist}
+                    >
+                      {missingFields.map((field) => (
+                        <li key={field} className={styles.checklistItem}>
+                          <span className={styles.checklistIcon} aria-hidden="true" />
+                          <span>{field}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <div className={styles.actionsCol}>
+                  <Button onClick={handleUpdate} type="button" loading={submitting} fullWidth>
+                    Update
+                  </Button>
+                  <Button
+                    onClick={handleUnpublish}
+                    type="button"
+                    variant="outline"
+                    disabled={submitting}
+                    fullWidth
+                  >
+                    Unpublish
+                  </Button>
+                </div>
+
+                <div className={styles.previewWrap}>
+                  <Link
+                    to={`/recipes/${form.slug}`}
+                    icon={iconPreview}
+                    iconSide="right"
+                    nudge="right"
+                    className={styles.previewLink}
+                  >
+                    View live recipe
+                  </Link>
+                </div>
+              </>
+            )}
+          </div>
+        </aside>
+      </div>
 
       <div className="sr-only" role="status" aria-live="polite">
-        {announcement.message && `${announcement.message}${announcement.toggle ? '\u200B' : ''}`}
+        {announcement.message && `${announcement.message}${announcement.toggle ? '​' : ''}`}
       </div>
 
       <ConfirmDialog
         open={blocker.state === 'blocked'}
-        title="Unsaved changes"
-        danger
-        confirmLabel="Discard changes"
-        cancelLabel="Stay on this page"
+        title="Leave with unsaved changes?"
+        confirmLabel="Leave anyway"
+        cancelLabel="Stay"
         onConfirm={() => blocker.proceed?.()}
         onCancel={() => blocker.reset?.()}
       >
-        Are you sure you want to leave this page? Your edits will be lost.
+        Your changes are still saving. If you leave now they might not be stored.
       </ConfirmDialog>
 
       <ConfirmDialog
         open={discardDialogOpen}
-        title="Discard draft?"
+        title="Discard this draft?"
         danger
-        confirmLabel="Discard"
-        cancelLabel="Cancel"
+        confirmLabel="Discard draft"
+        cancelLabel="Keep editing"
         onConfirm={handleDiscardConfirm}
         onCancel={() => setDiscardDialogOpen(false)}
       >
-        This will permanently delete this draft recipe. This action cannot be undone.
+        This draft and everything in it will be permanently deleted. This can&rsquo;t be undone.
       </ConfirmDialog>
     </div>
   )

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -199,7 +199,7 @@ const computeMissingFields = (form: FormState): string[] => {
   if (!form.title.trim()) missing.push('Title')
   if (!form.intro.trim()) missing.push('Intro')
   if (form.coverImageProcessedAt === undefined) missing.push('Cover image')
-  if (!form.coverImageAlt.trim()) missing.push('Cover image alt text')
+  if (!form.coverImageAlt.trim()) missing.push('Alt text')
   if (!form.ingredients.some((ing) => ing.item.trim())) missing.push('At least one ingredient')
   if (!form.steps.some((s) => s.text.trim())) missing.push('At least one step')
   form.steps.forEach((step, index) => {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -206,6 +206,9 @@ const computeMissingFields = (form: FormState): string[] => {
     if (step.image && step.image.processedAt === undefined) {
       missing.push(`Step ${index + 1} image still processing`)
     }
+    if (step.image?.processedAt !== undefined && !step.image.alt?.trim()) {
+      missing.push(`Step ${index + 1} image alt text`)
+    }
   })
   return missing
 }

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -11,6 +11,7 @@ import {
 import AutosaveStatus from '@components/AutosaveStatus'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
+import { IconAlertCircle } from '@components/icons'
 import ImageUpload from '@components/ImageUpload'
 import IngredientList from '@components/IngredientList'
 import Link from '@components/Link'
@@ -233,24 +234,6 @@ const draftFromCreated = (id: string, slug: string): Recipe => ({
 })
 
 const NEW_PATH = '/admin/recipes/new'
-
-const iconAlertCircle = (
-  <svg
-    width="17"
-    height="17"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <circle cx="12" cy="12" r="10" />
-    <line x1="12" y1="8" x2="12" y2="12" />
-    <line x1="12" y1="16" x2="12.01" y2="16" />
-  </svg>
-)
 
 const iconLock = (
   <svg
@@ -596,7 +579,7 @@ const RecipeEditor: FC = () => {
         <div className={styles.sessionBanner} role="alert">
           <span className={styles.bannerMessage}>
             <span className={styles.bannerIcon} aria-hidden="true">
-              {iconAlertCircle}
+              <IconAlertCircle size={17} ariaHidden />
             </span>
             <span>Your session has expired. Log in again to keep editing — your latest changes are saved.</span>
           </span>

--- a/src/styles/interactions.module.css
+++ b/src/styles/interactions.module.css
@@ -106,6 +106,17 @@
   background: var(--color-hover);
 }
 
+/* ── Icon-button hover ─────────────────────────────────────────
+   Neutral hover for square icon-only buttons (reorder/move controls) —
+   pairs with `dangerIconButtonHover` below for the destructive icon
+   button in the same cluster (see IngredientList/StepList's move
+   up/down + remove trio, ported from the design's `.iconbtn:hover`). */
+.iconButtonHover:hover {
+  color: var(--color-text-strong);
+  border-color: var(--color-border-strong);
+  background: var(--color-hover);
+}
+
 /* ── Danger icon-button hover ──────────────────────────────── */
 .dangerIconButtonHover:hover {
   color: var(--color-error);


### PR DESCRIPTION
Closes #228

## What changed

Rebuilt the admin Recipe Editor page (`src/pages/admin/RecipeEditor`) and its child components (`AutosaveStatus`, `ImageUpload`, `IngredientList`, `StepList`, `TagInput`) to match `docs/design/paper/pages/Admin Recipe Editor.dc.html`:

- Two-column sticky-rail layout (`minmax(0,1fr) 296px`, rail sticky at ≥880px), sections grouped via real `<fieldset>`/`<legend>` (Basics/Cover image/Timing & servings/Tags/Ingredients/Method).
- Slug field with public-URL hint, conditional "Reset to title" action, and a locked-state warning once images exist.
- Sticky rail: `AutosaveStatus` (spinner/checkmark/warning icons + relative time), draft vs. published action sets, "Before publishing" checklist, "View live recipe" link.
- `ImageUpload` restyled to the design's dashed dropzone (cover) / ghost button (steps) / shimmer-processing / ready+replace states.
- `IngredientList`/`StepList` rows converted to `<ul>/<li>` with 30×30 icon buttons (move up/down/remove) matching the design; `StepList` cards gained numbered circle badges.
- `TagInput` chips now render via the shared `Tag` component; kept the existing combobox ARIA pattern for suggestions (more accessible than the design's plain button row) rather than downgrading to match the mockup literally.
- Extracted a small shared `src/components/icons.tsx` for icon SVGs that were duplicated across these files.

All existing business logic — `useAutosave`, `useBlocker`, `useImageProcessingPoll`, `useReorderableList`, the form reducer, and `computeMissingFields`'s pre-existing checks — is preserved. Two small, genuinely new pieces of logic were added (see below).

## Why

Part of the akli.dev Warm Editorial "Paper" Redesign epic (#232) — this is the largest remaining screen in the admin app.

## How to verify

- `pnpm dev`, log in, open an existing recipe for editing and also start a new draft.
- Confirm autosave indicator states (saving/saved/error+retry), slug auto-derive/lock, image upload empty→processing→ready states for both cover and step images, and that Publish is disabled until the checklist passes.
- Toggle dark mode — verified via Playwright screenshots against the design prototype in both themes.
- `pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit` all pass.

## Decisions made

- **Step image alt-text gating**: the alt-text input for a step image now only renders once that image is "ready" (`processedAt` set), matching the design's own `sc-if` structure and the cover image's existing pattern — previously it always rendered, even with no image.
- **Publish checklist**: added a check requiring every *ready* step image to have alt text (previously only checked "still processing", never checked step alt text at all) — confirmed against the design's own reference checklist logic (`readyStepImgs.every(s => s.image.alt.trim())`).
- **Bug fix**: `StepList`'s `updateImage` was dropping `processedAt` on every keystroke into a step's alt-text field, which — combined with the new gating above — made the alt input disappear mid-edit. Fixed to preserve the rest of the existing image object.
- **`ImageUpload` empty-vs-processing**: added local `hasAttemptedUpload` state so a fresh mount shows the empty dropzone rather than a permanent "processing" placeholder (the prior behavior for *any* recipe with no cover at all). Known limitation: reloading the page while an image uploaded in a *previous* session is still server-side processing will briefly show "empty" instead of "processing" — this is an inherent backend-contract limitation (the API can't distinguish "no image" from "image mid-processing"; both return `processedAt: undefined`), not fixable at this layer without a new backend signal.
- **`ImageUpload` replace action**: uses a pencil/replace icon instead of the design's literal trash icon, since there's no standalone "delete image" callback in this component's API — re-upload is the only mutation path that exists.
- **`TagInput` suggestions**: kept the existing `role="combobox"`/`listbox`/`option` structure rather than downgrading to the design's plain button row, since the combobox pattern is more accessible.

## Out of scope (filed as follow-up issues)

- **#265** — Centralize shared icon components across admin pages (migrate `RecipeList.tsx`'s duplicate `iconPreview` to the new shared module) and give `Tag` a style hook for its internal remove button (currently reached via a bare element selector in `TagInput.module.css`). Both touch files outside this PR's scope.
- **#267** — Pre-existing `StatusBadge` color-contrast axe violation (the "Published" pill, 3.68:1 vs required 4.5:1). Confirmed unmodified by this diff; last touched in an earlier, already-merged issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)