### PR TITLE
Audit --color-success/--color-warning-on-tinted-bg pairings for AA contrast

### DIFF
--- a/src/components/Callout/Callout.module.css
+++ b/src/components/Callout/Callout.module.css
@@ -44,8 +44,19 @@
   background: color-mix(in srgb, var(--color-success) 6%, var(--color-surface));
 }
 
+/* WCAG AA override (issue #272): --color-success on this tint (6%
+   color-mix into --color-surface — an even lighter wash than
+   StatusBadge's 10% alpha pill) computes to ~3.59:1, worse than the
+   failing 3.68:1 StatusBadge (#267) case. Reusing that issue's exact
+   override color here (~4.70:1 against this backdrop) for consistency.
+   Dark mode already passes (~7.10:1), so it resets to the shared token. */
 .tip .label {
-  color: var(--color-success);
+  --callout-tip-fg: #1a754d; /* ~4.70:1 */
+  color: var(--callout-tip-fg);
+}
+
+[data-theme="dark"] .tip .label {
+  --callout-tip-fg: var(--color-success);
 }
 
 .warning {
@@ -53,8 +64,18 @@
   background: color-mix(in srgb, var(--color-warning) 6%, var(--color-surface));
 }
 
+/* WCAG AA override (issue #272): same pattern as `.tip .label` above but
+   for --color-warning — this 6% tint computes to ~3.58:1 (fails AA).
+   Reusing StatusBadge's (#267) exact warning override color (~4.85:1
+   against this backdrop). Dark mode already passes (~7.38:1), so it
+   resets to the shared token. */
 .warning .label {
-  color: var(--color-warning);
+  --callout-warning-fg: #8c5a08; /* ~4.85:1 */
+  color: var(--callout-warning-fg);
+}
+
+[data-theme="dark"] .warning .label {
+  --callout-warning-fg: var(--color-warning);
 }
 
 .info {

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -80,10 +80,24 @@
   color: var(--color-text-muted);
 }
 
