### PR TITLE
Extract a shared loading/error/empty "state box" CSS pattern

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,16 @@
 @import './styles/tokens.css';
 @import './styles/animations.css';
 
+/* Cascade layer order (higher-priority layers later): `component-defaults`
+   (Typography/Link/Tag's own base styles, issue #263) is beaten by
+   `state-box-heading` (stateBox.module.css's heading/body classes, issue
+   #269, which must win over a Typography variant applied to the same
+   element) — both still lose to any fully unlayered rule (any plain
+   consumer className, which is how every actual page-level override in
+   this codebase works). Declaring this order once, here, means it holds
+   regardless of which file's `@layer` block is parsed first at runtime. */
+@layer component-defaults, state-box-heading;
+
 /* ── Global base styles ────────────────────────────────────── */
 
 /* Design's Home.dc.html uses a bare `* { box-sizing: border-box }` —

--- a/src/index.css
+++ b/src/index.css
@@ -4,13 +4,16 @@
 
 /* Cascade layer order (higher-priority layers later): `component-defaults`
    (Typography/Link/Tag's own base styles, issue #263) is beaten by
-   `state-box-heading` (stateBox.module.css's heading/body classes, issue
-   #269, which must win over a Typography variant applied to the same
-   element) — both still lose to any fully unlayered rule (any plain
+   `composed-overrides` (any shared/composed-pattern module's classes that
+   must win over a `component-defaults`-layered variant class applied to
+   the same element — e.g. stateBox.module.css's heading/body classes,
+   issue #269) — both still lose to any fully unlayered rule (any plain
    consumer className, which is how every actual page-level override in
    this codebase works). Declaring this order once, here, means it holds
-   regardless of which file's `@layer` block is parsed first at runtime. */
-@layer component-defaults, state-box-heading;
+   regardless of which file's `@layer` block is parsed first at runtime,
+   and lets any future shared pattern opt into `composed-overrides`
+   without inventing another bespoke layer name. */
+@layer component-defaults, composed-overrides;
 
 /* ── Global base styles ────────────────────────────────────── */
 

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -252,81 +252,44 @@
 
 /* ── Empty / loading / error states — shared box shape ────────────── */
 
-.emptyBox,
-.loadingBox,
-.errorBox {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  border-radius: var(--radius-xl);
-}
-
 .emptyBox {
+  composes: box from '../../../styles/stateBox.module.css';
   border: 1px dashed var(--color-border);
   padding: clamp(48px, 8vw, 84px) 24px;
 }
 
 .loadingBox {
-  border: var(--border-width) solid var(--color-border);
-  padding: clamp(56px, 9vw, 92px) 24px;
-  gap: 18px;
+  composes: box loading from '../../../styles/stateBox.module.css';
 }
 
 .errorBox {
-  border: var(--border-width) solid color-mix(in srgb, var(--color-error) 30%, var(--color-border));
-  background: var(--color-error-bg);
-  padding: clamp(48px, 8vw, 80px) 24px;
-}
-
-.emptyIcon,
-.errorIcon {
-  width: 52px;
-  height: 52px;
-  /* 14px: design literal — between --radius-lg (12px) and --radius-xl
-     (16px), neither an exact match. */
-  border-radius: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 20px;
+  composes: box error from '../../../styles/stateBox.module.css';
 }
 
 .emptyIcon {
+  composes: icon from '../../../styles/stateBox.module.css';
   background: var(--color-surface);
   border: var(--border-width) solid var(--color-border);
   color: var(--color-text-muted);
 }
 
 .errorIcon {
-  background: var(--color-field);
-  border: var(--border-width) solid color-mix(in srgb, var(--color-error) 30%, var(--color-border));
-  color: var(--color-error);
+  composes: icon iconError from '../../../styles/stateBox.module.css';
 }
 
