### PR TITLE
Harden shared focus-management mechanism: real header-height token + shared main-landmark id constant

### DIFF
--- a/src/components/AdminLayout/AdminLayout.module.css
+++ b/src/components/AdminLayout/AdminLayout.module.css
@@ -9,9 +9,12 @@
   flex: 1;
   min-width: 0;
   overflow-x: clip;
-  /* SC 2.4.11: reserves room above the main landmark roughly equal to a
-     single-row sticky header's height, so the header — pinned via
-     position: sticky — never fully covers focus/scroll landing here or
-     on a near-top descendant. Mirrors PageShell.module.css .main. */
-  scroll-margin-block-start: var(--space-16);
+  /* SC 2.4.11: reserves room above the main landmark equal to the Header's
+     real rendered height — tracked live via --header-height, a custom
+     property a ResizeObserver in Header.tsx keeps in sync (covers both the
+     single-row layout and the narrow-viewport wrapped two-row state), so the
+     header — pinned via position: sticky — never fully covers focus/scroll
+     landing here or on a near-top descendant. Mirrors PageShell.module.css
+     .main. */
+  scroll-margin-block-start: var(--header-height);
 }

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import Header from './Header'
 
 const renderWithRouter = (ui: ReactElement, { route = '/' } = {}) => {
@@ -83,6 +83,21 @@ describe('Header', () => {
       expect(screen.queryByRole('navigation')).not.toBeInTheDocument()
       expect(screen.queryByRole('link', { name: 'Recipes' })).not.toBeInTheDocument()
       expect(screen.queryByRole('button', { name: /log out/i })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('--header-height custom property', () => {
+    afterEach(() => {
+      document.documentElement.style.removeProperty('--header-height')
+    })
+
+    it('sets --header-height on the document root after mount', () => {
+      renderWithRouter(<Header />)
+
+      const headerHeight = document.documentElement.style.getPropertyValue('--header-height')
+
+      expect(headerHeight).not.toBe('')
+      expect(headerHeight).toMatch(/^\d+(\.\d+)?px$/)
     })
   })
 })

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,7 @@
 import Button from '@components/Button'
 import ThemeToggle from '@components/ThemeToggle'
 import type { FC } from 'react'
+import { useEffect, useRef } from 'react'
 import { Link as RouterLink, useLocation } from 'react-router-dom'
 import styles from './Header.module.css'
 
@@ -39,6 +40,28 @@ const Header: FC<HeaderProps> = ({
   className: extraClassName,
 }) => {
   const { pathname } = useLocation()
+  const headerRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const element = headerRef.current
+    if (!element) return
+
+    // getBoundingClientRect(), not entry.contentRect/borderBoxSize — the
+    // header's border-block-end is part of its visual footprint, and only
+    // getBoundingClientRect() includes border in the measured height. Also
+    // re-fires on wrap (single row -> two rows on narrow viewports), so
+    // --header-height stays accurate for consumers like PageShell/AdminLayout's
+    // scroll-margin-block-start without them needing wrap-aware media queries.
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const height = entry.target.getBoundingClientRect().height
+        document.documentElement.style.setProperty('--header-height', `${height}px`)
+      }
+    })
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [])
 
   const className = [
     styles.header,
@@ -67,7 +90,7 @@ const Header: FC<HeaderProps> = ({
   )
 
   return (
-    <header className={className}>
+    <header ref={headerRef} className={className}>
       <div className={styles.inner}>
         <div className={styles.left}>
           <RouterLink to={brandTo} className={styles.brand}>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -41,22 +41,32 @@ const Header: FC<HeaderProps> = ({
 }) => {
   const { pathname } = useLocation()
   const headerRef = useRef<HTMLElement>(null)
+  const lastHeightRef = useRef<number | null>(null)
 
   useEffect(() => {
     const element = headerRef.current
     if (!element) return
 
-    // getBoundingClientRect(), not entry.contentRect/borderBoxSize — the
-    // header's border-block-end is part of its visual footprint, and only
-    // getBoundingClientRect() includes border in the measured height. Also
-    // re-fires on wrap (single row -> two rows on narrow viewports), so
-    // --header-height stays accurate for consumers like PageShell/AdminLayout's
-    // scroll-margin-block-start without them needing wrap-aware media queries.
+    // entry.borderBoxSize, not getBoundingClientRect() — borderBoxSize is by
+    // definition the content+padding+border box, so it already includes the
+    // header's border-block-end without forcing a synchronous layout read on
+    // every firing (getBoundingClientRect() falls back for the handful of
+    // older engines that don't support borderBoxSize). Also re-fires on wrap
+    // (single row -> two rows on narrow viewports), so --header-height stays
+    // accurate for consumers like PageShell/AdminLayout's
+    // scroll-margin-block-start without them needing wrap-aware media
+    // queries. The rounded height is cached so sub-pixel jitter mid-resize
+    // doesn't trigger redundant writes — every setProperty ripples a
+    // style/layout recalc out to those consumers, not just the header.
     const observer = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const height = entry.target.getBoundingClientRect().height
-        document.documentElement.style.setProperty('--header-height', `${height}px`)
-      }
+      const [entry] = entries
+      const height = entry.borderBoxSize?.[0]?.blockSize ?? entry.target.getBoundingClientRect().height
+      const roundedHeight = Math.round(height)
+
+      if (roundedHeight === lastHeightRef.current) return
+
+      lastHeightRef.current = roundedHeight
+      document.documentElement.style.setProperty('--header-height', `${roundedHeight}px`)
     })
     observer.observe(element)
 

--- a/src/components/PageShell/PageShell.module.css
+++ b/src/components/PageShell/PageShell.module.css
@@ -5,10 +5,11 @@
   padding-inline: var(--space-6);
   max-width: var(--max-w-site);
   margin-inline: auto;
-  /* SC 2.4.11: reserves room above the main landmark roughly equal to a
-     single-row sticky header's height (Header.module.css .inner: --space-4
-     block padding either side of a 32px control, ~64px), so the header —
-     pinned via position: sticky — never fully covers focus/scroll landing
-     here or on a near-top descendant. */
-  scroll-margin-block-start: var(--space-16);
+  /* SC 2.4.11: reserves room above the main landmark equal to the Header's
+     real rendered height — tracked live via --header-height, a custom
+     property a ResizeObserver in Header.tsx keeps in sync (covers both the
+     single-row layout and the narrow-viewport wrapped two-row state) — so
+     the header, pinned via position: sticky, never fully covers focus/scroll
+     landing here or on a near-top descendant. */
+  scroll-margin-block-start: var(--header-height);
 }

--- a/src/components/PageShell/PageShell.tsx
+++ b/src/components/PageShell/PageShell.tsx
@@ -1,6 +1,7 @@
 import SkipLink from '@components/SkipLink'
 import type { FC, ReactNode } from 'react'
 
+import { MAIN_LANDMARK_ID } from '../../constants/mainLandmark'
 import styles from './PageShell.module.css'
 
 export interface PageShellProps {
@@ -18,7 +19,7 @@ const PageShell: FC<PageShellProps> = ({ header, footer, mainClassName, children
   <>
     <SkipLink />
     {header}
-    <main id="main" tabIndex={-1} className={mainClassName ?? styles.main}>
+    <main id={MAIN_LANDMARK_ID} tabIndex={-1} className={mainClassName ?? styles.main}>
       {children}
     </main>
     {footer}

--- a/src/components/ScrollToTop/ScrollToTop.tsx
+++ b/src/components/ScrollToTop/ScrollToTop.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from 'react'
 import { useLocation, useNavigationType } from 'react-router-dom'
 
+import { MAIN_LANDMARK_ID } from '../../constants/mainLandmark'
+
 export default function ScrollToTop() {
   const { pathname, hash } = useLocation()
   const navigationType = useNavigationType()
@@ -29,7 +31,7 @@ export default function ScrollToTop() {
       // <h1>) after a client-side route change, so keyboard/screen-reader
       // users get the new page's context instead of staying on the old
       // focus target. preventScroll avoids fighting the scrollTo above.
-      document.getElementById('main')?.focus({ preventScroll: true })
+      document.getElementById(MAIN_LANDMARK_ID)?.focus({ preventScroll: true })
     }
     // navigationType is read above but deliberately left out of these deps —
     // it's consulted, not reacted to. A search-param-only change (e.g. a

--- a/src/components/SkipLink/SkipLink.tsx
+++ b/src/components/SkipLink/SkipLink.tsx
@@ -1,12 +1,14 @@
 import type { FC } from 'react'
+
+import { MAIN_LANDMARK_ID } from '../../constants/mainLandmark'
 import styles from './SkipLink.module.css'
 
 export interface SkipLinkProps {
-  /** id of the landmark to jump to. @default 'main' */
+  /** id of the landmark to jump to. @default MAIN_LANDMARK_ID ('main') */
   targetId?: string
 }
 
-const SkipLink: FC<SkipLinkProps> = ({ targetId = 'main' }) => (
+const SkipLink: FC<SkipLinkProps> = ({ targetId = MAIN_LANDMARK_ID }) => (
   <a href={`#${targetId}`} className={styles.skipLink}>
     Skip to main content
   </a>

--- a/src/constants/mainLandmark.ts
+++ b/src/constants/mainLandmark.ts
@@ -1,0 +1,3 @@
+// Shared by PageShell/RecipePreview (render it), SkipLink (links to it), and
+// ScrollToTop (focuses it) — keeping one constant means a rename can't drift.
+export const MAIN_LANDMARK_ID = 'main'

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -15,6 +15,7 @@ import { applyStepReadiness, type Recipe } from '@models/recipe'
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
+import { MAIN_LANDMARK_ID } from '../../../constants/mainLandmark'
 import styles from './RecipePreview.module.css'
 
 // Hoisted elements, not components — these never take props, so there's no
@@ -218,7 +219,7 @@ const RecipePreview: FC = () => {
 
   if (loading) {
     return (
-      <main id="main" tabIndex={-1} className={styles.main}>
+      <main id={MAIN_LANDMARK_ID} tabIndex={-1} className={styles.main}>
         <div className={styles.stateWrapper}>
           <Loading />
         </div>
@@ -228,7 +229,7 @@ const RecipePreview: FC = () => {
 
   if (notFound || !recipe) {
     return (
-      <main id="main" tabIndex={-1} className={styles.main}>
+      <main id={MAIN_LANDMARK_ID} tabIndex={-1} className={styles.main}>
         <div className={styles.notFoundBox}>
           <div className={styles.notFoundIcon}>{iconNotFound}</div>
           <Typography variant="heading1" className={styles.notFoundHeading}>
@@ -320,7 +321,7 @@ const RecipePreview: FC = () => {
       </div>
 
       <main
-        id="main"
+        id={MAIN_LANDMARK_ID}
         tabIndex={-1}
         className={[styles.main, styles.mainWithBanner].join(' ')}
       >

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -147,6 +147,10 @@
   --focus-ring-outline-offset: 3px;
 
   /* ── Layout ───────────────────────────────────────────────── */
+  /* Pre-JS/no-JS fallback for scroll-margin-block-start consumers (PageShell,
+     AdminLayout) — Header.tsx's ResizeObserver overwrites this with the
+     real rendered height (single- or wrapped-row) on mount. */
+  --header-height: var(--space-16);
   --max-w-site:    1080px; /* shell / header / footer width */
   --max-w-reading: 720px;  /* index + hero reading column */
   --max-w-article: 680px;  /* long-form article column */

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -36,6 +36,22 @@ if (typeof window !== 'undefined') {
   window.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver
 }
 
+export class MockResizeObserver {
+  observe: ReturnType<typeof vi.fn>
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+
+  constructor(callback: ResizeObserverCallback) {
+    this.observe = vi.fn((element: Element) => {
+      callback([{ target: element } as ResizeObserverEntry], {} as ResizeObserver)
+    })
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
+}
+
 // jsdom does not implement the native <dialog> element's `showModal`/`close`
 // behaviour. This minimal polyfill toggles the `open` attribute and dispatches
 // a `close` event so components built on native <dialog> (e.g. a future


### PR DESCRIPTION
Closes #249

## What changed
- **Real `--header-height` token.** `Header.tsx` now measures its own rendered box via a `ResizeObserver` (reading `entry.borderBoxSize` — already includes border, no forced synchronous layout — falling back to `getBoundingClientRect()` for engines without `borderBoxSize` support) and writes it to a `--header-height` custom property on `document.documentElement`. Re-fires automatically when the header wraps to two rows on narrow viewports. Writes are skipped when the rounded height hasn't changed, so sub-pixel resize jitter doesn't ripple a style/layout recalc out to `PageShell`/`AdminLayout`'s `scroll-margin-block-start` on every tick.
- `tokens.css` gets `--header-height: var(--space-16)` as the pre-JS/no-JS fallback default (same value as before, so initial paint is unchanged).
- `PageShell.module.css` / `AdminLayout.module.css` now consume `var(--header-height)` instead of the old hand-computed `var(--space-16)` guess.
- **Shared `MAIN_LANDMARK_ID` constant** (`src/constants/mainLandmark.ts`, matching the existing `socialLinks.ts` pattern) replaces four independently-duplicated `'main'` string literals: `PageShell.tsx`, `ScrollToTop.tsx`, `SkipLink.tsx`'s default prop, and all three occurrences in `RecipePreview.tsx` (which renders its own `<main>` outside `PageShell`).
- Added a `MockResizeObserver` to `tests/setup.ts` (mirrors the existing `MockIntersectionObserver` pattern — jsdom doesn't implement `ResizeObserver` natively) and a direct test asserting `Header` sets `--header-height` on mount.

## Why
The old `--space-16` scroll-margin was a hand-computed guess justified only by single-row header arithmetic in a comment — it silently desynced if header content/padding changed, and never accounted for the header's wrapped two-row state on narrow viewports. The `'main'` id was independently hardcoded in four places with no compile-time link between them, so a rename in any one could silently break `ScrollToTop`'s focus-on-route-change call (`?.focus()` swallows the `null`).

## How to verify
- Resize the viewport narrow enough that the header's nav wraps to two rows, then trigger a client-side route change (e.g. click a nav link) — focus/scroll should still land below the fully-wrapped header, not partially behind it.
- `pnpm test`, `pnpm lint`, `pnpm --package=typescript dlx tsc --noEmit -p .` all pass with no new errors.

## Decisions made
- The issue's original text named `Layout.tsx`/`AdminLayout.tsx`/`ScrollToTop.tsx` — `Layout.tsx` no longer exists (renamed to `PageShell.tsx` by an earlier, already-merged issue in this epic). Treated `PageShell.tsx` as the successor and additionally included `SkipLink.tsx` (a real 4th independent-literal site — `PageShell` renders `<SkipLink />` with no explicit `targetId`, so it was silently relying on the literal default matching) and `RecipePreview.tsx`'s three occurrences (a standalone route that renders its own `<main>` outside `PageShell`, consuming the exact same `ScrollToTop` focus contract). Both are squarely in scope of the issue's own stated purpose; leaving either out would have left the exact drift risk the issue is written to eliminate.
- **Left `RecipePreview.module.css`'s `.mainWithBanner` scroll-margin untouched**, even though it uses the same `--space-16` value. Its own comment confirms it's sized for a *different* sticky element (a status banner, not the Header — RecipePreview renders no Header) that just coincidentally shares the value today. Conflating it with `--header-height` would be semantically wrong.

## Out of scope (filed as follow-up issues)
- **#290** — Extend the `ResizeObserver`-driven measured-height mechanism (extracted into a reusable hook) to RecipePreview's own sticky status banner, replacing its coincidental `--space-16` approximation with a real `--banner-height`. Deferred because it requires extracting a new hook and touches a page component (`RecipePreview`) explicitly outside this issue's stated scope (`Layout`/`AdminLayout`/`Header`/`ScrollToTop` only).