### PR TITLE
Centralize Typography-variant vs consumer-className specificity fix

### DIFF
--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -1,25 +1,34 @@
 /* Link component styles */
 
-.link {
-  composes: focusRing from '../../styles/interactions.module.css';
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  color: var(--color-link);
-  font-weight: inherit;
-  text-decoration: none;
-  width: fit-content;
-  border-radius: var(--radius-sm);
-  transition: color var(--duration-fast) var(--easing-default);
-}
-
-.link:hover {
-  color: var(--color-primary);
-}
-
-@media (prefers-reduced-motion: reduce) {
+/* Base `.link` rule (+ :hover + reduced-motion reset) lives in a low-
+   priority @layer so a consumer's plain (unlayered) className always wins
+   over it, regardless of source/bundle order or matching specificity — see
+   issue #263 (same mechanism as Typography.module.css). Modifier/utility
+   classes below (tone/underline/icon/nudge) stay unlayered — those are
+   selected via Link's own props, not something a raw className collides
+   with. */
+@layer component-defaults {
   .link {
-    transition: none;
+    composes: focusRing from '../../styles/interactions.module.css';
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    color: var(--color-link);
+    font-weight: inherit;
+    text-decoration: none;
+    width: fit-content;
+    border-radius: var(--radius-sm);
+    transition: color var(--duration-fast) var(--easing-default);
+  }
+
+  .link:hover {
+    color: var(--color-primary);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .link {
+      transition: none;
+    }
   }
 }
 

--- a/src/components/RecipeDetailView/RecipeDetailView.module.css
+++ b/src/components/RecipeDetailView/RecipeDetailView.module.css
@@ -14,15 +14,12 @@
   margin-block-end: 28px;
 }
 
-/* .article .backLink (not bare): raises specificity above the shared
-   Link component's own `.link` (color: var(--color-link), an accent
-   blue) — a bare `.backLink` ties with it, same root cause as the
-   Typography fixes below (a plain className merge onto Link's own
-   variant class), and would otherwise leave this link's color
-   non-deterministic between the design's intended muted tone and
-   Link's default accent. Also overrides metaText's own baked-in
+/* Bare `.backLink` override: Link's own `.link` (color: var(--color-link))
+   now lives in `@layer component-defaults` (Link.module.css, #263), so
+   this plain unlayered class deterministically wins without needing the
+   old descendant-selector trick. Still overrides metaText's own baked-in
    font-size (13px/faint) — this back link wants 12px/muted instead. */
-.article .backLink {
+.backLink {
   font-size: 12px;
   color: var(--color-text-muted);
 }
@@ -41,10 +38,11 @@
   max-width: var(--max-w-article);
 }
 
