### PR TITLE
TagInput: add keyboard navigation to suggestions listbox

### DIFF
--- a/src/components/TagInput/TagInput.module.css
+++ b/src/components/TagInput/TagInput.module.css
@@ -95,7 +95,8 @@
   cursor: pointer;
   transition:
     border-color var(--duration-fast) var(--easing-default),
-    color var(--duration-fast) var(--easing-default);
+    color var(--duration-fast) var(--easing-default),
+    background-color var(--duration-fast) var(--easing-default);
 }
 
 /* Decorative "+" affordance from the design (TagInput.jsx renders "+ {tag}")
@@ -103,6 +104,23 @@
    labels aren't meaningfully different without it (purely visual). */
 .option::before {
   content: '+ ';
+}
+
+/* Arrow-key highlight — the ARIA state set via `aria-selected` on the
+   option already carries the semantics, so this keys off the attribute
+   directly rather than duplicating it as a second CSS Modules class.
+   Reuses `chipHover`'s own border/text treatment (border-color + color
+   swapped to --color-primary) so keyboard arrow-highlight and mouse
+   hover read as the same visual weight, plus a tinted background so the
+   *persistent* keyboard-selected state stays visible even without the
+   pointer sitting on it. The 10% color-mix background matches this
+   project's established "accent" fill (see UserManagement.module.css's
+   `.rolePillAdmin`, same color-mix(...transparent) shape as the --ring
+   token — the design's --accent-bg is rgba(31,102,224,0.10)). */
+.option[aria-selected='true'] {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: color-mix(in srgb, var(--color-primary) 10%, transparent);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/TagInput/TagInput.test.tsx
+++ b/src/components/TagInput/TagInput.test.tsx
@@ -86,4 +86,173 @@ describe('TagInput', () => {
 
     expect(input).toHaveAttribute('aria-expanded', 'true')
   })
+
+  // Keyboard navigation (#237). Bounds behaviour chosen: ArrowDown/ArrowUp CLAMP
+  // at the first/last option rather than wrapping around.
+
+  it('ArrowDown highlights the first suggestion via aria-selected, leaving others unselected', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+    expect(options[1]).toHaveAttribute('aria-selected', 'false')
+    expect(options[2]).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('ArrowDown pressed again moves the highlight to the next suggestion', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveAttribute('aria-selected', 'false')
+    expect(options[1]).toHaveAttribute('aria-selected', 'true')
+    expect(options[2]).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('ArrowDown stops at the last suggestion instead of wrapping back to the first', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveAttribute('aria-selected', 'false')
+    expect(options[1]).toHaveAttribute('aria-selected', 'false')
+    expect(options[2]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('ArrowUp moves the highlight back to the previous suggestion', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+    expect(options[1]).toHaveAttribute('aria-selected', 'false')
+    expect(options[2]).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('ArrowUp stops at the first suggestion instead of wrapping to the last', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+    expect(options[1]).toHaveAttribute('aria-selected', 'false')
+    expect(options[2]).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('Enter adds the highlighted suggestion, not the raw combobox text', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+
+    // Highlight the second option ("Indian"), which does not match the raw
+    // input text "I" verbatim.
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(mockOnChange).toHaveBeenCalledWith(['Indian'])
+    expect(mockOnChange).not.toHaveBeenCalledWith(['I'])
+  })
+
+  it('Escape closes the suggestion list without adding a tag', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(mockOnChange).not.toHaveBeenCalled()
+  })
+
+  it('ArrowDown/ArrowUp are no-ops when no suggestions are open', () => {
+    render(<TagInput tags={[]} onChange={mockOnChange} existingTags={['Italian']} />)
+
+    const input = screen.getByRole('combobox')
+
+    expect(() => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' })
+      fireEvent.keyDown(input, { key: 'ArrowUp' })
+    }).not.toThrow()
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(input).toHaveValue('')
+    expect(mockOnChange).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/TagInput/TagInput.test.tsx
+++ b/src/components/TagInput/TagInput.test.tsx
@@ -255,4 +255,89 @@ describe('TagInput', () => {
     expect(input).toHaveValue('')
     expect(mockOnChange).not.toHaveBeenCalled()
   })
+
+  // aria-activedescendant tracking (#237)
+
+  it('has no aria-activedescendant on initial render', () => {
+    render(<TagInput tags={[]} onChange={mockOnChange} existingTags={['Italian']} />)
+
+    const input = screen.getByRole('combobox')
+
+    expect(input).not.toHaveAttribute('aria-activedescendant')
+  })
+
+  it('has no aria-activedescendant after typing, before any arrow key press', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    expect(input).not.toHaveAttribute('aria-activedescendant')
+  })
+
+  it('sets aria-activedescendant to the highlighted option id and updates it as ArrowDown moves', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+    let options = screen.getAllByRole('option')
+    expect(input.getAttribute('aria-activedescendant')).toBe(options[0].id)
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+    options = screen.getAllByRole('option')
+    expect(input.getAttribute('aria-activedescendant')).toBe(options[1].id)
+  })
+
+  it('has no aria-activedescendant after Escape resets the highlight', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(input).not.toHaveAttribute('aria-activedescendant')
+  })
+
+  it('has no aria-activedescendant after Enter adds the highlighted tag', () => {
+    render(
+      <TagInput
+        tags={[]}
+        onChange={mockOnChange}
+        existingTags={['Italian', 'Indian', 'Irish']}
+      />
+    )
+
+    const input = screen.getByRole('combobox')
+    fireEvent.change(input, { target: { value: 'I' } })
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(input).not.toHaveAttribute('aria-activedescendant')
+  })
 })

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -91,6 +91,11 @@ const TagInput: FC<TagInputProps> = ({
           role="combobox"
           aria-expanded={isExpanded}
           aria-controls={listboxId}
+          aria-activedescendant={
+            isExpanded && highlightedIndex >= 0
+              ? `${listboxId}-option-${highlightedIndex}`
+              : undefined
+          }
           value={inputValue}
           onChange={(e) => handleInputChange(e.target.value)}
           onKeyDown={handleKeyDown}
@@ -101,18 +106,17 @@ const TagInput: FC<TagInputProps> = ({
         {isExpanded && (
           <ul id={listboxId} role="listbox" className={styles.listbox}>
             {filtered.map((tag, index) => (
+              // Keyboard selection is handled by the input's own onKeyDown (Enter
+              // selects filtered[highlightedIndex] via the same addTag call); DOM
+              // focus never leaves the input, per the WAI-ARIA combobox pattern.
+              // eslint-disable-next-line jsx-a11y/click-events-have-key-events
               <li
                 key={tag}
+                id={`${listboxId}-option-${index}`}
                 role="option"
                 aria-selected={index === highlightedIndex}
                 className={styles.option}
                 onClick={() => addTag(tag)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    addTag(tag)
-                  }
-                }}
               >
                 {tag}
               </li>

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -19,6 +19,8 @@ const TagInput: FC<TagInputProps> = ({
   placeholder,
 }) => {
   const [inputValue, setInputValue] = useState('')
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const [suggestionsClosed, setSuggestionsClosed] = useState(false)
   const listboxId = useId()
 
   const filtered = inputValue
@@ -27,25 +29,49 @@ const TagInput: FC<TagInputProps> = ({
       )
     : []
 
-  const isExpanded = filtered.length > 0
+  const isExpanded = filtered.length > 0 && !suggestionsClosed
 
   const addTag = (tag: string) => {
     if (tag.trim() && !tags.includes(tag.trim())) {
       onChange([...tags, tag.trim()])
     }
     setInputValue('')
+    setHighlightedIndex(-1)
+    setSuggestionsClosed(false)
   }
 
   const removeTag = (index: number) => {
     onChange(tags.filter((_, i) => i !== index))
   }
 
+  const handleInputChange = (value: string) => {
+    setInputValue(value)
+    setHighlightedIndex(-1)
+    setSuggestionsClosed(false)
+  }
+
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'ArrowDown') {
+      if (!isExpanded) return
       e.preventDefault()
-      if (inputValue.trim()) {
+      setHighlightedIndex((i) => Math.min(i + 1, filtered.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      if (!isExpanded) return
+      e.preventDefault()
+      setHighlightedIndex((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      const highlighted = isExpanded ? filtered[highlightedIndex] : undefined
+      if (highlighted) {
+        addTag(highlighted)
+      } else if (inputValue.trim()) {
         addTag(inputValue)
       }
+    } else if (e.key === 'Escape') {
+      if (!isExpanded) return
+      e.preventDefault()
+      setSuggestionsClosed(true)
+      setHighlightedIndex(-1)
     }
   }
 
@@ -66,7 +92,7 @@ const TagInput: FC<TagInputProps> = ({
           aria-expanded={isExpanded}
           aria-controls={listboxId}
           value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
+          onChange={(e) => handleInputChange(e.target.value)}
           onKeyDown={handleKeyDown}
           className={styles.input}
           placeholder={placeholder}
@@ -74,15 +100,19 @@ const TagInput: FC<TagInputProps> = ({
 
         {isExpanded && (
           <ul id={listboxId} role="listbox" className={styles.listbox}>
-            {filtered.map((tag) => (
-              // Arrow-key highlight + Enter-to-select keyboard nav tracked in #237.
-              // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+            {filtered.map((tag, index) => (
               <li
                 key={tag}
                 role="option"
-                aria-selected="false"
+                aria-selected={index === highlightedIndex}
                 className={styles.option}
                 onClick={() => addTag(tag)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    addTag(tag)
+                  }
+                }}
               >
                 {tag}
               </li>

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -31,13 +31,17 @@ const TagInput: FC<TagInputProps> = ({
 
   const isExpanded = filtered.length > 0 && !suggestionsClosed
 
+  const resetHighlight = () => {
+    setHighlightedIndex(-1)
+    setSuggestionsClosed(false)
+  }
+
   const addTag = (tag: string) => {
     if (tag.trim() && !tags.includes(tag.trim())) {
       onChange([...tags, tag.trim()])
     }
     setInputValue('')
-    setHighlightedIndex(-1)
-    setSuggestionsClosed(false)
+    resetHighlight()
   }
 
   const removeTag = (index: number) => {
@@ -46,20 +50,11 @@ const TagInput: FC<TagInputProps> = ({
 
   const handleInputChange = (value: string) => {
     setInputValue(value)
-    setHighlightedIndex(-1)
-    setSuggestionsClosed(false)
+    resetHighlight()
   }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'ArrowDown') {
-      if (!isExpanded) return
-      e.preventDefault()
-      setHighlightedIndex((i) => Math.min(i + 1, filtered.length - 1))
-    } else if (e.key === 'ArrowUp') {
-      if (!isExpanded) return
-      e.preventDefault()
-      setHighlightedIndex((i) => Math.max(i - 1, 0))
-    } else if (e.key === 'Enter') {
+    if (e.key === 'Enter') {
       e.preventDefault()
       const highlighted = isExpanded ? filtered[highlightedIndex] : undefined
       if (highlighted) {
@@ -67,8 +62,18 @@ const TagInput: FC<TagInputProps> = ({
       } else if (inputValue.trim()) {
         addTag(inputValue)
       }
+      return
+    }
+
+    if (!isExpanded) return
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setHighlightedIndex((i) => Math.min(i + 1, filtered.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlightedIndex((i) => Math.max(i - 1, 0))
     } else if (e.key === 'Escape') {
-      if (!isExpanded) return
       e.preventDefault()
       setSuggestionsClosed(true)
       setHighlightedIndex(-1)


### PR DESCRIPTION
Closes #237

## What changed
- Arrow-key navigation (`ArrowDown`/`ArrowUp`) moves a clamped `highlightedIndex` through the filtered suggestion list, reflected via `aria-selected` on each `<li role="option">`.
- `Enter` adds the highlighted option through the same `addTag` path the click handler uses; falls back to adding the raw combobox text as a new tag when nothing is highlighted (existing behaviour, unchanged).
- `Escape` closes the suggestions list without adding a tag.
- `aria-activedescendant` on the `<input>` tracks the highlighted option's `id` for screen readers, and a new `.option[aria-selected='true']` CSS rule gives it a visible highlight for sighted keyboard users (both added after review feedback — see "Decisions made").
- Removed the `jsx-a11y/click-events-have-key-events` eslint-disable that previously suppressed a lint warning on the option `<li>`'s `onClick`; see below for a deliberate re-addition of a narrower version of it.
- 12 new tests (5 keyboard-nav + 5 `aria-activedescendant` tracking, on top of 2 that got folded into the existing "click-to-add unchanged" coverage) — 20 total in `TagInput.test.tsx`, all passing.

## Why
WCAG 2.1.1 (Keyboard) — every interactive control operable by pointer must also be operable by keyboard. `TagInput`'s suggestions listbox had a click handler with no keyboard equivalent.

## How to verify
- `pnpm test` (775/775), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean).
- Manually: open a page using `TagInput` with `existingTags` populated, type to open suggestions, use ArrowDown/ArrowUp to move the highlight (now visibly tinted), press Enter to add the highlighted tag, press Escape to dismiss without adding.

## Decisions made
- **Bounds behaviour**: ArrowDown/ArrowUp *clamp* at the first/last suggestion rather than wrapping — matches common combobox/autocomplete conventions (e.g. browser address bars). Documented in test names.
- **Visual highlight added beyond the literal issue text**: review caught that `aria-selected` changing with no CSS hook and no `aria-activedescendant` wiring meant the "highlight" was invisible to sighted keyboard users and unannounced to screen readers — undermining the AC's actual intent, not just its letter. Fixed by wiring `aria-activedescendant` and adding a `.option[aria-selected='true']` style reusing the existing `chipHover` accent tokens plus a persistent background tint (`color-mix`, matching an existing precedent in `UserManagement.module.css`).
- **Suppression re-added, narrower**: the initial implementation removed the `jsx-a11y/click-events-have-key-events` suppression by adding an `onKeyDown` handler directly to the option `<li>` — but that handler could never fire, since DOM focus never leaves the `<input>` (the WAI-ARIA combobox pattern keeps focus on the input and drives selection via `aria-activedescendant`, not by moving focus into the listbox). A senior review flagged this as dead code that fakes standalone keyboard operability. Fixed by removing the dead handler and reinstating a single, narrowly-scoped, comment-justified suppression on just that one element. **This means the issue's literal AC ("the suppression is removed") is not met to the letter** — a deliberate, reviewed tradeoff: an honest justified suppression is preferable to unreachable code that misleads future maintainers.

## Out of scope
None filed — `/simplify` (4 parallel review angles) found two applicable simplification fixes (deduped a repeated `isExpanded` guard and a highlight-reset helper), both applied inline in a follow-up commit. One reuse finding (an `@supports` color-mix fallback) was investigated and skipped as a false positive — only 2 of 15 `color-mix` consumers in the codebase use that fallback, and the file cited as this change's own precedent doesn't have one either.