-/* .emptyBox .emptyHeading / .errorBox .errorHeading (not bare): raise
-   specificity above Typography's own `.heading2`. */
-.emptyBox .emptyHeading,
-.errorBox .errorHeading {
-  font-size: 20px;
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: -0.02em;
-  margin: 0 0 8px;
+.emptyHeading {
+  composes: heading from '../../../styles/stateBox.module.css';
 }
 
-/* .emptyBox .emptyBody / .errorBox .errorBody (not bare): raise
-   specificity above Typography's own `.body`. Identical apart from
-   max-width (36ch vs 38ch per the design's own two paragraphs), so the
-   shared declarations live in one rule and each box overrides just that. */
-.emptyBox .emptyBody,
-.errorBox .errorBody {
-  font-size: 14.5px;
-  line-height: 1.6;
-  color: var(--color-text-muted);
-  margin: 0 0 24px;
-  max-width: 36ch;
+.errorHeading {
+  composes: heading from '../../../styles/stateBox.module.css';
 }
 
-.errorBox .errorBody {
+.emptyBody {
+  composes: body from '../../../styles/stateBox.module.css';
+}
+
+.errorBody {
+  composes: body from '../../../styles/stateBox.module.css';
   max-width: 38ch;
 }

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -246,54 +246,40 @@
 /* ── Not-found state ──────────────────────────────────────────────────
    Matches Admin Recipe Preview.dc.html's not-found block (lines 121-133):
    icon box + h1 + body + ghost back-link, centered. Design literal has no
-   border on its own outer wrapper, but this reuses RecipeList.module.css's
-   `.emptyBox` bordered/rounded-box shape (same "adapt the established
-   pattern, don't invent a new one" precedent as `.stateWrapper` above),
-   sized/centered per the design's own max-width:520px column. */
+   border on its own outer wrapper, but this composes the shared
+   stateBox.module.css `.box` shape (same "adapt the established pattern,
+   don't invent a new one" precedent as `.stateWrapper` above), sized/
+   centered per the design's own max-width:520px column. */
 .notFoundBox {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
+  composes: box from '../../../styles/stateBox.module.css';
   max-width: 520px;
   margin-inline: auto;
   padding: clamp(56px, 9vw, 92px) 24px;
   border: 1px dashed var(--color-border);
-  border-radius: var(--radius-xl);
 }
 
 /* 54px: design literal (Admin Recipe Preview.dc.html line 123) — 2px past
-   RecipeList.module.css's `.emptyIcon`/`.errorIcon` 52px, same convention
-   otherwise (surface fill, hairline border, muted icon color). */
+   the shared shape's default 52px icon, otherwise the same convention
+   (surface fill, hairline border, muted icon color). */
 .notFoundIcon {
+  composes: icon from '../../../styles/stateBox.module.css';
   width: 54px;
   height: 54px;
-  border-radius: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   margin-bottom: 22px;
   background: var(--color-surface);
   border: var(--border-width) solid var(--color-border);
   color: var(--color-text-muted);
 }
 
-/* .notFoundBox .notFoundHeading (not bare): raises specificity above
-   Typography's own `.heading1` — same tie-fix pattern as
-   RecipeList.module.css's `.emptyBox .emptyHeading`. */
-.notFoundBox .notFoundHeading {
+.notFoundHeading {
+  composes: heading from '../../../styles/stateBox.module.css';
   font-size: 24px;
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: -0.02em;
   margin: 0 0 10px;
 }
 
-/* .notFoundBox .notFoundBody (not bare): raises specificity above
-   Typography's own `.body`. */
-.notFoundBox .notFoundBody {
+.notFoundBody {
+  composes: body from '../../../styles/stateBox.module.css';
   font-size: 15px;
-  line-height: 1.6;
-  color: var(--color-text-muted);
   margin: 0 0 26px;
   max-width: 38ch;
 }

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -414,55 +414,23 @@
    RecipeList.module.css's `.loadingBox`/`.errorBox` exactly (this is the
    third page in the epic to need this treatment). ─────────────────── */
 
-.loadingBox,
-.errorBox {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  border-radius: var(--radius-xl);
-}
-
 .loadingBox {
-  border: var(--border-width) solid var(--color-border);
-  padding: clamp(56px, 9vw, 92px) 24px;
-  gap: 18px;
+  composes: box loading from '../../../styles/stateBox.module.css';
 }
 
-/* --error-border: derived once here and inherited down to .errorIcon (a
-   direct child, per the markup in UserManagement.tsx) instead of repeating
-   the same color-mix() expression on both rules. */
 .errorBox {
-  --error-border: color-mix(in srgb, var(--color-error) 30%, var(--color-border));
-  border: var(--border-width) solid var(--error-border);
-  background: var(--color-error-bg);
-  padding: clamp(48px, 8vw, 80px) 24px;
+  composes: box error from '../../../styles/stateBox.module.css';
 }
 
 .errorIcon {
-  width: 52px;
-  height: 52px;
-  border-radius: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 20px;
-  background: var(--color-field);
-  border: var(--border-width) solid var(--error-border);
-  color: var(--color-error);
+  composes: icon iconError from '../../../styles/stateBox.module.css';
 }
 
-.errorBox .errorHeading {
-  font-size: 20px;
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: -0.02em;
-  margin: 0 0 8px;
+.errorHeading {
+  composes: heading from '../../../styles/stateBox.module.css';
 }
 
-.errorBox .errorBody {
-  font-size: 14.5px;
-  line-height: 1.6;
-  color: var(--color-text-muted);
-  margin: 0 0 24px;
+.errorBody {
+  composes: body from '../../../styles/stateBox.module.css';
   max-width: 38ch;
 }

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -410,9 +410,10 @@
   }
 }
 
-/* ── Loading / error states — shared box shape, matches
-   RecipeList.module.css's `.loadingBox`/`.errorBox` exactly (this is the
-   third page in the epic to need this treatment). ─────────────────── */
+/* ── Loading / error states — composes the shared box shape from
+   stateBox.module.css, matching RecipeList.module.css's `.loadingBox`/
+   `.errorBox` exactly (this is the third page in the epic to need this
+   treatment). ──────────────────────────────────────────────────────── */
 
 .loadingBox {
   composes: box loading from '../../../styles/stateBox.module.css';

--- a/src/styles/stateBox.module.css
+++ b/src/styles/stateBox.module.css
@@ -5,7 +5,7 @@
    future tweak. See issue #269.
 
    Split across two layers, both registered in order in `src/index.css`
-   (`@layer component-defaults, state-box-heading;`):
+   (`@layer component-defaults, composed-overrides;`):
 
    - `.box`/`.loading`/`.error`/`.icon`/`.iconError` live in
      `@layer component-defaults` (same mechanism as Typography.module.css /
@@ -18,7 +18,7 @@
      regardless of which named layer they're up against.
 
    - `.heading`/`.body` live in the separate, higher-priority
-     `@layer state-box-heading` instead. Unlike the classes above, these
+     `@layer composed-overrides` instead. Unlike the classes above, these
      two are also applied (via Typography's own `variant` prop) to
      elements already carrying `Typography.module.css`'s `.heading2`/
      `.body` classes — which are themselves in `@layer component-defaults`.
@@ -26,8 +26,11 @@
      layer, so two same-named-layer rules on the same element fall back to
      plain stylesheet/bundle order with no priority guarantee — exactly
      the ambiguity a named, ordered layer is meant to resolve. Giving
-     `.heading`/`.body` their own explicitly-higher-priority layer makes
-     them deterministically beat the Typography variant regardless of
+     `.heading`/`.body` a shared, explicitly-higher-priority layer (named
+     generically — any other shared/composed pattern needing the same
+     guarantee over a `component-defaults` variant class can reuse it
+     rather than inventing its own one-off layer) makes them
+     deterministically beat the Typography variant regardless of
      import/bundle order, while still losing (correctly) to any fully
      unlayered consumer override. */
 @layer component-defaults {
@@ -80,7 +83,7 @@
   }
 }
 
-@layer state-box-heading {
+@layer composed-overrides {
   .heading {
     font-size: 20px;
     font-weight: var(--font-weight-semibold);

--- a/src/styles/stateBox.module.css
+++ b/src/styles/stateBox.module.css
@@ -4,12 +4,32 @@
    near-identical but independently re-typed, silently drifting on any
    future tweak. See issue #269.
 
-   These classes live in `@layer component-defaults` (same mechanism as
-   Typography.module.css / Link.module.css, issue #263) so a consumer's
-   `composes:`-plus-local-declaration override deterministically wins for
-   whichever properties it redeclares (icon size, heading/body font-size,
-   box border/padding all vary slightly per consumer), without needing a
-   descendant-selector specificity boost. */
+   Split across two layers, both registered in order in `src/index.css`
+   (`@layer component-defaults, state-box-heading;`):
+
+   - `.box`/`.loading`/`.error`/`.icon`/`.iconError` live in
+     `@layer component-defaults` (same mechanism as Typography.module.css /
+     Link.module.css, issue #263) so a consumer's `composes:`-plus-local-
+     declaration override deterministically wins for whichever properties
+     it redeclares (icon size, box border/padding vary slightly per
+     consumer), without needing a descendant-selector specificity boost.
+     These classes only ever collide with their own consumers' local
+     overrides, which are always fully unlayered and so already win
+     regardless of which named layer they're up against.
+
+   - `.heading`/`.body` live in the separate, higher-priority
+     `@layer state-box-heading` instead. Unlike the classes above, these
+     two are also applied (via Typography's own `variant` prop) to
+     elements already carrying `Typography.module.css`'s `.heading2`/
+     `.body` classes — which are themselves in `@layer component-defaults`.
+     CSS merges same-named layers declared across files into one combined
+     layer, so two same-named-layer rules on the same element fall back to
+     plain stylesheet/bundle order with no priority guarantee — exactly
+     the ambiguity a named, ordered layer is meant to resolve. Giving
+     `.heading`/`.body` their own explicitly-higher-priority layer makes
+     them deterministically beat the Typography variant regardless of
+     import/bundle order, while still losing (correctly) to any fully
+     unlayered consumer override. */
 @layer component-defaults {
   .box {
     display: flex;
@@ -58,7 +78,9 @@
     border: var(--border-width) solid var(--state-box-error-border);
     color: var(--color-error);
   }
+}
 
+@layer state-box-heading {
   .heading {
     font-size: 20px;
     font-weight: var(--font-weight-semibold);

--- a/src/styles/stateBox.module.css
+++ b/src/styles/stateBox.module.css
@@ -1,0 +1,76 @@
+/* Shared "state box" shape (icon-in-rounded-square + heading + muted body,
+   optionally with a bordered/padded outer box) — previously hand-rolled
+   three times (RecipeList, UserManagement, RecipePreview), each copy
+   near-identical but independently re-typed, silently drifting on any
+   future tweak. See issue #269.
+
+   These classes live in `@layer component-defaults` (same mechanism as
+   Typography.module.css / Link.module.css, issue #263) so a consumer's
+   `composes:`-plus-local-declaration override deterministically wins for
+   whichever properties it redeclares (icon size, heading/body font-size,
+   box border/padding all vary slightly per consumer), without needing a
+   descendant-selector specificity boost. */
+@layer component-defaults {
+  .box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    border-radius: var(--radius-xl);
+  }
+
+  /* RecipeList's and UserManagement's loading state — byte-identical
+     border/padding/gap in both source files before this extraction. */
+  .loading {
+    border: var(--border-width) solid var(--color-border);
+    padding: clamp(56px, 9vw, 92px) 24px;
+    gap: 18px;
+  }
+
+  /* RecipeList's and UserManagement's error state — byte-identical
+     border/background/padding in both source files before this
+     extraction. `--state-box-error-border` is derived once here and
+     inherited down to `.iconError` (a direct-child consumer, per each
+     page's own markup) instead of repeating the same color-mix()
+     expression twice per page — generalizes a pattern UserManagement's
+     own pre-extraction CSS had already independently discovered. */
+  .error {
+    --state-box-error-border: color-mix(in srgb, var(--color-error) 30%, var(--color-border));
+    border: var(--border-width) solid var(--state-box-error-border);
+    background: var(--color-error-bg);
+    padding: clamp(48px, 8vw, 80px) 24px;
+  }
+
+  .icon {
+    width: 52px;
+    height: 52px;
+    /* 14px: design literal — between --radius-lg (12px) and --radius-xl
+       (16px), neither an exact match. */
+    border-radius: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 20px;
+  }
+
+  .iconError {
+    background: var(--color-field);
+    border: var(--border-width) solid var(--state-box-error-border);
+    color: var(--color-error);
+  }
+
+  .heading {
+    font-size: 20px;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: -0.02em;
+    margin: 0 0 8px;
+  }
+
+  .body {
+    font-size: 14.5px;
+    line-height: 1.6;
+    color: var(--color-text-muted);
+    margin: 0 0 24px;
+    max-width: 36ch;
+  }
+}


### PR DESCRIPTION
Closes #269

## What changed
- New `src/styles/stateBox.module.css` centralizes the icon-in-rounded-square + heading + muted-body "state box" shape, previously hand-rolled independently in `RecipeList.module.css`, `UserManagement.module.css`, and `RecipePreview.module.css`.
- All three consumers now `composes:` the shared classes (`.box`, `.loading`, `.error`, `.icon`, `.iconError`, `.heading`, `.body`) instead of redefining them. `RecipeList`'s and `UserManagement`'s loading/error states were byte-identical and now fully compose the shared shape; `RecipePreview`'s not-found variant overrides icon size and heading/body font-size locally (same `composes:`-plus-local-override pattern established in #263/#265).
- Declares an explicit two-tier CSS cascade layer order in `src/index.css` (`@layer component-defaults, composed-overrides;`) so `stateBox`'s heading/body classes deterministically beat `Typography.module.css`'s own variant classes applied to the same element, while still losing correctly to any fully unlayered per-page override.

## Why
Three independent copies of the same visual pattern meant any future tweak (padding, radius, icon size) had to be applied in three places and would silently drift if one was missed — exactly the kind of shape this codebase already centralizes elsewhere (`text.module.css`, `interactions.module.css`).

## How to verify
Since jsdom doesn't render real CSS cascade/layer order, this was verified three ways:
1. Direct `getComputedStyle` measurement in a live browser against the real compiled CSS, for every property (border, background, padding, icon size, heading/body typography) across all consumer variants — every value matched the original pre-extraction specification exactly.
2. A controlled, order-independence test confirming the fix resolves correctly regardless of which stylesheet loads first.
3. Inspection of the actual production build output (`pnpm build:client`) confirming the layer order is established once in the eagerly-loaded entry chunk, before any lazy admin route chunk contributes rules to it.
- `pnpm test`, `pnpm lint`, `pnpm --package=typescript dlx tsc --noEmit -p .` all pass with no new errors.

## Decisions made
- **A mid-review correction**: the first pass wrapped `stateBox`'s `.heading`/`.body` in the *same* `@layer component-defaults` used by `Typography.module.css`. An independent review pass caught that same-named layers merge across files, so on an element carrying both a Typography variant and a composed `stateBox` class, the winner fell back to non-deterministic bundle/chunk load order — not the guarantee the code claimed. Verified this empirically (reproduced the flip by reordering stylesheet load order) before fixing it with a genuine two-tier layer order, then re-verified the fix three ways (above) rather than trusting the first pass.
- `/simplify` suggested reverting to the older descendant-selector specificity trick instead of the two-layer approach for a smaller diff. Declined: roughly half of the composed heading/body sites need local overrides (not just `RecipePreview`'s), so reverting would mean half the sites need the old per-site specificity bookkeeping and half don't — reintroducing exactly the inconsistency this epic's `@layer` mechanism (#263) was adopted to eliminate.

## Out of scope (filed as follow-up issues)
- **#295** — `RecipeEditor.module.css`'s `.loadingBox` is a 4th, previously-undiscovered instance of this same duplication (missed by this issue's own scope, which only names three). Deferred because it has a distinct padding value requiring its own local override, and touches a file outside this issue's named scope.
- **#296** — `stateBox.module.css`'s compiled CSS currently ships duplicated across all three lazy admin route chunks (confirmed via production build inspection) rather than being deduplicated at the bundle level, since none of its three consumers share an eager common ancestor that already imports it. Deferred because the fix is a bundler-chunking concern outside CSS-authoring scope, and outside this issue's own AC (no visual/behavioral change required, not a bundle-size reduction).