### PR TITLE
Give Link a button-style variant and StatusBadge an accent/pill tone

### DIFF
--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -25,8 +25,43 @@
     color: var(--color-primary);
   }
 
+  /* Button/pill shapes several admin pages independently hand-rolled on top
+     of plain Link — border/bg, radius, hover color-swap, transition, all
+     re-derived per file (issue #270). Centralized here so consumers only
+     need to override their own size/spacing deltas via `composes:`. */
+  .ghost {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+    border: var(--border-width) solid var(--color-border-strong);
+    border-radius: var(--radius-md);
+    padding: var(--space-2) var(--space-4);
+    transition: border-color var(--duration-fast) var(--easing-default),
+      color var(--duration-fast) var(--easing-default);
+  }
+
+  .ghost:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+  }
+
+  .solid {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-btn-fg);
+    background: var(--color-btn-bg);
+    border-radius: var(--radius-md);
+    padding: var(--space-2) var(--space-4);
+    transition: opacity var(--duration-fast) var(--easing-default);
+  }
+
+  .solid:hover {
+    color: var(--color-btn-fg);
+    opacity: 0.9;
+  }
+
   @media (prefers-reduced-motion: reduce) {
-    .link {
+    .link,
+    .ghost,
+    .solid {
       transition: none;
     }
   }

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -29,12 +29,16 @@
      of plain Link — border/bg, radius, hover color-swap, transition, all
      re-derived per file (issue #270). Centralized here so consumers only
      need to override their own size/spacing deltas via `composes:`. */
-  .ghost {
+  .ghost,
+  .solid {
     font-weight: var(--font-weight-semibold);
-    color: var(--color-text);
-    border: var(--border-width) solid var(--color-border-strong);
     border-radius: var(--radius-md);
     padding: var(--space-2) var(--space-4);
+  }
+
+  .ghost {
+    color: var(--color-text);
+    border: var(--border-width) solid var(--color-border-strong);
     transition: border-color var(--duration-fast) var(--easing-default),
       color var(--duration-fast) var(--easing-default);
   }
@@ -45,16 +49,12 @@
   }
 
   .solid {
-    font-weight: var(--font-weight-semibold);
     color: var(--color-btn-fg);
     background: var(--color-btn-bg);
-    border-radius: var(--radius-md);
-    padding: var(--space-2) var(--space-4);
     transition: opacity var(--duration-fast) var(--easing-default);
   }
 
   .solid:hover {
-    color: var(--color-btn-fg);
     opacity: 0.9;
   }
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -14,6 +14,8 @@ export interface LinkProps {
   iconSide?: 'left' | 'right'
   /** Direction the icon nudges on hover. @default 'right' */
   nudge?: 'left' | 'right' | 'up-right' | 'none'
+  /** Button/pill shape. Omit for a plain link (default, unchanged). */
+  variant?: 'ghost' | 'solid'
   ariaLabel?: string
   className?: string
 }
@@ -33,6 +35,7 @@ const Link: FC<LinkProps> = ({
   icon,
   iconSide = 'right',
   nudge = 'right',
+  variant,
   ariaLabel,
   className: externalClassName,
 }) => {
@@ -48,6 +51,7 @@ const Link: FC<LinkProps> = ({
     // so hovering anywhere on the link (not just the tiny icon glyph) has to
     // trigger the icon's transform.
     NUDGE_CLASSES[nudge],
+    variant && styles[variant],
     externalClassName,
   ]
     .filter(Boolean)

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -44,7 +44,11 @@ const Link: FC<LinkProps> = ({
 
   const className = [
     styles.link,
-    styles[tone],
+    // Tone and variant are mutually exclusive color sources: tone is a
+    // plain-link text color, variant is a button shape with its own
+    // definitive colors. When variant is set it fully owns color, so the
+    // tone class is skipped to avoid it clobbering the variant's color.
+    variant ? undefined : styles[tone],
     underline ? styles.underline : '',
     // Nudge class goes on the link itself, not the icon — the CSS is a
     // `.nudgeX:hover .linkIcon` ancestor/descendant rule (see Link.module.css),

--- a/src/components/StatusBadge/StatusBadge.module.css
+++ b/src/components/StatusBadge/StatusBadge.module.css
@@ -56,3 +56,18 @@
   color: var(--color-text-muted);
   background: var(--color-surface);
 }
+
+.accent {
+  background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+  color: var(--color-primary);
+}
+
+/* Full-pill shape (role badges etc.) — extracted verbatim from
+   UserManagement.module.css's former `.rolePill` override (issue #270). */
+.pill {
+  border: none;
+  border-radius: var(--radius-full);
+  text-transform: uppercase;
+  font-size: 10.5px;
+  padding: 4px 10px;
+}

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -4,9 +4,11 @@ import styles from './StatusBadge.module.css'
 
 export interface StatusBadgeProps {
   /** @default 'neutral' */
-  tone?: 'success' | 'warning' | 'error' | 'neutral'
+  tone?: 'success' | 'warning' | 'error' | 'neutral' | 'accent'
   /** Show the leading dot. @default true */
   dot?: boolean
+  /** @default 'chip' */
+  shape?: 'chip' | 'pill'
   children?: ReactNode
   className?: string
   style?: CSSProperties
@@ -15,11 +17,14 @@ export interface StatusBadgeProps {
 const StatusBadge: FC<StatusBadgeProps> = ({
   tone = 'neutral',
   dot = true,
+  shape = 'chip',
   children,
   className: extraClassName,
   style,
 }) => {
-  const className = [styles.badge, styles[tone], extraClassName].filter(Boolean).join(' ')
+  const className = [styles.badge, styles[tone], shape === 'pill' && styles.pill, extraClassName]
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <span className={className} style={style}>

--- a/src/components/TagInput/TagInput.module.css
+++ b/src/components/TagInput/TagInput.module.css
@@ -117,8 +117,8 @@
    hover read as the same visual weight, plus a tinted background so the
    *persistent* keyboard-selected state stays visible even without the
    pointer sitting on it. The 10% color-mix background matches this
-   project's established "accent" fill (see UserManagement.module.css's
-   `.rolePillAdmin`, same color-mix(...transparent) shape as the --ring
+   project's established "accent" fill (see StatusBadge.module.css's
+   `.accent` tone, same color-mix(...transparent) shape as the --ring
    token — the design's --accent-bg is rgba(31,102,224,0.10)). */
 .option[aria-selected='true'] {
   border-color: var(--color-primary);

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -71,32 +71,23 @@
 /* Bare `.bannerAction` override: Link's own `.link` (color:
    var(--color-link)) now lives in `@layer component-defaults`
    (Link.module.css, #263), so this plain unlayered class deterministically
-   wins without needing the old descendant-selector trick. Styled to look
-   like the design's small ghost button, same "style Link locally"
-   precedent as RecipeList's `.newButton`. */
+   wins without needing the old descendant-selector trick. Border/color/
+   transition/hover now come from Link's own `.ghost` (issue #270, via
+   `composes:` + the `variant="ghost"` prop) — sizing, the extra hover
+   background wash (`.ghost` itself has none), and font-weight (this
+   banner link keeps its original `medium` weight, overriding `.ghost`'s
+   `semibold` default) stay local. */
 .bannerAction {
+  composes: ghost from '../../../components/Link/Link.module.css';
   flex-shrink: 0;
   width: auto;
   font-size: 13px;
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text);
-  border: var(--border-width) solid var(--color-border-strong);
-  border-radius: var(--radius-md);
   padding: 7px 14px;
-  transition: border-color var(--duration-fast) var(--easing-default),
-    color var(--duration-fast) var(--easing-default);
+  font-weight: var(--font-weight-medium);
 }
 
 .bannerAction:hover {
-  border-color: var(--color-primary);
-  color: var(--color-primary);
   background: var(--color-hover);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .bannerAction {
-    transition: none;
-  }
 }
 
 /* ── Back link ───────────────────────────────────────────────────── */

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -72,13 +72,12 @@
    var(--color-link)) now lives in `@layer component-defaults`
    (Link.module.css, #263), so this plain unlayered class deterministically
    wins without needing the old descendant-selector trick. Border/color/
-   transition/hover now come from Link's own `.ghost` (issue #270, via
-   `composes:` + the `variant="ghost"` prop) — sizing, the extra hover
-   background wash (`.ghost` itself has none), and font-weight (this
+   transition/hover already come from Link's own `.ghost` via the
+   `variant="ghost"` prop alone — no `composes:` needed, sizing, the extra
+   hover background wash (`.ghost` itself has none), and font-weight (this
    banner link keeps its original `medium` weight, overriding `.ghost`'s
    `semibold` default) stay local. */
 .bannerAction {
-  composes: ghost from '../../../components/Link/Link.module.css';
   flex-shrink: 0;
   width: auto;
   font-size: 13px;

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -566,7 +566,7 @@ const RecipeEditor: FC = () => {
             </span>
             <span>Your session has expired. Log in again to keep editing — your latest changes are saved.</span>
           </span>
-          <Link to={loginHref} className={styles.bannerAction}>
+          <Link to={loginHref} variant="ghost" className={styles.bannerAction}>
             Log in again
           </Link>
         </div>

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -42,16 +42,15 @@
    Applied to the shared Link component (client-side routing to
    /admin/recipes/new) rather than Button, which has no polymorphic `as`/
    href support — see RecipeDetailView.module.css's `.backLink` for the
-   same "style Link locally" precedent. Solid coloring/hover now come from
-   Link's own `.solid` (issue #270, via `composes:` + the `variant="solid"`
-   prop) — only sizing and the `:active` press effect (genuinely
-   RecipeList-specific, `.solid` has none) stay local. The opacity leg of
-   the transition is re-declared here alongside transform: `.solid`'s own
-   transition lives in Link.module.css's `@layer`, and an unlayered
-   `transition` on this class would otherwise replace it wholesale rather
-   than merge, silently dropping the hover fade. */
+   same "style Link locally" precedent. Solid coloring/hover already come
+   from Link's own `.solid` via the `variant="solid"` prop alone — no
+   `composes:` needed, only sizing and the `:active` press effect
+   (genuinely RecipeList-specific, `.solid` has none) stay local. The
+   opacity leg of the transition is re-declared here alongside transform:
+   `.solid`'s own transition lives in Link.module.css's `@layer`, and an
+   unlayered `transition` on this class would otherwise replace it
+   wholesale rather than merge, silently dropping the hover fade. */
 .newButton {
-  composes: solid from '../../../components/Link/Link.module.css';
   font-size: 14px;
   padding: 11px 18px;
   gap: var(--space-2);
@@ -59,8 +58,7 @@
     transform var(--duration-fast) var(--easing-default);
 }
 
-.header .newButton:active,
-.emptyBox .newButton:active {
+.newButton:active {
   transform: translateY(1px);
 }
 

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -42,27 +42,21 @@
    Applied to the shared Link component (client-side routing to
    /admin/recipes/new) rather than Button, which has no polymorphic `as`/
    href support — see RecipeDetailView.module.css's `.backLink` for the
-   same "style Link locally" precedent. Grouped selector: reused in both
-   the page header and the empty state. A bare `.newButton` class would tie
-   in specificity with Link's own `.link` (color, gap, radius) — same
-   failure mode documented throughout this file, fixed the same way. */
-.header .newButton,
-.emptyBox .newButton {
+   same "style Link locally" precedent. Solid coloring/hover now come from
+   Link's own `.solid` (issue #270, via `composes:` + the `variant="solid"`
+   prop) — only sizing and the `:active` press effect (genuinely
+   RecipeList-specific, `.solid` has none) stay local. The opacity leg of
+   the transition is re-declared here alongside transform: `.solid`'s own
+   transition lives in Link.module.css's `@layer`, and an unlayered
+   `transition` on this class would otherwise replace it wholesale rather
+   than merge, silently dropping the hover fade. */
+.newButton {
+  composes: solid from '../../../components/Link/Link.module.css';
   font-size: 14px;
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-btn-fg);
-  background: var(--color-btn-bg);
-  border-radius: var(--radius-md);
   padding: 11px 18px;
   gap: var(--space-2);
   transition: opacity var(--duration-fast) var(--easing-default),
     transform var(--duration-fast) var(--easing-default);
-}
-
-.header .newButton:hover,
-.emptyBox .newButton:hover {
-  color: var(--color-btn-fg);
-  opacity: 0.9;
 }
 
 .header .newButton:active,
@@ -71,8 +65,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .header .newButton,
-  .emptyBox .newButton {
+  .newButton {
     transition: none;
   }
 }

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -196,7 +196,7 @@ const RecipeList = () => {
           <Typography variant="body" className={styles.emptyBody}>
             Your kitchen is empty. Create your first recipe to start building the collection.
           </Typography>
-          <Link to="/admin/recipes/new" className={styles.newButton}>
+          <Link to="/admin/recipes/new" variant="solid" className={styles.newButton}>
             {iconPlus}
             Create your first recipe
           </Link>
@@ -284,7 +284,7 @@ const RecipeList = () => {
             {pluralize(sortedRecipes.length, 'recipe')}
           </Typography>
         </div>
-        <Link to="/admin/recipes/new" className={styles.newButton}>
+        <Link to="/admin/recipes/new" variant="solid" className={styles.newButton}>
           {iconPlus}
           New recipe
         </Link>

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -126,13 +126,29 @@
 /* ── Pill buttons ──────────────────────────────────────────────────
    .editLink / .viewLink / .publishButton (below) and .notFoundBackLink
    (further down) are four small action buttons sharing the same pill
-   shape (9px radius, 7px icon/label gap). Each is still selected via its
-   own compound selector (`.bannerActions .editLink`, not bare `.editLink`)
-   to raise specificity above the shared Link/Button components' own base
-   classes — same specificity-tie fix documented throughout this epic (see
-   `.bannerLeft .backLink` above). Only the shared shape is grouped here;
-   coloring (ghost vs solid), sizing and transition stay per-consumer
-   where they genuinely differ. */
+   shape (9px radius, 7px icon/label gap) — grouped via its own compound
+   selector (`.bannerActions .editLink`, not bare `.editLink`) to raise
+   specificity above the shared Link/Button components' own base classes —
+   same specificity-tie fix documented throughout this epic (see
+   `.bannerLeft .backLink` above). Ghost/solid coloring, transition and
+   hover are now centralized in Link.module.css's `.ghost`/`.solid`
+   (issue #270, pulled in via `composes:` below and applied via the
+   `variant` prop in RecipePreview.tsx, since Link's own layered defaults
+   always lose to these unlayered overrides regardless of specificity) —
+   only the shape/sizing deltas that genuinely differ per consumer stay
+   local here. */
+.editLink {
+  composes: ghost from '../../../components/Link/Link.module.css';
+  font-size: 13px;
+  padding: 8px 15px;
+}
+
+.viewLink {
+  composes: solid from '../../../components/Link/Link.module.css';
+  font-size: 13px;
+  padding: 8px 15px;
+}
+
 .bannerActions .editLink,
 .bannerActions .viewLink,
 .bannerActions .publishButton,
@@ -141,31 +157,6 @@
      1px off. */
   border-radius: 9px;
   gap: 7px;
-}
-
-/* Ghost pill look (bordered, transparent, primary-tinted on hover) shared
-   by .editLink and .notFoundBackLink — styled to look like the design's
-   small ghost button (`.banner-btn.banner-ghost`), same "style Link
-   locally" precedent as RecipeEditor.module.css's `.sessionBanner
-   .bannerAction`. */
-.bannerActions .editLink,
-.notFoundBox .notFoundBackLink {
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text);
-  border: var(--border-width) solid var(--color-border-strong);
-  transition: border-color var(--duration-fast) var(--easing-default),
-    color var(--duration-fast) var(--easing-default);
-}
-
-.bannerActions .editLink:hover,
-.notFoundBox .notFoundBackLink:hover {
-  border-color: var(--color-primary);
-  color: var(--color-primary);
-}
-
-.bannerActions .editLink {
-  font-size: 13px;
-  padding: 8px 15px;
 }
 
 /* Sizing-only override — the shared Button component's own `.button`/
@@ -177,31 +168,6 @@
 .bannerActions .publishButton {
   padding: 8px 15px;
   font-size: 13px;
-}
-
-/* Solid pill look — styled to look like the design's solid button
-   (`.banner-btn.banner-solid`), same "style Link locally" precedent as
-   RecipeList.module.css's `.header .newButton`. */
-.bannerActions .viewLink {
-  font-size: 13px;
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-btn-fg);
-  background: var(--color-btn-bg);
-  padding: 8px 15px;
-  transition: opacity var(--duration-fast) var(--easing-default);
-}
-
-.bannerActions .viewLink:hover {
-  color: var(--color-btn-fg);
-  opacity: 0.9;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .bannerActions .editLink,
-  .bannerActions .viewLink,
-  .notFoundBox .notFoundBackLink {
-    transition: none;
-  }
 }
 
 /* ── Main landmark ─────────────────────────────────────────────────────
@@ -284,10 +250,11 @@
   max-width: 38ch;
 }
 
-/* Shape, ghost coloring, transition and hover are shared with
-   `.bannerActions .editLink` in the "Pill buttons" group above — only the
-   size differs here. */
-.notFoundBox .notFoundBackLink {
+/* Ghost coloring/transition/hover come from Link's own `.ghost` (composed
+   below), same as `.editLink` in the "Pill buttons" group above — only the
+   shape/size differ here. */
+.notFoundBackLink {
+  composes: ghost from '../../../components/Link/Link.module.css';
   font-size: 14px;
   padding: 10px 18px;
 }

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -135,11 +135,7 @@
    prop alone (RecipePreview.tsx) — no `composes:` needed here, this local
    class only supplies this consumer's own size/shape deltas as a plain
    unlayered override. */
-.editLink {
-  font-size: 13px;
-  padding: 8px 15px;
-}
-
+.editLink,
 .viewLink {
   font-size: 13px;
   padding: 8px 15px;

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -131,20 +131,16 @@
    specificity above the shared Link/Button components' own base classes —
    same specificity-tie fix documented throughout this epic (see
    `.bannerLeft .backLink` above). Ghost/solid coloring, transition and
-   hover are now centralized in Link.module.css's `.ghost`/`.solid`
-   (issue #270, pulled in via `composes:` below and applied via the
-   `variant` prop in RecipePreview.tsx, since Link's own layered defaults
-   always lose to these unlayered overrides regardless of specificity) —
-   only the shape/sizing deltas that genuinely differ per consumer stay
-   local here. */
+   hover already come from Link's own `.ghost`/`.solid` via the `variant`
+   prop alone (RecipePreview.tsx) — no `composes:` needed here, this local
+   class only supplies this consumer's own size/shape deltas as a plain
+   unlayered override. */
 .editLink {
-  composes: ghost from '../../../components/Link/Link.module.css';
   font-size: 13px;
   padding: 8px 15px;
 }
 
 .viewLink {
-  composes: solid from '../../../components/Link/Link.module.css';
   font-size: 13px;
   padding: 8px 15px;
 }
@@ -250,11 +246,10 @@
   max-width: 38ch;
 }
 
-/* Ghost coloring/transition/hover come from Link's own `.ghost` (composed
-   below), same as `.editLink` in the "Pill buttons" group above — only the
-   shape/size differ here. */
+/* Ghost coloring/transition/hover come from Link's own `.ghost` via the
+   `variant="ghost"` prop alone, same as `.editLink` in the "Pill buttons"
+   group above — no `composes:` needed, only the shape/size differ here. */
 .notFoundBackLink {
-  composes: ghost from '../../../components/Link/Link.module.css';
   font-size: 14px;
   padding: 10px 18px;
 }

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -210,6 +210,7 @@ const RecipePreview: FC = () => {
             icon="←"
             iconSide="left"
             nudge="left"
+            variant="ghost"
             className={styles.notFoundBackLink}
           >
             Back to recipes
@@ -257,6 +258,7 @@ const RecipePreview: FC = () => {
               icon={iconEdit}
               iconSide="left"
               nudge="none"
+              variant="ghost"
               className={styles.editLink}
             >
               Edit
@@ -277,6 +279,7 @@ const RecipePreview: FC = () => {
                 icon={iconViewPublic}
                 iconSide="right"
                 nudge="up-right"
+                variant="solid"
                 className={styles.viewLink}
               >
                 View public page

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -308,33 +308,6 @@
   flex-wrap: wrap;
 }
 
-/* Role pill — built on StatusBadge (dot={false}, tone="neutral" for its
-   font-mono/padding/base-color shape) with a specificity-tie override for
-   the two properties the design's pill needs that no StatusBadge tone
-   provides: no border, and a full pill radius instead of --radius-sm.
-   `.rowMeta .rolePill` (not bare `.rolePill`): raises specificity above
-   StatusBadge's own `.badge`/`.neutral` regardless of CSS import order —
-   same specificity-tie fix documented throughout this epic (see
-   `.header .heading`). Status, by contrast, has no chip/background at all
-   in the design (just a dot + plain text) — that shape doesn't fit
-   StatusBadge, so it stays hand-rolled below. */
-.rowMeta .rolePill {
-  border: none;
-  border-radius: var(--radius-full);
-  text-transform: uppercase;
-  font-size: 10.5px;
-  padding: 4px 10px;
-}
-
-.rowMeta .rolePillAdmin {
-  /* 10%: matches the design's --accent-bg (rgba(31,102,224,0.10)) exactly —
-     same color-mix(...transparent) shape as the --ring token. StatusBadge
-     has no "accent" tone, so this is applied as a second override class
-     rather than a tone value. */
-  background: color-mix(in srgb, var(--color-primary) 10%, transparent);
-  color: var(--color-primary);
-}
-
 .statusCell {
   display: inline-flex;
   align-items: center;

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -300,13 +300,8 @@ const UserManagement = () => {
                 <div className={styles.rowMeta}>
                   <StatusBadge
                     dot={false}
-                    tone="neutral"
-                    className={[
-                      styles.rolePill,
-                      userRow.role === 'admin' && styles.rolePillAdmin,
-                    ]
-                      .filter(Boolean)
-                      .join(' ')}
+                    tone={userRow.role === 'admin' ? 'accent' : 'neutral'}
+                    shape="pill"
                   >
                     {ROLE_LABEL[userRow.role]}
                   </StatusBadge>


### PR DESCRIPTION
Closes #270

## What changed
- `Link` gains `variant?: 'ghost' | 'solid'`, covering the button/pill look `RecipePreview`, `RecipeList`, and `RecipeEditor` each hand-built from scratch on top of plain `Link` (border, radius, hover color-swap, transition, reduced-motion guard). The two new classes live in `Link.module.css`'s existing `@layer component-defaults` (issue #263), so each consumer's own size/spacing/font-weight deltas stay deterministic local overrides.
- `StatusBadge` gains `tone: 'accent'` and `shape?: 'chip' | 'pill'`, covering the role-pill look `UserManagement` previously faked via a second override class layered on top of `tone="neutral"`.
- All four consumer files (`RecipePreview`, `RecipeList`, `RecipeEditor`, `UserManagement`) migrated to the new variants — `UserManagement.module.css`'s `.rolePill`/`.rolePillAdmin` are removed entirely (no local override needed at all).

## Why
Both are the same underlying problem: the shared component's variant API didn't cover a shape multiple pages actually needed, so each page bolted on a local CSS override instead of extending the component — duplicated CSS, drift risk on any future tweak.

## How to verify
Since jsdom doesn't render real CSS cascade/layer order, this was verified via direct `getComputedStyle` measurement against the real compiled CSS in a live browser, for all 7 migrated elements (`editLink`, `viewLink`, `notFoundBackLink`, `newButton`, `bannerAction`, and `StatusBadge`'s role-pill in both admin/contributor states) — with correct DOM ancestor context where a shared shape rule is descendant-selector-scoped. Every value matches the original pre-extraction spec.
- `pnpm test`, `pnpm lint`, `pnpm --package=typescript dlx tsc --noEmit -p .` all pass with no new errors.

## Decisions made
- **A real bug caught mid-review and fixed**: `Link.tsx` always applied a tone class (default `'inherit'`, unlayered) alongside `variant` (layered). Since unlayered rules always beat layered ones regardless of order, the intended button-text color from `.ghost`/`.solid` never actually applied — `.solid` links rendered with near-invisible dark-on-dark text. My own first-pass verification missed this because it tested the variant class in isolation without including the tone class `Link.tsx` always adds. An independent review pass caught it; I reproduced it directly (measured `rgb(58,54,49)` text on `rgb(28,26,22)` background), then fixed it by skipping the tone class entirely when `variant` is set — semantically correct, since no consumer combines them and a button's color should come from its variant, not tone semantics — and re-verified the fix.
- The same review pass also caught that consumer CSS files were applying the variant class *twice* (once via the `variant` prop, once via a now-unnecessary `composes:` line with an incorrect justifying comment) — removed the redundant `composes:` everywhere; the `variant` prop alone is sufficient, and each consumer's local override class remains deterministic purely by being unlayered.
- Considered composing `Link`'s new `.ghost`/`.solid` from `Button.module.css`'s near-identical `.outline`/`.solid` variants instead of re-declaring the same values. Declined: `Button` renders a bare `<button>` with no polymorphic `as`/href support, and cross-composing from a peer component's CSS module felt like it'd create an odd coupling beyond this issue's stated scope ("extracts what already exists, it doesn't invent a new look").