### PR TITLE
Extend Grid to support fluid auto-fit columns

### DIFF
--- a/src/components/Grid/Grid.module.css
+++ b/src/components/Grid/Grid.module.css
@@ -60,3 +60,9 @@
     grid-template-columns: repeat(4, 1fr);
   }
 }
+
+/* ── Auto-fit variant ──────────────────────────────────────── */
+
+.autoFit {
+  grid-template-columns: repeat(auto-fit, minmax(var(--grid-min-width), 1fr));
+}

--- a/src/components/Grid/Grid.test.tsx
+++ b/src/components/Grid/Grid.test.tsx
@@ -88,4 +88,17 @@ describe('Grid', () => {
     expect(list.className).not.toContain('autoFit')
     expect(list.className).toContain('cols3')
   })
+
+  it('merges a passed className onto the list alongside its own classes', () => {
+    render(
+      <Grid className="custom-spacing">
+        <div>Item</div>
+      </Grid>
+    )
+
+    const list = screen.getByRole('list')
+    expect(list.className).toContain('custom-spacing')
+    expect(list.className).toContain('grid')
+    expect(list.className).toContain('cols3')
+  })
 })

--- a/src/components/Grid/Grid.test.tsx
+++ b/src/components/Grid/Grid.test.tsx
@@ -38,4 +38,54 @@ describe('Grid', () => {
     const item = screen.getByRole('listitem')
     expect(item).toHaveTextContent('Only Child')
   })