-/* .header .title (not a bare `.title` rule): raises specificity above
-   Typography's own `.heading1` (font-size/line-height/color) — see the
-   `.header .intro` comment below for why a bare class ties with it. */
-.header .title {
+/* Bare `.title` override: Typography's own `.heading1` now lives in
+   `@layer component-defaults` (Typography.module.css, #263), so this
+   plain unlayered class deterministically wins without needing the old
+   descendant-selector trick. */
+.title {
   font-size: clamp(32px, 5.4vw, 46px);
   font-weight: var(--font-weight-semibold);
   line-height: var(--line-height-tight);

--- a/src/components/RecipeDetailView/RecipeDetailView.module.css
+++ b/src/components/RecipeDetailView/RecipeDetailView.module.css
@@ -14,12 +14,16 @@
   margin-block-end: 28px;
 }
 
-/* Bare `.backLink` override: Link's own `.link` (color: var(--color-link))
-   now lives in `@layer component-defaults` (Link.module.css, #263), so
-   this plain unlayered class deterministically wins without needing the
-   old descendant-selector trick. Still overrides metaText's own baked-in
-   font-size (13px/faint) — this back link wants 12px/muted instead. */
-.backLink {
+/* .article .backLink (not bare): the descendant-selector specificity
+   boost is no longer needed to beat Link's own `.link` (color:
+   var(--color-link)) — that's now handled by `@layer component-defaults`
+   (Link.module.css, #263). But it's still needed to beat this same
+   rule's own composed `metaText` class (text.module.css), which bakes in
+   its own font-size (13px) and color (faint) at equal, single-class
+   specificity — a separate, pre-existing tie outside #263's scope
+   (Typography-variant/Link.link only). This back link wants 12px/muted,
+   not metaText's 13px/faint. */
+.article .backLink {
   font-size: 12px;
   color: var(--color-text-muted);
 }

--- a/src/components/Typography/Typography.module.css
+++ b/src/components/Typography/Typography.module.css
@@ -1,55 +1,63 @@
-.heading1 {
-  font-size: var(--font-size-4xl);
-  font-weight: var(--font-weight-semibold);
-  line-height: var(--line-height-tight);
-  color: var(--color-text-strong);
-}
+/* These variant rules are wrapped in a low-priority @layer so a consumer's
+   plain (unlayered) className always wins over them, regardless of source/
+   bundle order or matching specificity — per the CSS Cascade spec, any
+   unlayered rule beats any layered rule. Replaces the old per-callsite
+   descendant-selector trick (`.parent .child`) formerly needed to out-
+   specificity these vs a bare override. See issue #263. */
+@layer component-defaults {
+  .heading1 {
+    font-size: var(--font-size-4xl);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--color-text-strong);
+  }
 
-.heading2 {
-  font-size: var(--font-size-3xl);
-  font-weight: var(--font-weight-semibold);
-  line-height: var(--line-height-tight);
-  color: var(--color-text-strong);
-}
+  .heading2 {
+    font-size: var(--font-size-3xl);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--color-text-strong);
+  }
 
-.heading3 {
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-semibold);
-  line-height: var(--line-height-tight);
-  color: var(--color-text-strong);
-}
+  .heading3 {
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--color-text-strong);
+  }
 
-.heading4 {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-  line-height: var(--line-height-tight);
-  color: var(--color-text-strong);
-}
+  .heading4 {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-tight);
+    color: var(--color-text-strong);
+  }
 
-.body {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-normal);
-  line-height: var(--line-height-normal);
-  color: var(--color-text);
-}
+  .body {
+    font-size: var(--font-size-base);
+    font-weight: var(--font-weight-normal);
+    line-height: var(--line-height-normal);
+    color: var(--color-text);
+  }
 
-.bodyLarge {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-normal);
-  line-height: var(--line-height-relaxed);
-  color: var(--color-text);
-}
+  .bodyLarge {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-normal);
+    line-height: var(--line-height-relaxed);
+    color: var(--color-text);
+  }
 
-.label {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  line-height: var(--line-height-normal);
-  color: var(--color-text);
-}
+  .label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-normal);
+    color: var(--color-text);
+  }
 
-.caption {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-normal);
-  line-height: var(--line-height-normal);
-  color: var(--color-text-muted);
+  .caption {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-normal);
+    line-height: var(--line-height-normal);
+    color: var(--color-text-muted);
+  }
 }

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -68,13 +68,13 @@
   border-top-color: var(--color-warning);
 }
 
-/* .sessionBanner .bannerAction (not bare `.bannerAction`): raises
-   specificity above the shared Link component's own `.link` — same
-   specificity-tie fix documented throughout this epic (see
-   RecipeDetailView.module.css's `.article .backLink`). Styled to look
+/* Bare `.bannerAction` override: Link's own `.link` (color:
+   var(--color-link)) now lives in `@layer component-defaults`
+   (Link.module.css, #263), so this plain unlayered class deterministically
+   wins without needing the old descendant-selector trick. Styled to look
    like the design's small ghost button, same "style Link locally"
    precedent as RecipeList's `.newButton`. */