+/* WCAG AA override (issue #272): --color-success on --color-success-bg,
+   composited over this Toast's own --color-bg backdrop, computes to
+   ~3.68:1 (fails AA's 4.5:1 for normal text) — the glyph is text content,
+   not decorative, so this is a live failure, not just a hover-state blind
+   spot. Same failing token pairing StatusBadge (#267) hit; reusing its
+   exact override color here (~4.83:1 against this backdrop) rather than
+   tuning a new one, for visual consistency across "success text on its
+   own tint" everywhere in the app. Dark mode already passes (~6.87:1), so
+   it resets to the shared token. */
 .success::before {
   content: '✓';
   background: var(--color-success-bg);
-  color: var(--color-success);
+  --toast-success-fg: #1a754d; /* ~4.83:1 */
+  color: var(--toast-success-fg);
+}
+
+[data-theme="dark"] .success::before {
+  --toast-success-fg: var(--color-success);
 }
 
 .error::before {

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -223,11 +223,14 @@
    composited over this row's --color-field backdrop, computes to ~3.83:1
    (fails AA's 4.5:1) — axe doesn't probe :hover states, which is likely
    why this wasn't already flagged. Same failing pairing as StatusBadge
-   (#267); reusing its exact override color (~5.01:1 against this
-   backdrop) for consistency. Dark mode already passes (~6.40:1), so it
-   resets to the shared token. */
+   (#267); reusing its exact override color for consistency. Note
+   .row:hover also fires here (hovering a child hovers its ancestor),
+   layering --color-hover under this button's own background, which
+   brings the real margin to ~4.80:1 (not the ~5.01:1 you'd get against
+   --color-field alone) — still comfortably passes. Dark mode already
+   passes (~6.40:1), so it resets to the shared token. */
 .rowActions .publishAction:hover {
-  --publish-action-fg: #1a754d; /* ~5.01:1 */
+  --publish-action-fg: #1a754d; /* ~4.80:1, accounting for stacked .row:hover */
   color: var(--publish-action-fg);
   background: var(--color-success-bg);
 }

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -219,9 +219,21 @@
   background: var(--color-hover);
 }
 
+/* WCAG AA override (issue #272): --color-success on --color-success-bg,
+   composited over this row's --color-field backdrop, computes to ~3.83:1
+   (fails AA's 4.5:1) — axe doesn't probe :hover states, which is likely
+   why this wasn't already flagged. Same failing pairing as StatusBadge
+   (#267); reusing its exact override color (~5.01:1 against this
+   backdrop) for consistency. Dark mode already passes (~6.40:1), so it
+   resets to the shared token. */
 .rowActions .publishAction:hover {
-  color: var(--color-success);
+  --publish-action-fg: #1a754d; /* ~5.01:1 */
+  color: var(--publish-action-fg);
   background: var(--color-success-bg);
+}
+
+[data-theme="dark"] .rowActions .publishAction:hover {
+  --publish-action-fg: var(--color-success);
 }
 
 .rowActions .deleteAction:hover {


### PR DESCRIPTION
Closes #272

## What changed

Audited every `--color-success`/`--color-warning` text-on-its-own-tint pairing in the codebase (the same defect class #267 fixed in `StatusBadge`) for WCAG AA contrast. Found and fixed 4 more failing instances, all in light mode only (dark mode already passed everywhere):

| Location | Before | After |
|---|---|---|
| `Toast.module.css` `.success::before` (the ✓ glyph) | 3.68:1 | 4.83:1 |
| `RecipeList.module.css` `.rowActions .publishAction:hover` | 3.83:1 | ~4.80:1 (stacked `.row:hover` wash accounted for) |
| `Callout.module.css` `.tip .label` | 3.59:1 | 4.70:1 |
| `Callout.module.css` `.warning .label` | 3.58:1 | 4.85:1 |

Each fix reuses #267's exact override colors (`#1a754d` success, `#8c5a08` warning) via a component-local custom property with a `[data-theme="dark"]` reset, for visual consistency across every "success/warning text on its own tint" instance in the app.

**Measured and correctly left unchanged** (not text-on-tint, or already passing):
- `UserManagement.module.css`'s status dot — solid background, not text; passes the 3:1 non-text bar (WCAG 1.4.11) with room to spare.
- `RecipeEditor.module.css`'s slug-lock icon and `RecipePreview.module.css`'s status icon — both `aria-hidden` icons, not text; pass the 3:1 icon bar even where the stricter 4.5:1 text bar would fail.
- `AutosaveStatus.module.css`'s saved/error icons — also `aria-hidden`, same reasoning.

No shared "on-tint" token was introduced in this PR — only 4 distinct failing consumers were found, which is what the issue's own criteria treated as below the threshold for a token-level change (see "Out of scope" below for the follow-up this later prompted).

## Why

#267 fixed `StatusBadge` in isolation, deliberately, to stay in scope. This issue existed to check whether the same token pairing fails elsewhere too — it does, in 3 of the 4 places already suspected, plus one more (`Callout`'s warning variant) found by checking the rest of that same file.

## How to verify

1. Trigger a success toast, hover the "Publish" action on the admin Recipe list, and view a Callout with `tone="tip"`/`tone="warning"` on the docs/blog content that uses them — in both light and dark mode, confirm the text still reads clearly (slightly darker green/amber in light mode only).
2. **Manual axe check needed**, same limitation as #267/#268: `axe-core`'s `color-contrast` rule cannot execute under this repo's jsdom test environment (no canvas). One of the four fixes (`RecipeList`'s `:hover` state) is additionally unreachable by axe even in a real browser, since axe only scans default DOM state — that one needs a manual hover-and-inspect check specifically.
3. `pnpm test` (762/762 passing), `pnpm lint` (0 errors — 4 pre-existing unrelated warnings), `pnpm exec tsc --noEmit` (0 errors).

## Decisions made

- Reused #267's exact hex values rather than deriving fresh ones per component, for visual consistency (all four instances mean the same semantic thing — "success/warning text on a tint of itself").
- Did not touch the shared `--color-success`/`--color-warning`/`-bg` tokens in `tokens.css` — many other consumers rely on their current values against `--color-bg`, where they already pass.
- A review pass flagged that `RecipeList.module.css`'s `.rowActions .publishAction:hover` also triggers the ancestor `.row:hover` background wash, which stacks under the button's own tint — corrected the contrast comment from ~5.01:1 to the accurate ~4.80:1 (still comfortably passes; this was a comment-precision fix, not a code change).

## Out of scope (filed as follow-up issue)

- **#276** — Now that 5 rules across 4 files (this PR's 4 plus the already-merged `StatusBadge`) hardcode the identical `#1a754d`/`#8c5a08` pair, a review pass flagged this as having crossed the issue's own stated threshold for promoting to a shared `tokens.css` token. Deferred because centralizing it means touching `StatusBadge.module.css`, which is outside this issue's file scope and is a structural refactor that deserves its own review.