### PR TITLE
Add a component-box max-width tier to the paper token scale

### DIFF
--- a/docs/design/paper/design_system/tokens/spacing.css
+++ b/docs/design/paper/design_system/tokens/spacing.css
@@ -44,6 +44,7 @@
   --max-w-reading: 720px;  /* index + hero reading column */
   --max-w-article: 680px;  /* long-form article column */
   --max-w-prose:   54ch;   /* hero paragraph measure */
+  --max-w-sm:      24rem;  /* compact component box — dialogs, cards, toasts */
 
   /* Z-index */
   --z-header:  20;

--- a/docs/design/paper/token-migration.md
+++ b/docs/design/paper/token-migration.md
@@ -129,16 +129,20 @@ with text measure. Each usage was evaluated on its own layout role:
 | Consumer | Old | Role | Resolution |
 |---|---|---|---|
 | `AppsCta.module.css` `.inner`, `CVDownload.module.css` `.inner` | `--max-w-2xl` (672px) | Centered CTA text section | **Clean fit** → `--max-w-article` (680px, 1% off). Semantically right (a text-centered content block) and numerically almost exact. |
-| `ConfirmDialog.module.css` `.dialog` | `--max-w-sm` (384px) | Modal dialog width | **No fit** — smallest new token (680px) is ~1.8× this box; forcing it would nearly double every confirm dialog's width. Kept as a commented literal `24rem`, flagged for a possible future `--max-w-dialog`/`--max-w-sm` re-add to the design system. |
-| `SocialCard.module.css` `.card` | `--max-w-sm` (384px) | Compact footer card | Same reasoning as `ConfirmDialog` — literal `24rem`, flagged. |
-| `FullPageHeader.module.css` `.imageWrapper` (3 responsive tiers) | `--max-w-xs`/`--max-w-md`/`--max-w-lg` (320/448/512px) | Portrait image width cap, not a text column | Same reasoning — literals `20rem`/`28rem`/`32rem` preserving the exact prior px-equivalent values, flagged. In practice this cap is usually dominated by the 50%-flex-column width at typical viewports, so the visual impact of *not* forcing a token here is minimal, but the value itself has no honest semantic home in the current 4-token max-w scale. |
+| `ConfirmDialog.module.css` `.dialog`, `SocialCard.module.css` `.card`, `ToastProvider.module.css` `.container` | `--max-w-sm` (384px) | Modal dialog / compact footer card / toast stack width | **Resolved (issue #233):** the design system gained a `--max-w-sm` (24rem / 384px) compact-component-box tier, added alongside the reading-column scale specifically for non-text boxes. All three consumers, previously kept as commented `24rem` literals, now reference `var(--max-w-sm)`. |
 
-**Deviation from the "always use the nearest existing token" instruction:** for the three
-component-box cases above, using the nearest available token (`--max-w-article`, 680px)
-would visibly break the component (dialog/card nearly doubling in width, hero portrait
-overshooting its column). This is flagged explicitly rather than silently forced — if the
-design system later adds a smaller max-width step (e.g. `--max-w-sm` ~24rem for
-dialogs/cards), these three literals should switch to it.
+`FullPageHeader.module.css` no longer exists in the codebase (the hero portrait now lives in
+`Home.module.css` `.photo`, sized with a `clamp()`, not a breakpoint-tiered max-width), so the
+`20rem`/`28rem`/`32rem` literals this section originally described have nothing left to
+migrate. `Login.module.css` `.column` uses `max-width: 392px`, not `24rem` — a different value,
+not this token's consumer — so it was left untouched by #233 (swapping in `--max-w-sm` would
+shrink it by 8px, a real visual change, not a refactor).
+
+**Deviation from the "always use the nearest existing token" instruction (historical, #218):**
+before #233 added `--max-w-sm`, using the nearest available token (`--max-w-article`, 680px)
+for the cases above would have visibly broken the component (dialog/card nearly doubling in
+width). That's why they were kept as flagged literals rather than forced onto `--max-w-article`
+at the time — #233 is the "later" this note referred to.
 
 ## 4. Meaning flips (name unchanged, semantics changed)
 

--- a/src/components/ConfirmDialog/ConfirmDialog.module.css
+++ b/src/components/ConfirmDialog/ConfirmDialog.module.css
@@ -4,9 +4,8 @@
   border-radius: var(--radius-2xl);
   box-shadow: var(--shadow-xl);
   padding: var(--space-6);
-  /* No paper max-w token fits a dialog; see token-migration.md §3c — kept
-     as a literal, capped against the viewport for small screens. */
-  inline-size: min(92vw, 24rem);
+  /* --max-w-sm capped against the viewport for small screens. */
+  inline-size: min(92vw, var(--max-w-sm));
   color: var(--color-text);
 }
 

