### PR TITLE
Restore list/listitem ARIA roles on list-style:none lists

### DIFF
--- a/src/components/FileMeta/FileMeta.tsx
+++ b/src/components/FileMeta/FileMeta.tsx
@@ -22,14 +22,21 @@ const FileMeta: FC<FileMetaProps> = ({ fileInfo, hasError }) => {
     const { type, size, date } = fileInfo
 
     return (
-      <ul className={styles.list}>
-        <li>{`${type} format`}</li>
+      // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
+      // `list-style: none` is applied anywhere in it; role="list" (paired
+      // with role="listitem" below) restores it explicitly.
+      // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+      <ul className={styles.list} role="list">
+        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above */}
+        <li role="listitem">{`${type} format`}</li>
         <li aria-hidden="true">•</li>
-        <li>{size}</li>
+        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above */}
+        <li role="listitem">{size}</li>
         {date && (
           <>
             <li aria-hidden="true">•</li>
-            <li>Updated {date}</li>
+            {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above */}
+            <li role="listitem">Updated {date}</li>
           </>
         )}
       </ul>

--- a/src/components/FileMeta/FileMeta.tsx
+++ b/src/components/FileMeta/FileMeta.tsx
@@ -22,10 +22,7 @@ const FileMeta: FC<FileMetaProps> = ({ fileInfo, hasError }) => {
     const { type, size, date } = fileInfo
 
     return (
-      // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
-      // `list-style: none` is applied anywhere in it; role="list" (paired
-      // with role="listitem" below) restores it explicitly.
-      // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+      // eslint-disable-next-line jsx-a11y/no-redundant-roles -- .list sets list-style: none, which drops implicit list semantics in Safari/VoiceOver; role="list" (paired with role="listitem" on each <li>) restores it
       <ul className={styles.list} role="list">
         {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above */}
         <li role="listitem">{`${type} format`}</li>

--- a/src/components/FileTree/FileTree.tsx
+++ b/src/components/FileTree/FileTree.tsx
@@ -43,9 +43,15 @@ const renderNodes = (nodes: TreeNode[], isRoot: boolean): ReactNode => {
   if (nodes.length === 0) return null
 
   return (
-    <ul className={isRoot ? styles.rootList : styles.list}>
+    // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
+    // `list-style: none` is applied anywhere in it (both .rootList and
+    // .list here); role="list" (paired with role="listitem" below)
+    // restores it explicitly.
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+    <ul className={isRoot ? styles.rootList : styles.list} role="list">
       {nodes.map((node, index) => (
-        <li key={`${node.name}-${index}`} className={styles.item}>
+        // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above
+        <li key={`${node.name}-${index}`} className={styles.item} role="listitem">
           <span><span aria-hidden="true">{node.isFolder ? '📁 ' : '📄 '}</span>{node.name}</span>
           {node.children.length > 0 && renderNodes(node.children, false)}
         </li>

--- a/src/components/FileTree/FileTree.tsx
+++ b/src/components/FileTree/FileTree.tsx
@@ -43,11 +43,7 @@ const renderNodes = (nodes: TreeNode[], isRoot: boolean): ReactNode => {
   if (nodes.length === 0) return null
 
   return (
-    // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
-    // `list-style: none` is applied anywhere in it (both .rootList and
-    // .list here); role="list" (paired with role="listitem" below)
-    // restores it explicitly.
-    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- .rootList/.list set list-style: none, which drops implicit list semantics in Safari/VoiceOver; role="list" (paired with role="listitem" on each <li>) restores it
     <ul className={isRoot ? styles.rootList : styles.list} role="list">
       {nodes.map((node, index) => (
         // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -15,10 +15,7 @@ const columnClassMap: Record<NonNullable<GridProps['columns']>, string> = {
 
 const Grid: FC<GridProps> = ({ children, columns = 3 }) => {
   return (
-    // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
-    // `list-style: none` is applied anywhere in it; role="list" (paired
-    // with role="listitem" below) restores it explicitly.
-    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- .grid sets list-style: none, which drops implicit list semantics in Safari/VoiceOver; role="list" (paired with role="listitem" on each <li>) restores it
     <ul className={`${styles.grid} ${columnClassMap[columns]}`} role="list">
       {Array.isArray(children) ? (
         children.map((child, index) => (

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -15,15 +15,21 @@ const columnClassMap: Record<NonNullable<GridProps['columns']>, string> = {
 
 const Grid: FC<GridProps> = ({ children, columns = 3 }) => {
   return (
-    <ul className={`${styles.grid} ${columnClassMap[columns]}`}>
+    // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
+    // `list-style: none` is applied anywhere in it; role="list" (paired
+    // with role="listitem" below) restores it explicitly.
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+    <ul className={`${styles.grid} ${columnClassMap[columns]}`} role="list">
       {Array.isArray(children) ? (
         children.map((child, index) => (
-          <li key={index} className={styles.item}>
+          // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above
+          <li key={index} className={styles.item} role="listitem">
             {child}
           </li>
         ))
       ) : (
-        <li className={styles.item}>{children}</li>
+        // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above
+        <li className={styles.item} role="listitem">{children}</li>
       )}
     </ul>
   )

--- a/src/components/RecipeIngredients/RecipeIngredients.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.tsx
@@ -87,11 +87,16 @@ const RecipeIngredients: FC<RecipeIngredientsProps> = ({ ingredients, slug }) =>
   }
 
   return (
-    <ul className={styles.list}>
+    // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
+    // `list-style: none` is applied anywhere in it; role="list" (paired
+    // with role="listitem" below) restores it explicitly.
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+    <ul className={styles.list} role="list">
       {ingredients.map((ingredient, idx) => {
         const key = `${ingredient.item}-${idx}`
         return (
-          <li key={key} className={styles.item}>
+          // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above
+          <li key={key} className={styles.item} role="listitem">
             <label className={styles.row}>
               <input
                 type="checkbox"

--- a/src/components/RecipeIngredients/RecipeIngredients.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.tsx
@@ -87,10 +87,7 @@ const RecipeIngredients: FC<RecipeIngredientsProps> = ({ ingredients, slug }) =>
   }
 
   return (
-    // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
-    // `list-style: none` is applied anywhere in it; role="list" (paired
-    // with role="listitem" below) restores it explicitly.
-    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- .list sets list-style: none, which drops implicit list semantics in Safari/VoiceOver; role="list" (paired with role="listitem" on each <li>) restores it
     <ul className={styles.list} role="list">
       {ingredients.map((ingredient, idx) => {
         const key = `${ingredient.item}-${idx}`

--- a/src/components/SocialCard/SocialCard.tsx
+++ b/src/components/SocialCard/SocialCard.tsx
@@ -65,10 +65,7 @@ const SocialCard: FC = () => {
       <Typography variant="heading3" as="h2" id="social-heading" className={styles.heading}>
         Get in touch
       </Typography>
-      {/* Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
-          `list-style: none` is applied anywhere in it; role="list" (paired
-          with role="listitem" below) restores it explicitly. */}
-      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above */}
+      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- .list sets list-style: none, which drops implicit list semantics in Safari/VoiceOver; role="list" (paired with role="listitem" on each <li>) restores it */}
       <ul className={styles.list} role="list">
         {SOCIAL_CARD_PROPS.map(({ name, url, icon }) => (
           // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above

--- a/src/components/SocialCard/SocialCard.tsx
+++ b/src/components/SocialCard/SocialCard.tsx
@@ -65,9 +65,14 @@ const SocialCard: FC = () => {
       <Typography variant="heading3" as="h2" id="social-heading" className={styles.heading}>
         Get in touch
       </Typography>
-      <ul className={styles.list}>
+      {/* Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
+          `list-style: none` is applied anywhere in it; role="list" (paired
+          with role="listitem" below) restores it explicitly. */}
+      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above */}
+      <ul className={styles.list} role="list">
         {SOCIAL_CARD_PROPS.map(({ name, url, icon }) => (
-          <li key={name}>
+          // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above
+          <li key={name} role="listitem">
             <a
               href={url}
               target="_blank"

--- a/src/pages/Blog/Blog.tsx
+++ b/src/pages/Blog/Blog.tsx
@@ -107,10 +107,7 @@ const Blog = () => {
           </button>
         </div>
       ) : (
-        // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
-        // `list-style: none` is applied anywhere in it; role="list" (paired
-        // with role="listitem" below) restores it explicitly.
-        // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+        // eslint-disable-next-line jsx-a11y/no-redundant-roles -- .postList sets list-style: none, which drops implicit list semantics in Safari/VoiceOver; role="list" (paired with role="listitem" on each <li>) restores it
         <ul className={styles.postList} role="list">
           {filteredPosts.map((post) => (
             // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above

--- a/src/pages/Blog/Blog.tsx
+++ b/src/pages/Blog/Blog.tsx
@@ -107,9 +107,14 @@ const Blog = () => {
           </button>
         </div>
       ) : (
-        <ul className={styles.postList}>
+        // Safari/VoiceOver drops list semantics from a <ul>/<li> pair once
+        // `list-style: none` is applied anywhere in it; role="list" (paired
+        // with role="listitem" below) restores it explicitly.
+        // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment above
+        <ul className={styles.postList} role="list">
           {filteredPosts.map((post) => (
-            <li key={post.slug}>
+            // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above
+            <li key={post.slug} role="listitem">
               <article className={styles.postCard}>
                 <RouterLink to={`/blog/${post.slug}`} className={styles.postLink}>
                   <div className={styles.meta}>
@@ -127,9 +132,11 @@ const Blog = () => {
                   </div>
                   <p className={styles.description}>{post.description}</p>
                 </RouterLink>
-                <ul className={styles.tags}>
+                {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- .tags sets list-style: none, which drops implicit list semantics in Safari/VoiceOver; role="list" (paired with role="listitem" below) restores it */}
+                <ul className={styles.tags} role="list">
                   {post.tags.map((tag) => (
-                    <li key={tag}>
+                    // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above
+                    <li key={tag} role="listitem">
                       <TagChip tag={tag} activeTag={activeTag} onSelect={handleTagClick} />
                     </li>
                   ))}


### PR DESCRIPTION
Closes #239

## What changed
Extended the Safari/VoiceOver list-semantics fix from #223 (Toast/ToastProvider) to 6 more components' genuine `<ul>`/`<li>` lists that lose implicit list semantics once `list-style: none` is applied — adding explicit `role="list"` on the `<ul>` and `role="listitem"` on each `<li>`, each paired with a `jsx-a11y/no-redundant-roles` justification comment:

- `FileMeta.tsx` (CV metadata row — `•` separators correctly excluded, they're `aria-hidden`)
- `FileTree.tsx` (both `.rootList` and `.list`, shared render path)
- `RecipeIngredients.tsx`
- `SocialCard.tsx`
- `Grid.tsx` (both the array-map and single-child render branches)
- `Blog.tsx` (the post list, and each post's nested tag-chip list — 2 sites)

`TagInput.tsx`'s suggestions `<ul>` was audited and correctly left untouched — it already carries an explicit `role="listbox"` (WAI-ARIA combobox pattern) with `role="option"` children, which supersedes implicit list semantics and isn't affected by this Safari bug.

## Why
Consistent accessibility semantics — some lists in the codebase had this restoration and some didn't, with nothing to catch the inconsistency.

## How to verify
- `pnpm test` (775/775, no test files modified — existing `getByRole('list')`/`getAllByRole('listitem')` assertions in RecipeIngredients/FileMeta/SocialCard/Grid tests now pass against explicit rather than implicit roles), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean).
- VoiceOver on Safari: navigate any of the touched lists — list/listitem semantics are announced.

## Decisions made
- Blog's `list-style: none` sites were at different line numbers than the issue cited (78/168, not 10) — the file had changed since the issue was filed; verified against current `HEAD` rather than the stale line numbers.
- `/simplify` review flagged the copy-pasted 3-4 line explanation comment as already drifting in wording across sites — normalized all 7 new sites to the single-line combined comment+eslint-disable form `ToastProvider.tsx` already used.

## Out of scope (filed as follow-up issue)
- **#280** — Extract a shared `SemanticList`/`ListItem` primitive. `/simplify`'s altitude review flagged that the pattern is now hand-copied identically at 8 sites (Toast/ToastProvider + this PR's 7) and recommended extracting a shared primitive now rather than continuing to defer it. Filed as a follow-up rather than folded into this PR because it would require redesigning the markup/styling contract for 7 already-different consumers (className passthrough, conditional children, array-vs-single-child branching) — a structural refactor deserving its own review, consistent with this issue's own "Out of scope" note that deferred this exact decision.