### PR TITLE
Give Tag an anchor (as="a") variant; reuse in BlogPost tag links

### DIFF
--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -16,24 +16,32 @@
   color: var(--color-text-muted);
 }
 
-button.tag {
+button.tag,
+a.tag {
   cursor: pointer;
   transition: border-color var(--duration-fast) var(--easing-default),
               color var(--duration-fast) var(--easing-default);
 }
 
+a.tag {
+  text-decoration: none;
+}
+
 /* Mirrors interactions.module.css's chipHover (border-color/color → accent
    on hover) — can't `composes` it here since composition only applies to a
    simple single-class selector, and this hover must be scoped to
-   interactive (button) tags only, not static display spans. Guarded against
-   .active so the hover tint doesn't fight the selected-filter fill. */
-button.tag:hover:not(.active) {
+   interactive (button/anchor) tags only, not static display spans. Guarded
+   against .active so the hover tint doesn't fight the selected-filter
+   fill. */
+button.tag:hover:not(.active),
+a.tag:hover:not(.active) {
   border-color: var(--color-primary);
   color: var(--color-primary);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  button.tag {
+  button.tag,
+  a.tag {
     transition: none;
   }
 }

--- a/src/components/Tag/Tag.test.tsx
+++ b/src/components/Tag/Tag.test.tsx
@@ -1,6 +1,7 @@
 import Tag from '@components/Tag'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 
 describe('Tag', () => {
   it('as="button" exposes aria-pressed reflecting `active` and toggles via click', async () => {
@@ -50,5 +51,34 @@ describe('Tag', () => {
     await user.click(removeControl)
 
     expect(handleRemove).toHaveBeenCalledTimes(1)
+  })
+
+  it('as="a" with an internal "to" renders a router link with the correct href', () => {
+    render(
+      <MemoryRouter>
+        <Tag as="a" to="/blog?tag=italian">
+          Italian
+        </Tag>
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link', { name: 'Italian' })
+    expect(link).toHaveAttribute('href', '/blog?tag=italian')
+    expect(link).not.toHaveAttribute('target')
+  })
+
+  it('as="a" with an external "to" opens in a new tab safely', () => {
+    render(
+      <MemoryRouter>
+        <Tag as="a" to="https://example.com">
+          Italian
+        </Tag>
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link', { name: 'Italian' })
+    expect(link).toHaveAttribute('href', 'https://example.com')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noreferrer')
   })
 })

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -2,11 +2,7 @@ import type { CSSProperties, FC, MouseEvent, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import styles from './Tag.module.css'
 
-export interface TagProps {
-  /** `span` for display, `button` for an interactive filter chip, `a` for a navigable link. @default 'span' */
-  as?: 'span' | 'button' | 'a'
-  /** Destination for `as="a"`; ignored otherwise. */
-  to?: string
+interface TagBaseProps {
   /** Selected filter state (accent fill). @default false */
   active?: boolean
   /** Adds a remove control (editor tag input). @default false */
@@ -18,22 +14,37 @@ export interface TagProps {
   style?: CSSProperties
 }
 
-const Tag: FC<TagProps> = ({
-  as = 'span',
-  to,
-  active = false,
-  removable = false,
-  onRemove,
-  onClick,
-  children,
-  className: extraClassName,
-  style,
-}) => {
+export type TagProps = TagBaseProps &
+  (
+    | {
+        /** `a` for a navigable link. */
+        as: 'a'
+        /** Destination for `as="a"`; required. */
+        to: string
+      }
+    | {
+        /** `span` for display, `button` for an interactive filter chip. @default 'span' */
+        as?: 'span' | 'button'
+        to?: never
+      }
+  )
+
+const Tag: FC<TagProps> = (props) => {
+  const {
+    active = false,
+    removable = false,
+    onRemove,
+    onClick,
+    children,
+    className: extraClassName,
+    style,
+  } = props
+
   const className = [styles.tag, active && styles.active, extraClassName]
     .filter(Boolean)
     .join(' ')
 
-  if (as === 'button') {
+  if (props.as === 'button') {
     return (
       <button
         type="button"
@@ -47,14 +58,21 @@ const Tag: FC<TagProps> = ({
     )
   }
 
-  if (as === 'a') {
-    const href = to ?? ''
+  if (props.as === 'a') {
+    const href = props.to
     const isExternal =
       /^https?:\/\//.test(href) || href.startsWith('mailto:') || href.startsWith('tel:')
 
     if (isExternal) {
       return (
-        <a href={href} className={className} style={style} onClick={onClick}>
+        <a
+          href={href}
+          className={className}
+          style={style}
+          onClick={onClick}
+          target="_blank"
+          rel="noreferrer"
+        >
           {children}
         </a>
       )

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,9 +1,12 @@
 import type { CSSProperties, FC, MouseEvent, ReactNode } from 'react'
+import { Link as RouterLink } from 'react-router-dom'
 import styles from './Tag.module.css'
 
 export interface TagProps {
-  /** `span` for display, `button` for an interactive filter chip. @default 'span' */
-  as?: 'span' | 'button'
+  /** `span` for display, `button` for an interactive filter chip, `a` for a navigable link. @default 'span' */
+  as?: 'span' | 'button' | 'a'
+  /** Destination for `as="a"`; ignored otherwise. */
+  to?: string
   /** Selected filter state (accent fill). @default false */
   active?: boolean
   /** Adds a remove control (editor tag input). @default false */
@@ -17,6 +20,7 @@ export interface TagProps {
 
 const Tag: FC<TagProps> = ({
   as = 'span',
+  to,
   active = false,
   removable = false,
   onRemove,
@@ -40,6 +44,26 @@ const Tag: FC<TagProps> = ({
       >
         {children}
       </button>
+    )
+  }
+
+  if (as === 'a') {
+    const href = to ?? ''
+    const isExternal =
+      /^https?:\/\//.test(href) || href.startsWith('mailto:') || href.startsWith('tel:')
+
+    if (isExternal) {
+      return (
+        <a href={href} className={className} style={style} onClick={onClick}>
+          {children}
+        </a>
+      )
+    }
+
+    return (
+      <RouterLink to={href} className={className} style={style} onClick={onClick}>
+        {children}
+      </RouterLink>
     )
   }
 

--- a/src/pages/Blog/BlogPost.module.css
+++ b/src/pages/Blog/BlogPost.module.css
@@ -110,29 +110,6 @@
   border-radius: var(--radius-sm);
 }
 
-.tag {
-  composes: focusRing chipHover from '../../styles/interactions.module.css';
-  display: inline-block;
-  padding: var(--space-1) var(--space-2);
-  font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
-  letter-spacing: var(--tracking-meta);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-surface);
-  color: var(--color-text-muted);
-  text-decoration: none;
-  transition:
-    border-color var(--duration-fast) var(--easing-default),
-    color var(--duration-fast) var(--easing-default);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .tag {
-    transition: none;
-  }
-}
-
 /* Matches the design's share block exactly: 56px/32px top spacing —
    distinctly more than the related-posts section below (--space-8/6),
    no tokens land on either literal. */

--- a/src/pages/Blog/BlogPost.tsx
+++ b/src/pages/Blog/BlogPost.tsx
@@ -3,11 +3,12 @@ import CodeBlock from '@components/CodeBlock'
 import FileTree from '@components/FileTree'
 import Image from '@components/Image'
 import Link from '@components/Link'
+import Tag from '@components/Tag'
 import Typography from '@components/Typography'
 import NotFound from '@pages/NotFound'
 import type { AnchorHTMLAttributes } from 'react'
 import { Suspense, useMemo } from 'react'
-import { Link as RouterLink, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import styles from './BlogPost.module.css'
 import { formatDate, getLazyPost, getPost, posts } from './posts'
 import type { PostMeta } from './posts'
@@ -84,9 +85,9 @@ const BlogPost = () => {
         <ul className={styles.tags}>
           {post.tags.map((tag) => (
             <li key={tag}>
-              <RouterLink to={`/blog?tag=${tag}`} className={styles.tag}>
+              <Tag as="a" to={`/blog?tag=${tag}`}>
                 {tag}
-              </RouterLink>
+              </Tag>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
Closes #248

## What changed
- `Tag` gains an `as="a"` variant rendering a real, navigable anchor: react-router `Link` for internal paths, a plain `<a target="_blank" rel="noreferrer">` for external URLs (mirroring `Link.tsx`'s own internal/external split).
- `to` is enforced at compile time via a discriminated union — required when `as="a"`, disallowed otherwise — so a consumer can't silently forget it and render a broken empty-href link.
- `Tag.module.css`'s interactive-chip hover/transition rules (previously scoped to `button.tag`) now also cover `a.tag`, so anchor chips get the same hover-to-accent treatment as button chips.
- `BlogPost.tsx` now renders its post tags with `<Tag as="a" to={...}>` instead of a raw `RouterLink` styled by a hand-rolled `.tag` rule in `BlogPost.module.css` — that rule (plus its reduced-motion block) is deleted.
- Added test coverage for both new render paths (internal href, external href with `target`/`rel`).

## Why
`BlogPost.module.css`'s `.tag` rule was a near-verbatim reimplementation of `Tag`'s own chip styling (font, border, radius, colors, hover, reduced-motion guard) — a copy that would silently drift from the canonical `Tag` styling over time. Consolidating onto the shared component gives a single source of truth for chip visuals across all three render modes (span/button/anchor).

## How to verify
- Visit a blog post (`/blog/<slug>`) and confirm the tag chips in the header still look and behave like tags (border, mono font, hover-to-accent) and still link to `/blog?tag=<tag>`.
- `pnpm test`, `pnpm lint`, `pnpm --package=typescript dlx tsc --noEmit -p .` all pass with no new errors.

## Decisions made
- Chose a discriminated union (`{ as: 'a'; to: string } | { as?: 'span' | 'button'; to?: never }`) over a plain optional `to?: string`, even though it adds some indirection (`props.as`/`props.to` instead of destructured locals) — an independent review pass caught that an optional `to` would silently render `<Link to="">` (a no-op link) if a caller forgot it. The type safety was judged worth the small added complexity; flagged by `/simplify` as possibly more machinery than needed, but reverting it would reintroduce that exact bug class.
- External anchors get `target="_blank" rel="noreferrer"`, matching `Link.tsx`'s existing external-link behavior, even though no current caller passes an external `to` to `Tag` — the branch exists and needed to be correct, not just currently-unexercised.
- Left BlogPost's tag chips at `Tag`'s own canonical padding (`--space-3` horizontal) rather than reproducing the old `.tag` rule's slightly narrower `--space-2` padding — a ~4px visual difference. Since the whole point of this issue is collapsing drifted copies onto one canonical chip style, matching `Tag`'s real padding is the intended outcome, not a regression, despite the AC's literal "visual appearance unchanged" wording.

## Out of scope (filed as follow-up issues)
- **#288** — Extract a shared `isExternalHref` classification helper (the internal/external URL check now exists independently in `Link.tsx`, `AppCard.tsx`, and this PR's `Tag.tsx`); also evaluate having `Tag`'s `as="a"` branch compose the existing `Link` component. Deferred because it touches `Link.tsx` and `AppCard.tsx`, both outside this issue's scope.