--- a/src/components/SocialCard/SocialCard.module.css
+++ b/src/components/SocialCard/SocialCard.module.css
@@ -9,8 +9,7 @@
   margin-inline: auto;
   padding-block: var(--space-6);
   padding-inline: var(--space-6);
-  /* No paper max-w token fits; see token-migration.md §3c. */
-  max-width: 24rem;
+  max-width: var(--max-w-sm);
 }
 
 .heading {

--- a/src/contexts/ToastContext/ToastProvider.module.css
+++ b/src/contexts/ToastContext/ToastProvider.module.css
@@ -3,7 +3,7 @@
   inset-block-end: var(--space-4);
   inset-inline-end: var(--space-4);
   z-index: var(--z-toast);
-  max-width: min(24rem, calc(100vw - 2 * var(--space-4)));
+  max-width: min(var(--max-w-sm), calc(100vw - 2 * var(--space-4)));
 }
 
 .list {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -152,6 +152,7 @@
   --max-w-article: 680px;  /* long-form article column */
   --max-w-prose:   54ch;   /* hero paragraph measure */
   --max-w-prose-narrow: 46ch; /* short paragraph measure (in-progress notes, kitchen intro) */
+  --max-w-sm:      24rem;  /* compact component box — dialogs, cards, toasts */
 
   /* ── Z-index ──────────────────────────────────────────────── */
   --z-header:  20;


### PR DESCRIPTION
Closes #233

## What changed
- Added `--max-w-sm: 24rem` to `src/styles/tokens.css` and `docs/design/paper/design_system/tokens/spacing.css` — a new compact component-box tier alongside the existing reading-column `--max-w-*` scale (site/reading/article/prose).
- Migrated `ConfirmDialog`, `SocialCard`, and the toast stack (`ToastProvider.module.css` — the actual 24rem-constrained element; `Toast.module.css` itself has no max-width rule) from hardcoded `24rem` literals to `var(--max-w-sm)`.
- Updated `docs/design/paper/token-migration.md` §3c to reflect the token's existence and replace the old "no fit, kept as literal, flagged" language.

## Why
Four components independently converged on the same ~24rem box width during #218's token migration with no token to reference — a signal the `--max-w-*` scale was missing a tier for compact, non-text component boxes (dialogs, cards, toasts), not that these components had one-off needs.

## How to verify
- `grep -rn "24rem" src/components/ConfirmDialog src/components/SocialCard src/contexts/ToastContext` shows no remaining literals — all reference `var(--max-w-sm)`.
- Visually: ConfirmDialog, SocialCard, and toast notifications render at identical widths to before (the token's value equals the literals it replaces, so there is no visual change).
- `pnpm test` (762/762 passing), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean).

## Decisions made
- **Token name/value**: `--max-w-sm` at `24rem`, per the resolution already proposed in `token-migration.md` §3c during #218's review (this issue is the "later" that note referred to).
- **FullPageHeader not migrated**: `FullPageHeader.module.css` no longer exists in the codebase — it was deleted in a prior `/simplify` pass (commit `413b110`). The hero portrait now lives in `Home.module.css` `.photo`, sized with a fluid `clamp()`, not a breakpoint-tiered max-width. Nothing to migrate.
- **Login not migrated**: `Login.module.css` `.column` uses `max-width: 392px`, not `24rem` (384px) — a different value. Since the issue's AC requires pixel-identical layout and explicitly puts value changes out of scope, this was left untouched rather than silently shrinking the login card by 8px.

## Out of scope
None filed — `/simplify` (4 parallel review angles: reuse, simplification, efficiency, altitude) returned no actionable findings on this diff.