### PR TITLE
Share form field CSS base across Input/Textarea/TagInput

### DIFF
--- a/src/components/Input/Input.module.css
+++ b/src/components/Input/Input.module.css
@@ -8,24 +8,19 @@
   width: 100%;
 }
 
+/* --input-bg/-radius let a consumer re-theme a specific field (e.g.
+   RecipeSearch's surface-tinted pill) by setting custom properties on
+   an ancestor — they inherit through this wrapper's own internal .field
+   element, so there's no specificity fight with a consumer's own
+   className the way two same-specificity classes on this element would
+   have (whichever landed later in the compiled stylesheet would win).
+   The core declaration block (width/font/color/background/border/
+   radius/padding/transition, shared byte-for-byte with Textarea and
+   TagInput) lives in the shared `field` composable — see
+   src/styles/formField.module.css for the full rationale (issue #244). */
 .field {
+  composes: field from '../../styles/formField.module.css';
   composes: fieldFocusRing from '../../styles/interactions.module.css';
-  width: 100%;
-  font-family: var(--font-sans);
-  font-size: var(--font-size-md);
-  color: var(--color-text-strong);
-  /* --input-bg/-radius let a consumer re-theme a specific field (e.g.
-     RecipeSearch's surface-tinted pill) by setting custom properties on
-     an ancestor — they inherit through this wrapper's own internal .field
-     element, so there's no specificity fight with a consumer's own
-     className the way two same-specificity classes on this element would
-     have (whichever landed later in the compiled stylesheet would win). */
-  background-color: var(--input-bg, var(--color-field));
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--input-radius, var(--radius-md));
-  padding: var(--space-3);
-  transition: border-color var(--duration-fast) var(--easing-default),
-              background-color var(--duration-fast) var(--easing-default);
 }
 
 .field:focus-visible {
@@ -34,12 +29,6 @@
 
 .field:disabled {
   background-color: var(--color-surface);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .field {
-    transition: none;
-  }
 }
 
 /* Invalid: error border always on, plus an error-tinted ring on focus

--- a/src/components/Input/Input.module.css
+++ b/src/components/Input/Input.module.css
@@ -15,12 +15,15 @@
    className the way two same-specificity classes on this element would
    have (whichever landed later in the compiled stylesheet would win).
    The core declaration block (width/font/color/background/border/
-   radius/padding/transition, shared byte-for-byte with Textarea and
-   TagInput) lives in the shared `field` composable — see
-   src/styles/formField.module.css for the full rationale (issue #244). */
+   radius/padding, shared byte-for-byte with Textarea and TagInput)
+   lives in the shared `field` composable — see
+   src/styles/formField.module.css for the full rationale (issue #244).
+   transition stays local (see that file's comment for why). */
 .field {
   composes: field from '../../styles/formField.module.css';
   composes: fieldFocusRing from '../../styles/interactions.module.css';
+  transition: border-color var(--duration-fast) var(--easing-default),
+              background-color var(--duration-fast) var(--easing-default);
 }
 
 .field:focus-visible {
@@ -29,6 +32,12 @@
 
 .field:disabled {
   background-color: var(--color-surface);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field {
+    transition: none;
+  }
 }
 
 /* Invalid: error border always on, plus an error-tinted ring on focus

--- a/src/components/TagInput/TagInput.module.css
+++ b/src/components/TagInput/TagInput.module.css
@@ -54,12 +54,20 @@
 }
 
 /* The core field-chrome block (width/font/color/background/border/
-   radius/padding/transition) is shared byte-for-byte with Input and
-   Textarea's `.field` via the `field` composable — see
-   src/styles/formField.module.css for the full rationale (issue #244). */
+   radius/padding) is shared byte-for-byte with Input and Textarea's
+   `.field` via the `field` composable — see
+   src/styles/formField.module.css for the full rationale (issue #244),
+   including why transition stays local. */
 .input {
   composes: field from '../../styles/formField.module.css';
   composes: fieldFocusRing from '../../styles/interactions.module.css';
+  transition: border-color var(--duration-fast) var(--easing-default);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .input {
+    transition: none;
+  }
 }
 
 .listbox {

--- a/src/components/TagInput/TagInput.module.css
+++ b/src/components/TagInput/TagInput.module.css
@@ -53,23 +53,13 @@
   position: relative;
 }
 
+/* The core field-chrome block (width/font/color/background/border/
+   radius/padding/transition) is shared byte-for-byte with Input and
+   Textarea's `.field` via the `field` composable — see
+   src/styles/formField.module.css for the full rationale (issue #244). */
 .input {
+  composes: field from '../../styles/formField.module.css';
   composes: fieldFocusRing from '../../styles/interactions.module.css';
-  width: 100%;
-  font-family: var(--font-sans);
-  font-size: var(--font-size-md);
-  color: var(--color-text-strong);
-  background-color: var(--color-field);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--space-3);
-  transition: border-color var(--duration-fast) var(--easing-default);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .input {
-    transition: none;
-  }
 }
 
 .listbox {

--- a/src/components/Textarea/Textarea.module.css
+++ b/src/components/Textarea/Textarea.module.css
@@ -2,9 +2,9 @@
    (background, border, focus border-tint) per Textarea.jsx/prompt.md. */
 
 /* The core field-chrome block (width/font/color/background/border/
-   radius/padding/transition) is shared byte-for-byte with Input and
-   TagInput via the `field` composable — see
-   src/styles/formField.module.css for the full rationale (issue #244).
+   radius/padding) is shared byte-for-byte with Input and TagInput via
+   the `field` composable — see src/styles/formField.module.css for the
+   full rationale (issue #244), including why transition stays local.
    line-height/resize/min-height stay here — genuinely Textarea-only. */
 .field {
   composes: field from '../../styles/formField.module.css';
@@ -12,8 +12,15 @@
   line-height: var(--line-height-relaxed);
   resize: vertical;
   min-height: var(--space-20);
+  transition: border-color var(--duration-fast) var(--easing-default);
 }
 
 .field:disabled {
   background-color: var(--color-surface);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field {
+    transition: none;
+  }
 }

--- a/src/components/Textarea/Textarea.module.css
+++ b/src/components/Textarea/Textarea.module.css
@@ -1,28 +1,19 @@
 /* Textarea.module.css — shares Input's `.ds-field` styling language
    (background, border, focus border-tint) per Textarea.jsx/prompt.md. */
 
+/* The core field-chrome block (width/font/color/background/border/
+   radius/padding/transition) is shared byte-for-byte with Input and
+   TagInput via the `field` composable — see
+   src/styles/formField.module.css for the full rationale (issue #244).
+   line-height/resize/min-height stay here — genuinely Textarea-only. */
 .field {
+  composes: field from '../../styles/formField.module.css';
   composes: fieldFocusRing from '../../styles/interactions.module.css';
-  width: 100%;
-  font-family: var(--font-sans);
-  font-size: var(--font-size-md);
   line-height: var(--line-height-relaxed);
-  color: var(--color-text-strong);
-  background-color: var(--color-field);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--space-3);
   resize: vertical;
   min-height: var(--space-20);
-  transition: border-color var(--duration-fast) var(--easing-default);
 }
 
 .field:disabled {
   background-color: var(--color-surface);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .field {
-    transition: none;
-  }
 }

--- a/src/styles/formField.module.css
+++ b/src/styles/formField.module.css
@@ -1,0 +1,40 @@
+/* formField.module.css — shared base "field" chrome for form-field-style
+   inputs (Input, Textarea, TagInput). These three components render
+   visually identical field chrome (background, border, radius, padding,
+   transition) and previously duplicated the same declaration block
+   verbatim across their own `.module.css` files (see issue #244).
+
+   Consumers `composes: field from '../../styles/formField.module.css';`
+   here alongside their own separate
+   `composes: fieldFocusRing from '../../styles/interactions.module.css';`
+   (CSS Modules `composes` supports multiple sources) plus whatever stays
+   genuinely per-consumer (line-height/resize/min-height for Textarea,
+   :focus-visible/:disabled overrides for Input, its own :disabled for
+   Textarea, etc.) — see each component's own Input.module.css /
+   Textarea.module.css / TagInput.module.css for what stays local and why.
+
+   `--input-bg`/`--input-radius` let a consumer re-theme a specific field
+   (e.g. RecipeSearch's surface-tinted pill) by setting custom properties on
+   an ancestor — only Input.module.css's callers currently set these.
+   Textarea/TagInput never define either custom property, so the fallback
+   (`--color-field` / `--radius-md`) is their only observed value: using the
+   same custom-property expression here for all three consumers renders
+   byte-identical to their previous per-file literal values. */
+.field {
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-md);
+  color: var(--color-text-strong);
+  background-color: var(--input-bg, var(--color-field));
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--input-radius, var(--radius-md));
+  padding: var(--space-3);
+  transition: border-color var(--duration-fast) var(--easing-default),
+              background-color var(--duration-fast) var(--easing-default);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .field {
+    transition: none;
+  }
+}

