### PR TITLE
Deduplicate social links between Footer and SocialCard

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,13 +1,7 @@
 import Link from '@components/Link'
 import { useId, type FC } from 'react'
+import { SOCIAL_LINKS } from '../../constants/socialLinks'
 import styles from './Footer.module.css'
-
-/** Reuses the same three links as SocialCard (GitHub / LinkedIn / Email). */
-const ELSEWHERE_LINKS: { label: string; href: string }[] = [
-  { label: 'GitHub', href: 'https://github.com/vandelay87' },
-  { label: 'LinkedIn', href: 'https://www.linkedin.com/in/akli-aissat-b08119115/' },
-  { label: 'Email', href: 'mailto:akliaissat@outlook.com' },
-]
 
 export interface FooterProps {
   /** @default 'public' */
@@ -36,9 +30,9 @@ const Footer: FC<FooterProps> = ({ variant = 'public', email, className: extraCl
                 Elsewhere
               </span>
               <ul className={styles.linkList}>
-                {ELSEWHERE_LINKS.map((link) => (
+                {SOCIAL_LINKS.map((link) => (
                   <li key={link.href}>
-                    <Link to={link.href}>{link.label}</Link>
+                    <Link to={link.href}>{link.name}</Link>
                   </li>
                 ))}
               </ul>

--- a/src/components/SocialCard/SocialCard.tsx
+++ b/src/components/SocialCard/SocialCard.tsx
@@ -1,9 +1,9 @@
 import Typography from '@components/Typography'
 import { FC, JSX } from 'react'
-import { SOCIAL_LINKS_WITH_EMAIL_SUBJECT } from '../../constants/socialLinks'
+import { SOCIAL_LINKS_WITH_EMAIL_SUBJECT, type SocialLinkName } from '../../constants/socialLinks'
 import styles from './SocialCard.module.css'
 
-const ICONS_BY_NAME: Record<string, JSX.Element> = {
+const ICONS_BY_NAME: Record<SocialLinkName, JSX.Element> = {
   GitHub: (
     <svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
       <path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.8-1.4-3.8-1.4-.5-1.2-1.2-1.5-1.2-1.5-1-.7.1-.7.1-.7 1.1.1 1.6 1.2 1.6 1.2 1 .1.8 1.3.8 1.3.9 1.6 2.3 1.1 2.9.8.1-.6.3-1.1.6-1.4-2.5-.3-5.1-1.3-5.1-5.8 0-1.3.5-2.4 1.2-3.2-.1-.3-.6-1.4.1-2.8 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.2-1.5 3.3-1.2 3.3-1.2.7 1.4.2 2.5.1 2.8.7.8 1.2 1.9 1.2 3.2 0 4.5-2.6 5.5-5.1 5.8.3.3.6.9.6 1.9v2.8c0 .4.2.7.8.6A11.5 11.5 0 0 0 23.5 12C23.5 5.7 18.3.5 12 .5z" />

--- a/src/components/SocialCard/SocialCard.tsx
+++ b/src/components/SocialCard/SocialCard.tsx
@@ -1,60 +1,25 @@
 import Typography from '@components/Typography'
 import { FC, JSX } from 'react'
+import { SOCIAL_LINKS_WITH_EMAIL_SUBJECT } from '../../constants/socialLinks'
 import styles from './SocialCard.module.css'
 
-type SocialCardProps = {
-  name: string
-  url: string
-  icon: JSX.Element
+const ICONS_BY_NAME: Record<string, JSX.Element> = {
+  GitHub: (
+    <svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.8-1.4-3.8-1.4-.5-1.2-1.2-1.5-1.2-1.5-1-.7.1-.7.1-.7 1.1.1 1.6 1.2 1.6 1.2 1 .1.8 1.3.8 1.3.9 1.6 2.3 1.1 2.9.8.1-.6.3-1.1.6-1.4-2.5-.3-5.1-1.3-5.1-5.8 0-1.3.5-2.4 1.2-3.2-.1-.3-.6-1.4.1-2.8 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.2-1.5 3.3-1.2 3.3-1.2.7 1.4.2 2.5.1 2.8.7.8 1.2 1.9 1.2 3.2 0 4.5-2.6 5.5-5.1 5.8.3.3.6.9.6 1.9v2.8c0 .4.2.7.8.6A11.5 11.5 0 0 0 23.5 12C23.5 5.7 18.3.5 12 .5z" />
+    </svg>
+  ),
+  LinkedIn: (
+    <svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5zM2 9h6v12H2zM10 9h5.6v1.8h.1c.8-1.4 2.8-2 4.3-2 4.6 0 5.5 3 5.5 6.8V21h-6v-5.2c0-1.2 0-2.7-1.6-2.7s-1.8 1.3-1.8 2.6V21h-6z" />
+    </svg>
+  ),
+  Email: (
+    <svg fill="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4a2 2 0 0 1-2-2V6c0-1.1.9-2 2-2zm0 2v.5l8 5 8-5V6H4zm16 2.7l-7.5 4.7a1 1 0 0 1-1 0L4 8.7V18h16V8.7z" />
+    </svg>
+  ),
 }
-
-const SOCIAL_CARD_PROPS: SocialCardProps[] = [
-  {
-    name: 'GitHub',
-    url: 'https://github.com/vandelay87',
-    icon: (
-      <svg
-
-        fill="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.2.8-.6v-2c-3.2.7-3.8-1.4-3.8-1.4-.5-1.2-1.2-1.5-1.2-1.5-1-.7.1-.7.1-.7 1.1.1 1.6 1.2 1.6 1.2 1 .1.8 1.3.8 1.3.9 1.6 2.3 1.1 2.9.8.1-.6.3-1.1.6-1.4-2.5-.3-5.1-1.3-5.1-5.8 0-1.3.5-2.4 1.2-3.2-.1-.3-.6-1.4.1-2.8 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.2-1.5 3.3-1.2 3.3-1.2.7 1.4.2 2.5.1 2.8.7.8 1.2 1.9 1.2 3.2 0 4.5-2.6 5.5-5.1 5.8.3.3.6.9.6 1.9v2.8c0 .4.2.7.8.6A11.5 11.5 0 0 0 23.5 12C23.5 5.7 18.3.5 12 .5z" />
-      </svg>
-    ),
-  },
-  {
-    name: 'LinkedIn',
-    url: 'https://www.linkedin.com/in/akli-aissat-b08119115/',
-    icon: (
-      <svg
-
-        fill="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path d="M4.98 3.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5zM2 9h6v12H2zM10 9h5.6v1.8h.1c.8-1.4 2.8-2 4.3-2 4.6 0 5.5 3 5.5 6.8V21h-6v-5.2c0-1.2 0-2.7-1.6-2.7s-1.8 1.3-1.8 2.6V21h-6z" />
-      </svg>
-    ),
-  },
-  {
-    name: 'Email',
-    url: 'mailto:akliaissat@outlook.com?subject=Hello',
-    icon: (
-      <svg
-
-        fill="currentColor"
-        viewBox="0 0 24 24"
-        aria-hidden="true"
-        focusable="false"
-      >
-        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4a2 2 0 0 1-2-2V6c0-1.1.9-2 2-2zm0 2v.5l8 5 8-5V6H4zm16 2.7l-7.5 4.7a1 1 0 0 1-1 0L4 8.7V18h16V8.7z" />
-      </svg>
-    ),
-  },
-]
 
 const SocialCard: FC = () => {
   return (
@@ -67,11 +32,11 @@ const SocialCard: FC = () => {
       </Typography>
       {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- .list sets list-style: none, which drops implicit list semantics in Safari/VoiceOver; role="list" (paired with role="listitem" on each <li>) restores it */}
       <ul className={styles.list} role="list">
-        {SOCIAL_CARD_PROPS.map(({ name, url, icon }) => (
+        {SOCIAL_LINKS_WITH_EMAIL_SUBJECT.map(({ name, href }) => (
           // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above
           <li key={name} role="listitem">
             <a
-              href={url}
+              href={href}
               target="_blank"
               rel="noopener noreferrer"
               title={name}
@@ -79,7 +44,7 @@ const SocialCard: FC = () => {
               className={styles.link}
             >
               <span className="sr-only">{name}</span>
-              {icon}
+              {ICONS_BY_NAME[name]}
             </a>
           </li>
         ))}

--- a/src/constants/socialLinks.ts
+++ b/src/constants/socialLinks.ts
@@ -12,8 +12,9 @@ export const SOCIAL_LINKS: SocialLink[] = [
   { name: 'Email', href: `mailto:${EMAIL_ADDRESS}` },
 ]
 
-// SocialCard's email link prefills a subject line; Footer's stays a bare mailto. This split is
-// an intentional Resolved Decision (docs/prds/paper-redesign.md #1), not drift to be fixed.
+// SocialCard's email link prefills a subject line; Footer's stays a bare mailto per Resolved
+// Decision #1 (docs/prds/paper-redesign.md), which specifies Footer's bare mailto explicitly —
+// this split is intentional, not drift to be fixed.
 export const SOCIAL_LINKS_WITH_EMAIL_SUBJECT: SocialLink[] = SOCIAL_LINKS.map((link) =>
   link.name === 'Email' ? { ...link, href: `mailto:${EMAIL_ADDRESS}?subject=Hello` } : link
 )

--- a/src/constants/socialLinks.ts
+++ b/src/constants/socialLinks.ts
@@ -1,5 +1,7 @@
+export type SocialLinkName = 'GitHub' | 'LinkedIn' | 'Email'
+
 export interface SocialLink {
-  name: string
+  name: SocialLinkName
   href: string
 }
 

--- a/src/constants/socialLinks.ts
+++ b/src/constants/socialLinks.ts
@@ -1,0 +1,19 @@
+export interface SocialLink {
+  name: string
+  href: string
+}
+
+const EMAIL_ADDRESS = 'akliaissat@outlook.com'
+
+/** GitHub/LinkedIn/Email link data shared by Footer and SocialCard. */
+export const SOCIAL_LINKS: SocialLink[] = [
+  { name: 'GitHub', href: 'https://github.com/vandelay87' },
+  { name: 'LinkedIn', href: 'https://www.linkedin.com/in/akli-aissat-b08119115/' },
+  { name: 'Email', href: `mailto:${EMAIL_ADDRESS}` },
+]
+
+// SocialCard's email link prefills a subject line; Footer's stays a bare mailto. This split is
+// an intentional Resolved Decision (docs/prds/paper-redesign.md #1), not drift to be fixed.
+export const SOCIAL_LINKS_WITH_EMAIL_SUBJECT: SocialLink[] = SOCIAL_LINKS.map((link) =>
+  link.name === 'Email' ? { ...link, href: `mailto:${EMAIL_ADDRESS}?subject=Hello` } : link
+)


### PR DESCRIPTION
Closes #243

## What changed
- New `src/constants/socialLinks.ts` exports `SOCIAL_LINKS` (GitHub/LinkedIn/Email, bare mailto) and `SOCIAL_LINKS_WITH_EMAIL_SUBJECT` (derived, appends `?subject=Hello` to just the Email entry).
- `Footer.tsx` imports `SOCIAL_LINKS` directly, replacing its local `ELSEWHERE_LINKS` array (also renamed its `label` field to `name` to match `SocialCard`'s existing convention).
- `SocialCard.tsx` imports `SOCIAL_LINKS_WITH_EMAIL_SUBJECT`, replacing its local `SOCIAL_CARD_PROPS` array. Icon SVGs stayed local (a data module shouldn't hold JSX) in a new `ICONS_BY_NAME` lookup, now typed against a shared `SocialLinkName` union so a typo/rename is a compile error instead of a silent missing icon.

## Why
The two components independently hardcoded the same GitHub/LinkedIn/Email data, with one intentional divergence (the Email mailto's subject line) undocumented as a shared source — risk of future drift if a URL ever changes.

## How to verify
- `pnpm test` (778/778 — `Footer.test.tsx` and `SocialCard.test.tsx` both assert exact href strings including the bare-vs-subject mailto distinction, unmodified and still passing), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean).
- Every href value verified byte-identical to the pre-refactor originals (diffed against `epic/paper-redesign`).
- Visually: Footer's "Elsewhere" links and the Home page's SocialCard should be unchanged — same URLs, same icons, same mailto behavior.

## Decisions made
- **mailto split**: base array + derived override (`.map()` on just the Email entry) rather than two fully independent arrays or a parameterized function — proportionate for a single field differing on a single entry, confirmed as the right altitude by review.
- **Naming**: picked `name` (SocialCard's existing field) as canonical; `Footer` updated to match.
- **No `@constants` alias added**: `src/constants/` didn't exist before this PR and no alias convention covers it; used a relative import, consistent with how `src/utils` (also alias-less) is imported elsewhere in the codebase.

## Out of scope
None filed. `/simplify` (4 parallel review angles) converged on one real finding — the icon lookup was keyed by a bare `string` against data from a file it doesn't own, with no compiler link — fixed inline via a shared `SocialLinkName` union type. Review also flagged a code comment that slightly overstated what the PRD's Resolved Decision explicitly covers; reworded for precision.