### PR TITLE
Centralize shared icon components; give Tag a style hook for its remove button

### DIFF
--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -56,20 +56,27 @@ a.tag:hover:not(.active) {
   border-color: var(--color-primary);
 }
 
-.remove {
-  composes: focusRing from '../../styles/interactions.module.css';
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  /* SC 2.5.8 Target size (minimum) — the glyph alone renders well under
-     24x24 CSS px at --font-size-xs; give the control an explicit minimum
-     hit area. */
-  min-width: 24px;
-  min-height: 24px;
-  border: none;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
-  padding: 0;
-  line-height: 1;
+/* `.remove` lives in a low-priority @layer so a consumer's plain (unlayered)
+   `removeClassName` always wins over it, regardless of source/bundle order
+   or matching specificity — same mechanism as Typography.module.css /
+   Link.module.css (issue #263), applied here to close out #265's own AC on
+   TagInput's former element-type-selector workaround for this exact rule. */
+@layer component-defaults {
+  .remove {
+    composes: focusRing from '../../styles/interactions.module.css';
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* SC 2.5.8 Target size (minimum) — the glyph alone renders well under
+       24x24 CSS px at --font-size-xs; give the control an explicit minimum
+       hit area. */
+    min-width: 24px;
+    min-height: 24px;
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+  }
 }

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -8,6 +8,8 @@ interface TagBaseProps {
   /** Adds a remove control (editor tag input). @default false */
   removable?: boolean
   onRemove?: (e: MouseEvent) => void
+  /** Extra className merged onto the remove button — only meaningful with `removable`. */
+  removeClassName?: string
   onClick?: (e: MouseEvent) => void
   children?: ReactNode
   className?: string
@@ -37,12 +39,15 @@ const Tag: FC<TagProps> = (props) => {
     onClick,
     children,
     className: extraClassName,
+    removeClassName,
     style,
   } = props
 
   const className = [styles.tag, active && styles.active, extraClassName]
     .filter(Boolean)
     .join(' ')
+
+  const removeButtonClassName = [styles.remove, removeClassName].filter(Boolean).join(' ')
 
   if (props.as === 'button') {
     return (
@@ -91,7 +96,7 @@ const Tag: FC<TagProps> = (props) => {
     <span className={className} style={style}>
       {children}
       {removable && (
-        <button type="button" className={styles.remove} aria-label={removeLabel} onClick={onRemove}>
+        <button type="button" className={removeButtonClassName} aria-label={removeLabel} onClick={onRemove}>
           <span aria-hidden="true">&times;</span>
         </button>
       )}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -47,8 +47,6 @@ const Tag: FC<TagProps> = (props) => {
     .filter(Boolean)
     .join(' ')
 
-  const removeButtonClassName = [styles.remove, removeClassName].filter(Boolean).join(' ')
-
   if (props.as === 'button') {
     return (
       <button
@@ -90,6 +88,7 @@ const Tag: FC<TagProps> = (props) => {
     )
   }
 
+  const removeButtonClassName = [styles.remove, removeClassName].filter(Boolean).join(' ')
   const removeLabel = typeof children === 'string' ? `Remove ${children}` : 'Remove tag'
 
   return (

--- a/src/components/TagInput/TagInput.module.css
+++ b/src/components/TagInput/TagInput.module.css
@@ -32,20 +32,25 @@
   border-radius: 8px;
 }
 
-/* Targets Tag's internally-rendered remove `<button>` by element type,
-   not by class — Tag.module.css's `.remove` class name is scoped to that
-   module and isn't reachable from here, but plain type selectors aren't
-   hashed by CSS Modules. Mirrors the design's own `.chip button` /
-   `.chip button:hover` rules exactly (Admin Recipe Editor.dc.html's
-   `.chip` styles). Tag's default `.remove { color: inherit }` has no
-   hover treatment of its own (most Tag consumers don't want a red tint),
-   so both the faint resting color and the hover-to-error tint are
-   supplied here. */
-.chips .chip button {
+/* Tag exposes its remove button via the `removeClassName` prop (issue #265),
+   so this styles it directly by class rather than reaching into Tag's
+   internal markup with a bare element-type selector — that old approach
+   would silently break or over-match if Tag's internal markup ever changed.
+   Bare class, not scoped under `.chips .chip`: Tag.module.css's own
+   `.remove` rule now lives in `@layer component-defaults` (same mechanism
+   as Typography/Link, #263), so this plain unlayered class deterministically
+   outranks it without needing the old descendant-selector trick — same
+   pattern RecipeDetailView.module.css's `.title` already uses. Mirrors the
+   design's own `.chip button` / `.chip button:hover` rules exactly (Admin
+   Recipe Editor.dc.html's `.chip` styles). Tag's default `.remove
+   { color: inherit }` has no hover treatment of its own (most Tag consumers
+   don't want a red tint), so both the faint resting color and the
+   hover-to-error tint are supplied here. */
+.chipRemove {
   color: var(--color-text-faint);
 }
 
-.chips .chip button:hover {
+.chipRemove:hover {
   color: var(--color-error);
 }
 

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -84,7 +84,13 @@ const TagInput: FC<TagInputProps> = ({
     <div className={styles.container}>
       <div className={styles.chips}>
         {tags.map((tag, i) => (
-          <Tag key={tag} removable onRemove={() => removeTag(i)} className={styles.chip}>
+          <Tag
+            key={tag}
+            removable
+            onRemove={() => removeTag(i)}
+            className={styles.chip}
+            removeClassName={styles.chipRemove}
+          >
             {tag}
           </Tag>
         ))}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -59,6 +59,97 @@ export const iconPlus = (
   </svg>
 )
 
+// iconEdit/iconPreview/iconPublish carry explicit width/height even though
+// some consumers (RecipeList.tsx's .rowActions .actionButton) have a CSS
+// rule that overrides SVG-level sizing anyway — the other consumer (Link's
+// `icon` prop) has no such rule, so the SVG's own attributes are what size
+// it there. The explicit size is correct in both places, so it's kept.
+export const iconEdit = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+    <path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z" />
+  </svg>
+)
+
+export const iconPreview = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+)
+
+export const iconPublish = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 19V5" />
+    <path d="m5 12 7-7 7 7" />
+  </svg>
+)
+
+export const iconWarning = (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+)
+
+export const iconRetry = (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+    <path d="M3 3v5h5" />
+  </svg>
+)
+
 export interface IconAlertCircleProps {
   size: number
   // Optional because one caller (AutosaveStatus) already wraps this icon in

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -11,7 +11,7 @@ import {
 import AutosaveStatus from '@components/AutosaveStatus'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
-import { IconAlertCircle } from '@components/icons'
+import { IconAlertCircle, iconPreview } from '@components/icons'
 import ImageUpload from '@components/ImageUpload'
 import IngredientList from '@components/IngredientList'
 import Link from '@components/Link'
@@ -249,23 +249,6 @@ const iconLock = (
   >
     <rect x="3" y="11" width="18" height="11" rx="2" />
     <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-  </svg>
-)
-
-const iconPreview = (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
-    <circle cx="12" cy="12" r="3" />
   </svg>
 )
 

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -7,6 +7,7 @@ import {
 } from '@api/recipes'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
+import { iconEdit, iconPreview, iconPublish, iconRetry, iconWarning } from '@components/icons'
 import Link from '@components/Link'
 import Loading from '@components/Loading'
 import StatusBadge from '@components/StatusBadge'
@@ -34,51 +35,6 @@ const iconPlus = (
   >
     <line x1="12" y1="5" x2="12" y2="19" />
     <line x1="5" y1="12" x2="19" y2="12" />
-  </svg>
-)
-
-const iconEdit = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-    <path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z" />
-  </svg>
-)
-
-const iconPreview = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
-    <circle cx="12" cy="12" r="3" />
-  </svg>
-)
-
-const iconPublish = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M12 19V5" />
-    <path d="m5 12 7-7 7 7" />
   </svg>
 )
 
@@ -127,41 +83,6 @@ const iconDocument = (
   >
     <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
     <path d="M14 2v5h5" />
-  </svg>
-)
-
-const iconWarning = (
-  <svg
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.8"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
-    <line x1="12" y1="9" x2="12" y2="13" />
-    <line x1="12" y1="17" x2="12.01" y2="17" />
-  </svg>
-)
-
-const iconRetry = (
-  <svg
-    width="15"
-    height="15"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
-    <path d="M3 3v5h5" />
   </svg>
 )
 

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -1,6 +1,7 @@
 import { isSessionError } from '@api/auth'
 import { fetchRecipeByIdAdmin, publishRecipe } from '@api/recipes'
 import Button from '@components/Button'
+import { iconEdit, iconPublish } from '@components/icons'
 import Link from '@components/Link'
 import Loading from '@components/Loading'
 import RecipeDetailView from '@components/RecipeDetailView'
@@ -20,7 +21,7 @@ import styles from './RecipePreview.module.css'
 
 // Hoisted elements, not components — these never take props, so there's no
 // need to re-invoke a function (and rebuild the tree) on every render. Same
-// established pattern as `iconRetry` in RecipeList.tsx / `iconLock` in
+// established pattern as `iconRetry` in icons.tsx / `iconLock` in
 // RecipeEditor.tsx. Paths match Admin Recipe Preview.dc.html's inline SVGs
 // (lines 76, 81-82, 88, 93, 100) exactly.
 const iconStatusPublished = (
@@ -53,40 +54,6 @@ const iconStatusDraft = (
   >
     <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
     <circle cx="12" cy="12" r="3" />
-  </svg>
-)
-
-const iconEdit = (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-    <path d="M18.5 2.5a2.12 2.12 0 0 1 3 3L12 15l-4 1 1-4Z" />
-  </svg>
-)
-
-const iconPublish = (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M12 19V5" />
-    <path d="m5 12 7-7 7 7" />
   </svg>
 )
 

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -2,7 +2,7 @@ import { handleSessionError } from '@api/auth'
 import { fetchUsers, inviteUser, removeUser, UserExistsError } from '@api/users'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
-import { IconAlertCircle } from '@components/icons'
+import { IconAlertCircle, iconRetry, iconWarning } from '@components/icons'
 import Input from '@components/Input'
 import Loading from '@components/Loading'
 import StatusBadge from '@components/StatusBadge'
@@ -51,41 +51,6 @@ const iconTrash = (
     <path d="M3 6h18" />
     <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
     <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
-  </svg>
-)
-
-const iconWarning = (
-  <svg
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.8"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
-    <line x1="12" y1="9" x2="12" y2="13" />
-    <line x1="12" y1="17" x2="12.01" y2="17" />
-  </svg>
-)
-
-const iconRetry = (
-  <svg
-    width="15"
-    height="15"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
-    <path d="M3 3v5h5" />
   </svg>
 )
 


### PR DESCRIPTION
Closes #265

## What changed

**Icon centralization**
- `iconEdit`, `iconPreview`, `iconPublish`, `iconWarning`, `iconRetry` — each previously duplicated across 2-3 admin page files — now live once in `src/components/icons.tsx`.
- `RecipeList.tsx`, `RecipeEditor.tsx`, `RecipePreview.tsx`, and `UserManagement.tsx` all import these from `@components/icons` instead of locally redefining them. Non-duplicated icons (`iconLock`, `iconTrash`, `iconStatusPublished`, etc.) stay local.

**Tag remove-button style hook**
- `Tag` gains a `removeClassName` prop, merged onto its internal remove `<button>` the same way `className` merges onto the root element.
- `Tag.module.css`'s `.remove` rule moves into `@layer component-defaults` (the mechanism introduced in #263) so a consumer's plain `removeClassName` override is deterministic.
- `TagInput` now passes `removeClassName={styles.chipRemove}` instead of reaching into `Tag`'s internal markup via a bare `.chips .chip button` element-type selector.

## Why
Both were real, low-risk maintainability gaps flagged by `/simplify` across two prior issues (#228, #229) but out of scope for either at the time — fixing them required touching files outside those issues' own screens (the already-merged `RecipeList.tsx`, and the shared `Tag` component used across many already-shipped pages).

## How to verify
- Visit `/admin/recipes`, `/admin/recipes/<id>/edit`, `/admin/recipes/<id>/preview`, and `/admin/users` — all icons render identically to before (edit pencil, preview eye, publish arrow, warning triangle, retry arrows).
- Add/remove tags in the admin recipe editor's tag input — the chip remove (×) button still renders faint by default and red on hover.
- `pnpm test`, `pnpm lint`, `pnpm --package=typescript dlx tsc --noEmit -p .` all pass with no new errors.

## Decisions made
- `iconEdit`/`iconPreview`/`iconPublish` existed in two slightly different forms: with explicit `width="14" height="14"` (used via `Link`'s `icon` prop, which has no CSS forcing icon size) and without (used in `RecipeList.tsx`, which has its own `.rowActions .actionButton svg { width: 15px; height: 15px }` CSS override). Kept the sized version as canonical for all consumers — verified (including independently, via review) that `RecipeList`'s CSS override wins regardless of the SVG's own attributes, so this is correct in both contexts, not just harmless in one.
- The issue's Acceptance Criteria bullet list only explicitly names `iconPreview`/`iconWarning`/`iconRetry` for `RecipeList.tsx`, but its "What" section is explicit that `iconEdit`/`iconPublish` must also move out of `RecipeList.tsx` ("every consumer, including `RecipeList.tsx` itself") — otherwise `RecipePreview.tsx` would have nothing correct to import from. Migrated both per that broader instruction.