--- a/src/styles/formField.module.css
+++ b/src/styles/formField.module.css
@@ -1,8 +1,17 @@
 /* formField.module.css — shared base "field" chrome for form-field-style
    inputs (Input, Textarea, TagInput). These three components render
-   visually identical field chrome (background, border, radius, padding,
-   transition) and previously duplicated the same declaration block
-   verbatim across their own `.module.css` files (see issue #244).
+   visually identical field chrome (background, border, radius, padding)
+   and previously duplicated the same declaration block verbatim across
+   their own `.module.css` files (see issue #244).
+
+   `transition` deliberately stays OUT of this shared block and out of
+   this file's own scope: Input transitions both border-color and
+   background-color (it has a `:focus-visible` background swap),
+   Textarea/TagInput only ever transition border-color — unifying them
+   would make Textarea's `:disabled` background-color change animate
+   when it doesn't today, a real (if subtle) behavior change caught in
+   review. Each consumer keeps its own `transition` declaration (and
+   `prefers-reduced-motion` override) locally.
 
    Consumers `composes: field from '../../styles/formField.module.css';`
    here alongside their own separate
@@ -10,8 +19,9 @@
    (CSS Modules `composes` supports multiple sources) plus whatever stays
    genuinely per-consumer (line-height/resize/min-height for Textarea,
    :focus-visible/:disabled overrides for Input, its own :disabled for
-   Textarea, etc.) — see each component's own Input.module.css /
-   Textarea.module.css / TagInput.module.css for what stays local and why.
+   Textarea, its own transition, etc.) — see each component's own
+   Input.module.css / Textarea.module.css / TagInput.module.css for what
+   stays local and why.
 
    `--input-bg`/`--input-radius` let a consumer re-theme a specific field
    (e.g. RecipeSearch's surface-tinted pill) by setting custom properties on
@@ -29,12 +39,4 @@
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--input-radius, var(--radius-md));
   padding: var(--space-3);
-  transition: border-color var(--duration-fast) var(--easing-default),
-              background-color var(--duration-fast) var(--easing-default);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .field {
-    transition: none;
-  }
 }


### PR DESCRIPTION
Closes #244

## What changed
- New `src/styles/formField.module.css` exports a `.field` composable with the genuinely identical block across all three: `width`, `font-family`, `font-size`, `color`, `background-color` (using Input's `var(--input-bg, var(--color-field))` fallback expression for all three, byte-identical since Textarea/TagInput never define `--input-bg`), `border`, `border-radius` (same fallback pattern), `padding`.
- `Input.module.css` `.field`, `Textarea.module.css` `.field`, and `TagInput.module.css` `.input` now `composes: field from '../../styles/formField.module.css'` alongside their existing `composes: fieldFocusRing from '../../styles/interactions.module.css'`.
- Genuinely per-consumer styling stays local: Textarea's `line-height`/`resize`/`min-height`, Input's `:focus-visible`/`:disabled`/`.invalid`/`.prefixIcon`/`.suffix` rules, Textarea's own `:disabled` rule, and — after a review fix — each consumer's own `transition` + `prefers-reduced-motion` override (see Decisions made).

## Why
The three field-style consumers duplicated an identical CSS block, risking the kind of drift already seen between Footer/SocialCard (#243) — a token or visual tweak today requires remembering to update three files.

## How to verify
- `pnpm test` (778/778), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean).
- Visual equivalence verified via compiled build (`pnpm build:client`), not just tests — jsdom doesn't render real CSS cascade/composes resolution. Diffed `dist/client/assets/*.css` before/after: only the two chunks containing these three components' styles changed, and the structural rule-set diff shows exactly the expected consolidation with no unintended differences. Dark mode unaffected (only token *values* differ by theme, not which file declares the properties).

## Decisions made
- **`transition` deliberately excluded from the shared base.** The first version unified `transition` into the shared `.field`, using Input's two-property list (`border-color`, `background-color`) for all three — but Textarea/TagInput originally transitioned only `border-color`. Review caught that this would make Textarea's `:disabled` background-color change animate when it never did before — a real, if subtle, behavior change. Fixed by keeping `transition` (and its reduced-motion override) local to each of the three files, each matching its exact pre-refactor value. Independently re-verified via compiled build after the fix: Input's chunk has the two-property transition, Textarea/TagInput's chunk has `border-color` only.
- **`:disabled` not shared** between Input and Textarea despite being identical — TagInput composes the same base and has no disabled state; sharing `:disabled` would attach dead styling to it the moment it ever gained one. Confirmed reasonable by review.
- **New file, not folded into `interactions.module.css`**: that file is scoped to interaction-state composables (`:hover`/`:focus-visible` behaviors); this is static field chrome — a distinct concern, confirmed by `/simplify`'s reuse angle.

## Out of scope
None filed. `/simplify` (4 parallel review angles, re-run after the transition fix) found no further actionable findings — remaining duplication (the 3-line reduced-motion block, `:disabled` between Input/Textarea) is trivial and was already a considered, deliberate decision.