### PR TITLE
StatusBadge success-tone pill fails color-contrast (3.68:1, needs 4.5:1)

### DIFF
--- a/src/components/StatusBadge/StatusBadge.module.css
+++ b/src/components/StatusBadge/StatusBadge.module.css
@@ -23,13 +23,31 @@
 }
 
 .success {
-  color: var(--color-success);
+  /* WCAG AA override (issue #267): --color-success (#1F8A5B) on this pill's
+     composited background is only ~3.68:1 (fails AA's 4.5:1 for normal text).
+     Darkened to #1A754D (~4.83:1) for this component only — see issue for why
+     the shared token isn't changed. Dark mode already passes (~6.86:1), so it
+     resets to the token below. */
+  color: #1a754d;
   background: var(--color-success-bg);
 }
 
+[data-theme="dark"] .success {
+  color: var(--color-success);
+}
+
 .warning {
-  color: var(--color-warning);
+  /* WCAG AA override (issue #267): --color-warning (#A66E0A) on this pill's
+     composited background is only ~3.66:1 (fails AA's 4.5:1 for normal text).
+     Darkened to #8C5A08 (~4.96:1) for this component only — see issue for why
+     the shared token isn't changed. Dark mode already passes (~6.85:1), so it
+     resets to the token below. */
+  color: #8c5a08;
   background: var(--color-warning-bg);
+}
+
+[data-theme="dark"] .warning {
+  color: var(--color-warning);
 }
 
 .error {

--- a/src/components/StatusBadge/StatusBadge.module.css
+++ b/src/components/StatusBadge/StatusBadge.module.css
@@ -22,32 +22,29 @@
   background: currentcolor;
 }
 
+/* WCAG AA override (issue #267): --color-success/--color-warning on their
+   pill backgrounds compute to ~3.68:1/~3.66:1 (fail AA's 4.5:1 for normal
+   text). Each is darkened via a component-local custom property, scoped to
+   StatusBadge only — see issue for why the shared tokens aren't changed.
+   Dark mode already passes for both, so it resets to the shared token. */
 .success {
-  /* WCAG AA override (issue #267): --color-success (#1F8A5B) on this pill's
-     composited background is only ~3.68:1 (fails AA's 4.5:1 for normal text).
-     Darkened to #1A754D (~4.83:1) for this component only — see issue for why
-     the shared token isn't changed. Dark mode already passes (~6.86:1), so it
-     resets to the token below. */
-  color: #1a754d;
+  --status-success-fg: #1a754d; /* ~4.83:1 */
+  color: var(--status-success-fg);
   background: var(--color-success-bg);
 }
 
 [data-theme="dark"] .success {
-  color: var(--color-success);
+  --status-success-fg: var(--color-success);
 }
 
 .warning {
-  /* WCAG AA override (issue #267): --color-warning (#A66E0A) on this pill's
-     composited background is only ~3.66:1 (fails AA's 4.5:1 for normal text).
-     Darkened to #8C5A08 (~4.96:1) for this component only — see issue for why
-     the shared token isn't changed. Dark mode already passes (~6.85:1), so it
-     resets to the token below. */
-  color: #8c5a08;
+  --status-warning-fg: #8c5a08; /* ~4.96:1 */
+  color: var(--status-warning-fg);
   background: var(--color-warning-bg);
 }
 
 [data-theme="dark"] .warning {
-  color: var(--color-warning);
+  --status-warning-fg: var(--color-warning);
 }
 
 .error {


### PR DESCRIPTION
Closes #267

## What changed

Darkened `StatusBadge`'s light-mode `success`/`warning` tone text colors so they meet WCAG AA's 4.5:1 contrast requirement against their pill backgrounds:

- `.success`: `--color-success` (#1F8A5B, ~3.68:1) → `#1a754d` (~4.83:1)
- `.warning`: `--color-warning` (#A66E0A, ~3.66:1) → `#8c5a08` (~4.96:1)

Both are scoped as component-local CSS custom properties (`--status-success-fg`/`--status-warning-fg`), not raw hex inline, following the existing local-custom-property precedent in `RecipeSearch.module.css`/`Callout.module.css`. Dark mode already passed for both tones (~6.86:1/~6.85:1) and is left untouched via a `[data-theme="dark"]` override that resets back to the shared token. `.error` and `.neutral` were already passing (~4.70:1) and are untouched. No changes to `StatusBadge.tsx` or the shared `tokens.css` — `background` values are unchanged, so this is a pure color-value fix with no layout/behavior change.

## Why

`axe-core` flagged a serious color-contrast violation on `StatusBadge`'s `success` tone (used for the "Published" pill on the admin Recipe list/Recipe Editor pages) during manual verification while reviewing #228. WCAG 2.1 AA requires 4.5:1 for normal-weight text at this size; the pre-existing token pairing fell short. The issue also asked to check `warning`/`error` for the same pattern — `warning` had the same failure, `error` did not.

## How to verify

1. Load the admin Recipe list and Recipe Editor pages in light mode; visually confirm the "Published" (success) and any "Draft"/warning-tone pills still read clearly with slightly darker green/amber text.
2. Toggle dark mode; confirm no visible change (dark mode was already passing and is untouched).
3. **Manual axe check needed** — `axe-core`'s `color-contrast` rule cannot execute in this repo's Vitest/jsdom environment at all (jsdom has no `HTMLCanvasElement` 2D context, which axe's contrast rule requires; confirmed via reproducible `getContext` "Not implemented" errors in every axe-instrumented test run, before and after this change). This is a pre-existing environment limitation, not something introduced here, and matches how the original bug was found (manual axe verification, per the issue's Context section). Please run axe DevTools (or Lighthouse) against the admin Recipe list and Recipe Editor pages in a real browser before merging, to close out the issue's AC #2 ("axe reports zero color-contrast violations").
4. `pnpm test` (762/762 passing), `pnpm lint` (0 errors — 4 pre-existing unrelated warnings in `src/components/icons.tsx`), `pnpm exec tsc --noEmit` (0 errors).

## Decisions made

- Fixed this locally in `StatusBadge.module.css` rather than changing the shared `--color-success`/`--color-warning` tokens in `tokens.css`, per the issue's explicit scoping — those tokens are consumed by ~14 other components/pages, and a global change would ripple into unrelated visual changes outside this issue's scope.
- Used component-local custom properties (`--status-success-fg`/`--status-warning-fg`) instead of bare hex literals directly on `color`, per a `/simplify` reuse finding — this matches an existing pattern elsewhere in the codebase and keeps the override greppable/nameable rather than a magic string buried in a comment.
- No new automated test was added for the contrast fix itself — `axe-core`'s `color-contrast` rule can't run under jsdom (see above), and the only alternative (asserting `getComputedStyle(...).color` directly) would be hollow, since this project's Vitest config doesn't inject real CSS Modules styles into jsdom (no `css: true`), so computed style wouldn't reflect the actual cascade. Existing `StatusBadge.test.tsx` coverage (renders/visibility per tone) is unaffected and still accurately covers the component's real behavior.

## Out of scope (filed as follow-up issue)

- **#272** — Audit whether the same `--color-success`/`--color-warning`-on-tinted-background pairing pattern fails AA contrast elsewhere too (`Toast.module.css` success glyph, `RecipeList.module.css` hover state, `Callout.module.css` tip label). Surfaced by `/simplify` (altitude angle); deferred because auditing every consumer touches files well outside this issue's StatusBadge-only scope.