-.sessionBanner .bannerAction {
+.bannerAction {
   flex-shrink: 0;
   width: auto;
   font-size: 13px;
@@ -87,14 +87,14 @@
     color var(--duration-fast) var(--easing-default);
 }
 
-.sessionBanner .bannerAction:hover {
+.bannerAction:hover {
   border-color: var(--color-primary);
   color: var(--color-primary);
   background: var(--color-hover);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .sessionBanner .bannerAction {
+  .bannerAction {
     transition: none;
   }
 }


### PR DESCRIPTION
Closes #263

## What changed
- `Typography.module.css`'s 8 variant classes (`.heading1`–`.caption`) and `Link.module.css`'s `.link`/`.link:hover`/reduced-motion rules now live in `@layer component-defaults`. Per the CSS Cascade spec, any unlayered rule always beats any layered rule regardless of specificity or source order — so a consumer's plain `className` now deterministically wins over these components' own base styles, with no descendant-selector trick required. Tone/underline/icon/nudge modifier classes in `Link.module.css` stay unlayered (they're selected via `Link`'s own props, not something a raw `className` collides with).
- Proved the mechanism by de-scoping 2 sites from the old `.parent .child` trick to bare classes: `RecipeDetailView.module.css`'s `.title` and `RecipeEditor.module.css`'s `.bannerAction`.
- All other existing `.parent .child` workaround sites are left as-is, per the issue's own explicit "Out of scope" note.

## Why
`Typography`'s variant class and `Link`'s `.link` class were each merged with a consumer's `className` as two equal-specificity classes on the same element — whichever rule happened to land later in the *compiled* bundle won, non-deterministic and dependent on build order, not source order. This had already been independently hand-patched 8+ times across the codebase with a bespoke descendant-selector trick. `@layer` fixes the mechanism once instead of relying on every future consumer rediscovering and hand-rolling the same workaround.

## How to verify
Since jsdom doesn't render real CSS cascade/layer order, this was verified against the live dev server with a headless browser, measuring `getComputedStyle` directly (not just screenshots):
- `/recipes/<any-slug>` in both light and dark theme: the "All recipes" back link renders muted/12px (not Link's default accent color), and the recipe title renders the page's custom `clamp(32px,5.4vw,46px)`/tight-tracking override (not Typography's smaller default `heading1` sizing) — measured `46px` / `-1.38px` letter-spacing in both themes.
- Isolated proof of the `@layer` mechanism itself: a synthetic unlayered override class was injected against `Link`'s real compiled `.link` class on a live page, confirming the unlayered class wins.

## Decisions made
- **A mid-review course correction**: the first pass de-scoped `RecipeDetailView.module.css`'s `.article .backLink` (one of the issue's own suggested example sites) to bare `.backLink`. Browser verification caught that this exposed a *second, unrelated* specificity tie — `.backLink` also `composes: metaText from text.module.css`, and `metaText` independently sets its own conflicting `font-size`/`color` at equal specificity. The old 2-class selector was incidentally winning against both ties at once; de-scoping it reopened the `metaText` tie and produced a real regression (measured 13px/faint instead of the intended 12px/muted). Reverted `.article .backLink` to the descendant-selector form (now documented as needed only for the `metaText` tie, not the `Link.link` tie) and used `RecipeEditor.module.css`'s `.bannerAction` — a clean `Link` + `className` site with no `composes` entanglement — as the replacement second proof site instead.
- No new hardcoded hex/px values or `!important` were introduced — the diff only moves existing declarations into `@layer` blocks or simplifies selectors.

## Out of scope (filed as follow-up issues)
- **#292** — Extend `@layer component-defaults` to `text.module.css`'s shared classes (`metaText`, `pageHeading`, `pageLead`, etc.), which have the exact same specificity-tie mechanism against `composes`-consuming call sites. Deferred because it's composed into 11+ other files across the codebase and is explicitly outside this issue's stated scope (Typography/Link only).