### PR TITLE
Fix Image's blur-placeholder shimmer animation (CSS Modules keyframe scoping)

### DIFF
--- a/src/components/Image/Image.module.css
+++ b/src/components/Image/Image.module.css
@@ -53,7 +53,7 @@
     rgb(255 255 255 / 0.15) 50%,
     transparent 75%
   );
-  animation: shimmer 2s ease-in-out infinite;
+  animation: global(shimmer) 2s ease-in-out infinite;
 }
 
 [data-theme="dark"] .pulsePlaceholder::after {


### PR DESCRIPTION
Closes #241

## What changed
`src/components/Image/Image.module.css:56` — wrapped the `shimmer` keyframe reference in `global(...)`:
```diff
- animation: shimmer 2s ease-in-out infinite;
+ animation: global(shimmer) 2s ease-in-out infinite;
```

## Why
Vite's CSS Modules transform scopes any `animation`/`animation-name` identifier to a hashed local name regardless of whether a matching `@keyframes` exists locally. `shimmer` is actually defined globally in `src/styles/animations.css`, so without the `global(...)` wrapper the animation silently pointed at a nonexistent hashed keyframe and never ran — freezing `Image`'s blur-placeholder shimmer. Same bug, same fix pattern already applied to `interactions.module.css`'s `.spinner`/`.shimmer` and `Button.module.css`'s `.spinner` in a prior issue; `Image` was missed because it's a pre-existing component outside that issue's scope.

## How to verify
- Compiled build output (`pnpm build:client`, `dist/client/assets/*.css`): the `.pulsePlaceholder::after` rule now resolves to the literal `animation:shimmer`, and a matching `@keyframes shimmer{...}` block exists in the same stylesheet — confirmed independently by both the implementing agent and the review pass.
- `pnpm test` (775/775 — this class of bug isn't observable in jsdom, so the test run confirms no regressions, not the fix itself), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean).
- Visually: any `Image` in a loading state should show a moving shimmer sweep across its blur placeholder instead of a static gradient.

## Decisions made
Audited every `.module.css` file in the repo for the same pattern (any `animation`/`animation-name` referencing a keyframe not defined in that same file, without a `global(...)` wrapper). Found no other instances — `interactions.module.css` (2 sites) and `Button.module.css` (1 site) already correctly wrap their global keyframe references; `ProcessingPlaceholder.module.css`'s two `animation: none` declarations don't reference a keyframe at all. No `.module.css` file in the codebase defines its own local `@keyframes`.

## Out of scope
None — single-line fix, no findings from review.