### PR TITLE
RecipeDetailView ingredients hint/serves-label text fails color-contrast (4.34:1, needs 4.5:1)

### DIFF
--- a/src/components/RecipeDetailView/RecipeDetailView.module.css
+++ b/src/components/RecipeDetailView/RecipeDetailView.module.css
@@ -136,6 +136,18 @@
   border-radius: var(--radius-xl);
   background: var(--color-surface);
   padding: 22px 22px 14px;
+  /* WCAG AA override: --color-text-faint is tuned against --color-bg
+     (#FBFAF7), not this panel's --color-surface (#F4F1EA), so it falls
+     short here — #767066 on #F4F1EA is ~4.35:1 (fails 4.5:1). Darkened
+     locally to #706A60 (~4.75:1) for text inside this panel. */
+  --ingredients-panel-faint-fg: #706A60;
+}
+
+[data-theme="dark"] .ingredientsPanel {
+  /* Same shortfall in dark mode: --color-text-faint (#877F73) on this
+     panel's dark --color-surface (#1C1A15) is ~4.40:1 (fails 4.5:1).
+     Lightened locally to #8C8478 (~4.71:1). */
+  --ingredients-panel-faint-fg: #8C8478;
 }
 
 .ingredientsHead {
@@ -158,13 +170,13 @@
 .servesLabel {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  color: var(--color-text-faint);
+  color: var(--ingredients-panel-faint-fg);
   white-space: nowrap;
 }
 
 .ingredientsHint {
   font-size: var(--font-size-xs);
-  color: var(--color-text-faint);
+  color: var(--ingredients-panel-faint-fg);
   margin: 0 0 var(--space-3);
 }
 

--- a/src/components/RecipeDetailView/RecipeDetailView.module.css
+++ b/src/components/RecipeDetailView/RecipeDetailView.module.css
@@ -170,13 +170,13 @@
 .servesLabel {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  color: var(--ingredients-panel-faint-fg);
+  color: var(--ingredients-panel-faint-fg, var(--color-text-faint));
   white-space: nowrap;
 }
 
 .ingredientsHint {
   font-size: var(--font-size-xs);
-  color: var(--ingredients-panel-faint-fg);
+  color: var(--ingredients-panel-faint-fg, var(--color-text-faint));
   margin: 0 0 var(--space-3);
 }
 

--- a/src/components/RecipeIngredients/RecipeIngredients.module.css
+++ b/src/components/RecipeIngredients/RecipeIngredients.module.css
@@ -61,7 +61,14 @@
 
 .checkbox:checked ~ .name {
   text-decoration: line-through;
-  color: var(--color-text-faint);
+  /* WCAG AA override: --color-text-faint fails 4.5:1 against this
+     panel's --color-surface (4.35:1 light / 4.40:1 dark) — see
+     RecipeDetailView.module.css's .ingredientsPanel comment. Reuses
+     the same panel-scoped custom property (inherited down the DOM
+     tree from the .ingredientsPanel ancestor this always renders
+     inside), falling back to the original token if ever rendered
+     without that ancestor. */
+  color: var(--ingredients-panel-faint-fg, var(--color-text-faint));
 }
 
 .qty {
@@ -72,7 +79,7 @@
 }
 
 .checkbox:checked ~ .qty {
-  color: var(--color-text-faint);
+  color: var(--ingredients-panel-faint-fg, var(--color-text-faint));
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Closes #268

## What changed

Fixed AA-contrast failures on `RecipeDetailView`'s ingredients panel:

- `.servesLabel` ("Serves 2") and `.ingredientsHint` ("Tap to check off as you go.") were both `color: var(--color-text-faint)` on `--color-surface` — computing to ~4.35:1 light / ~4.40:1 dark, both failing WCAG AA's 4.5:1.
- Also found and fixed the same failure on `RecipeIngredients`'s checked-off ingredient text (`.checkbox:checked ~ .name`/`.qty`) — this component renders directly inside the same `.ingredientsPanel`, on the same background, so it had the identical bug, just reachable via the `:checked` state rather than unconditional markup.

Fix: a component-local custom property `--ingredients-panel-faint-fg` declared on `.ingredientsPanel` (light `#706A60` ≈4.75:1) with a `[data-theme="dark"]` override (`#8C8478` ≈4.71:1). All four affected rules read it via `var(--ingredients-panel-faint-fg, var(--color-text-faint))` — the fallback keeps them safe if ever rendered outside `.ingredientsPanel`. `RecipeIngredients.module.css` consumes the property cross-file via ordinary DOM/CSS inheritance (confirmed precedented elsewhere in this codebase: `Callout`→`BlogPost`, `RecipeSearch`→`Input`). `.stepsLabel` (also uses `--color-text-faint`, but sits on `--color-bg` where the token already passes) and the shared `tokens.css` token itself were left untouched.

## Why

`axe-core` flagged a serious color-contrast violation on the ingredients panel during manual verification while reviewing #229 (the admin Recipe Preview page reuses this same shared component). WCAG 2.1 AA requires 4.5:1 for normal-weight text at this size. The issue also asked to check dark mode, since the underlying token might share the shortfall — it did.

## How to verify

1. Load the public `/recipes/:slug` page and the admin Recipe Preview page in light mode; confirm "Serves N", the ingredients hint, and a checked-off ingredient all still read clearly with slightly darker muted text.
2. Toggle dark mode; confirm the same three states read clearly with slightly lighter muted text.
3. **Manual axe check needed** — same as the already-merged sibling issue #267 (PR #273): `axe-core`'s `color-contrast` rule cannot execute under this repo's jsdom test environment (no `HTMLCanvasElement` 2D context). Please run axe DevTools/Lighthouse against the public Recipe page and admin Recipe Preview page in a real browser before merging, to close out AC #2.
4. `pnpm test` (762/762 passing), `pnpm lint` (0 errors — 4 pre-existing unrelated warnings in `src/components/icons.tsx`), `pnpm exec tsc --noEmit` (0 errors).

## Decisions made

- Fixed locally via a component-scoped custom property rather than changing the shared `--color-text-faint` token in `tokens.css`, since that token is consumed by many other components (`text.module.css`, `TagInput`, `Footer`, `Input`, `Toast`, `RecipeCard`, `UserManagement`, `RecipeEditor`, `RecipeList`, `Recipes`, `Login`) most of which sit on `--color-bg`, where it already passes.
- Extended the fix from the two classes named in the issue to also cover `RecipeIngredients`'s checked-item text, after an independent review pass caught that it shares the identical bug in the identical panel — same root cause, reachable by ordinary use (checking off an ingredient), so fixing it in this PR rather than filing a separate issue.
- Added a `var(x, fallback)` guard on all four consuming rules (including the two named in the issue, which didn't strictly need it but gain the same defensiveness) so nothing silently breaks if any of these classes is ever rendered outside `.ingredientsPanel`.

## Out of scope (filed as follow-up issue)

- **#274** — Audit whether the same `--color-text-faint`-on-`--color-surface`/`--color-field` pairing pattern fails AA contrast elsewhere too (`TagInput.module.css:45` chip remove button, `Input.module.css:72` prefix icon — both flagged by `/simplify`'s altitude pass as likely failing the same way, unaudited). Deferred because auditing every consumer touches files well outside this issue's ingredients-panel scope.