+
+  it('applies the auto-fit class and no fixed column class when minWidth is set', () => {
+    render(
+      <Grid minWidth="320px">
+        <div>Item</div>
+      </Grid>
+    )
+
+    const list = screen.getByRole('list')
+    expect(list.className).toContain('autoFit')
+    expect(list.className).not.toContain('cols1')
+    expect(list.className).not.toContain('cols2')
+    expect(list.className).not.toContain('cols3')
+    expect(list.className).not.toContain('cols4')
+  })
+
+  it('sets the --grid-min-width custom property from minWidth', () => {
+    render(
+      <Grid minWidth="320px">
+        <div>Item</div>
+      </Grid>
+    )
+
+    const list = screen.getByRole('list')
+    expect(list.style.getPropertyValue('--grid-min-width')).toBe('320px')
+  })
+
+  it('lets minWidth override an explicit columns prop entirely', () => {
+    render(
+      <Grid minWidth="320px" columns={4}>
+        <div>Item</div>
+      </Grid>
+    )
+
+    const list = screen.getByRole('list')
+    expect(list.className).toContain('autoFit')
+    expect(list.className).not.toContain('cols4')
+  })
+
+  it('does not apply the auto-fit class when minWidth is omitted (regression guard)', () => {
+    render(
+      <Grid>
+        <div>Item</div>
+      </Grid>
+    )
+
+    const list = screen.getByRole('list')
+    expect(list.className).not.toContain('autoFit')
+    expect(list.className).toContain('cols3')
+  })
 })

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,9 +1,10 @@
-import { FC, ReactNode } from 'react'
+import { CSSProperties, FC, ReactNode } from 'react'
 import styles from './Grid.module.css'
 
 interface GridProps {
   children: ReactNode
   columns?: 1 | 2 | 3 | 4
+  minWidth?: string
 }
 
 const columnClassMap: Record<NonNullable<GridProps['columns']>, string> = {
@@ -13,10 +14,18 @@ const columnClassMap: Record<NonNullable<GridProps['columns']>, string> = {
   4: styles.cols4,
 }
 
-const Grid: FC<GridProps> = ({ children, columns = 3 }) => {
+const Grid: FC<GridProps> = ({ children, columns = 3, minWidth }) => {
+  const gridClassName = minWidth
+    ? `${styles.grid} ${styles.autoFit}`
+    : `${styles.grid} ${columnClassMap[columns]}`
+
+  const gridStyle = minWidth
+    ? ({ '--grid-min-width': minWidth } as CSSProperties)
+    : undefined
+
   return (
     // eslint-disable-next-line jsx-a11y/no-redundant-roles -- .grid sets list-style: none, which drops implicit list semantics in Safari/VoiceOver; role="list" (paired with role="listitem" on each <li>) restores it
-    <ul className={`${styles.grid} ${columnClassMap[columns]}`} role="list">
+    <ul className={gridClassName} style={gridStyle} role="list">
       {Array.isArray(children) ? (
         children.map((child, index) => (
           // eslint-disable-next-line jsx-a11y/no-redundant-roles -- not redundant, see comment on the <ul> above

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -5,6 +5,7 @@ interface GridProps {
   children: ReactNode
   columns?: 1 | 2 | 3 | 4
   minWidth?: string
+  className?: string
 }
 
 const columnClassMap: Record<NonNullable<GridProps['columns']>, string> = {
@@ -14,10 +15,19 @@ const columnClassMap: Record<NonNullable<GridProps['columns']>, string> = {
   4: styles.cols4,
 }
 
-const Grid: FC<GridProps> = ({ children, columns = 3, minWidth }) => {
-  const gridClassName = minWidth
-    ? `${styles.grid} ${styles.autoFit}`
-    : `${styles.grid} ${columnClassMap[columns]}`
+const Grid: FC<GridProps> = ({
+  children,
+  columns = 3,
+  minWidth,
+  className: extraClassName,
+}) => {
+  const gridClassName = [
+    styles.grid,
+    minWidth ? styles.autoFit : columnClassMap[columns],
+    extraClassName,
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   const gridStyle = minWidth
     ? ({ '--grid-min-width': minWidth } as CSSProperties)

--- a/src/pages/Apps/Apps.module.css
+++ b/src/pages/Apps/Apps.module.css
@@ -32,13 +32,8 @@
   margin-block-end: var(--space-6);
 }
 
-.grid {
-  list-style: none;
-  margin: 0 0 var(--space-8);
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: var(--space-6);
+.gridWrapper {
+  margin-block-end: var(--space-8);
 }
 
 .inProgress {

--- a/src/pages/Apps/Apps.module.css
+++ b/src/pages/Apps/Apps.module.css
@@ -32,7 +32,7 @@
   margin-block-end: var(--space-6);
 }
 
-.gridWrapper {
+.gridSpacing {
   margin-block-end: var(--space-8);
 }
 

--- a/src/pages/Apps/Apps.tsx
+++ b/src/pages/Apps/Apps.tsx
@@ -1,5 +1,6 @@
 import AppCard from '@components/AppCard'
 import type { AppCardProps } from '@components/AppCard'
+import Grid from '@components/Grid'
 import Link from '@components/Link'
 import Typography from '@components/Typography'
 import type { FC } from 'react'
@@ -60,13 +61,13 @@ const Apps: FC = () => {
         <div className={styles.countRow}>
           <span>{APPS_COUNT_LABEL}</span>
         </div>
-        <ul className={styles.grid}>
-          {APPS.map((app) => (
-            <li key={app.href}>
-              <AppCard {...app} />
-            </li>
-          ))}
-        </ul>
+        <div className={styles.gridWrapper}>
+          <Grid minWidth="320px">
+            {APPS.map((app) => (
+              <AppCard key={app.href} {...app} />
+            ))}
+          </Grid>
+        </div>
 
         <aside className={styles.inProgress} aria-labelledby="in-progress-heading">
           <Typography variant="caption" as="p" id="in-progress-heading" className={styles.eyebrow}>

--- a/src/pages/Apps/Apps.tsx
+++ b/src/pages/Apps/Apps.tsx
@@ -61,13 +61,11 @@ const Apps: FC = () => {
         <div className={styles.countRow}>
           <span>{APPS_COUNT_LABEL}</span>
         </div>
-        <div className={styles.gridWrapper}>
-          <Grid minWidth="320px">
-            {APPS.map((app) => (
-              <AppCard key={app.href} {...app} />
-            ))}
-          </Grid>
-        </div>
+        <Grid minWidth="320px" className={styles.gridSpacing}>
+          {APPS.map((app) => (
+            <AppCard key={app.href} {...app} />
+          ))}
+        </Grid>
 
         <aside className={styles.inProgress} aria-labelledby="in-progress-heading">
           <Typography variant="caption" as="p" id="in-progress-heading" className={styles.eyebrow}>

--- a/src/pages/Home/Home.module.css
+++ b/src/pages/Home/Home.module.css
@@ -314,13 +314,8 @@ a.row {
   color: var(--color-text-muted);
 }
 
-.recipeGrid {
-  list-style: none;
-  margin: 0 0 var(--space-10);
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: var(--space-6);
+.recipeGridWrapper {
+  margin-block-end: var(--space-10);
 }
 
 .browseAll {

--- a/src/pages/Home/Home.module.css
+++ b/src/pages/Home/Home.module.css
@@ -314,7 +314,7 @@ a.row {
   color: var(--color-text-muted);
 }
 
-.recipeGridWrapper {
+.recipeGridSpacing {
   margin-block-end: var(--space-10);
 }
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,4 +1,5 @@
 import { fetchRecipes } from '@api/recipes'
+import Grid from '@components/Grid'
 import Image from '@components/Image'
 import Link from '@components/Link'
 import RecipeCard from '@components/RecipeCard'
@@ -168,13 +169,13 @@ const Home: FC = () => {
                 written down so they&apos;re easy to make again.
               </Typography>
             </div>
-            <ul className={styles.recipeGrid}>
-              {recipes.map((recipe) => (
-                <li key={recipe.id}>
-                  <RecipeCard recipe={recipe} eager hideTags />
-                </li>
-              ))}
-            </ul>
+            <div className={styles.recipeGridWrapper}>
+              <Grid minWidth="220px">
+                {recipes.map((recipe) => (
+                  <RecipeCard key={recipe.id} recipe={recipe} eager hideTags />
+                ))}
+              </Grid>
+            </div>
             <div className={styles.browseAll}>
               <Link
                 to="/recipes"

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -169,13 +169,11 @@ const Home: FC = () => {
                 written down so they&apos;re easy to make again.
               </Typography>
             </div>
-            <div className={styles.recipeGridWrapper}>
-              <Grid minWidth="220px">
-                {recipes.map((recipe) => (
-                  <RecipeCard key={recipe.id} recipe={recipe} eager hideTags />
-                ))}
-              </Grid>
-            </div>
+            <Grid minWidth="220px" className={styles.recipeGridSpacing}>
+              {recipes.map((recipe) => (
+                <RecipeCard key={recipe.id} recipe={recipe} eager hideTags />
+              ))}
+            </Grid>
             <div className={styles.browseAll}>
               <Link
                 to="/recipes"


### PR DESCRIPTION
Closes #247

## What changed
- `Grid` gains an optional `minWidth?: string` prop (TDD — tests written first). When set, it fully overrides `columns` and applies a new `.autoFit` class (`grid-template-columns: repeat(auto-fit, minmax(var(--grid-min-width), 1fr))`), with `minWidth` passed through as an inline `--grid-min-width` custom property so any value works without a fixed set of variant classes.
- `Grid` also gains a `className?: string` prop, merged onto its `<ul>` alongside its own classes.
- `Apps.tsx` and `Home.tsx` no longer hand-roll a `<ul>` + auto-fit grid CSS rule — both now render `<Grid minWidth="..." className="...">` directly wrapping their cards.
- `Recipes.tsx` (the only other real `Grid` consumer — `RecipesCta` no longer exists in the codebase) is untouched.

## Why
`Apps.tsx`'s app-card grid and `Home.tsx`'s recipe rail each duplicated a responsive `auto-fit`/`minmax` grid layout that `Grid` already provided in fixed-column form only.

## How to verify
- `pnpm test` (783/783), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean).
- Visual equivalence verified via compiled build (`pnpm build:client`), not just tests: `.autoFit` produces the expected fluid rule, `Grid`'s base `gap` and each page's specific bottom margin are preserved exactly, and margin-collapse behavior is unaffected by removing the wrapper divs (both old and new structures are plain block boxes with no border/padding).
- Incidental improvement: Apps/Home's grids now inherit `role="list"`/`role="listitem"` for free via `Grid` — this markup wasn't covered by #239's list-semantics audit since it was page-local, not part of a shared component.

## Decisions made
- **`className` prop added after review.** The first version wrapped `<Grid>` in a page-local `<div>` purely to add a `margin-block-end`. Two independent `/simplify` review angles (simplification, altitude) converged on the same finding: needing this wrapper at both real call sites signals `Grid` was missing a `className` prop. Added it, removed both wrapper divs.
- **`minWidth` stays a free string, not a token/enum.** Altitude review also suggested constraining `minWidth` to a closed set of values (matching `columns`'s `1|2|3|4` union) instead of an arbitrary CSS string. Not applied here — it would require establishing a new design-token scale that doesn't exist yet, a design decision outside this refactor's scope, consistent with how #233 split a similar token-scale decision into its own issue rather than bundling it into an unrelated PR. Filed as follow-up **#286**.

## Out of scope (filed as follow-up issue)
- **#286** — Constrain `Grid`'s `minWidth` prop to a token/enum instead of an arbitrary CSS string. Deferred because it requires a new design-token decision (see above).