### PR TITLE
Audit --color-text-faint-on-surface/-field pairings for AA contrast

### DIFF
--- a/src/components/ImageUpload/ImageUpload.module.css
+++ b/src/components/ImageUpload/ImageUpload.module.css
@@ -56,7 +56,8 @@
      neither lands). */
   font-size: 12.5px;
   line-height: var(--line-height-normal);
-  color: var(--color-text-faint);
+  /* .dropzone renders on --color-surface (issue #274). */
+  color: var(--color-text-faint-on-surface);
 }
 
 /* ── Processing state — step thumbnail width cap ──────────────────

--- a/src/components/Input/Input.module.css
+++ b/src/components/Input/Input.module.css
@@ -67,7 +67,8 @@
   inset-block-start: 50%;
   transform: translateY(-50%);
   display: flex;
-  color: var(--color-text-faint);
+  /* .field has a --color-field background (issue #274). */
+  color: var(--color-text-faint-on-field);
   pointer-events: none;
 }
 

--- a/src/components/TagInput/TagInput.module.css
+++ b/src/components/TagInput/TagInput.module.css
@@ -47,7 +47,8 @@
    don't want a red tint), so both the faint resting color and the
    hover-to-error tint are supplied here. */
 .chipRemove {
-  color: var(--color-text-faint);
+  /* Renders on Tag's --color-surface background (issue #274). */
+  color: var(--color-text-faint-on-surface);
 }
 
 .chipRemove:hover {

--- a/src/pages/admin/Login/Login.module.css
+++ b/src/pages/admin/Login/Login.module.css
@@ -97,7 +97,8 @@
 .column .footnote {
   font-size: 12.5px; /* no token lands between --font-size-xs (11px) and --font-size-sm (13px) */
   line-height: var(--line-height-normal);
-  color: var(--color-text-faint);
+  /* Renders inside <Card fill>, whose .fill sets --color-surface (issue #274). */
+  color: var(--color-text-faint-on-surface);
   margin: 18px 0 0; /* no --space-* token lands on 18px (--space-4=16px, --space-5=20px) */
   text-align: center;
 }

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -385,6 +385,10 @@
 .checklistLabel {
   composes: sectionLabel;
   margin-bottom: var(--space-2);
+  /* .railCard has a --color-surface background (issue #274) — sectionLabel's
+     own faint color is tuned for --color-bg, the bare <legend> usage's
+     actual context. */
+  color: var(--color-text-faint-on-surface);
 }
 
 .checklist {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -197,7 +197,8 @@
 
 .input::placeholder,
 .textarea::placeholder {
-  color: var(--color-text-faint);
+  /* .field (shared) has a --color-field background (issue #274). */
+  color: var(--color-text-faint-on-field);
 }
 
 .input[readonly] {

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -151,7 +151,8 @@
 
 .updatedLabel {
   font-size: 12.5px;
-  color: var(--color-text-faint);
+  /* .list has a --color-field background (issue #274). */
+  color: var(--color-text-faint-on-field);
   /* 4px: design literal, on top of `.rowMeta`'s own 7px gap (Admin
      Recipes.dc.html line 126 sets this margin in addition to the flex
      gap already separating every sibling). */

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -64,7 +64,8 @@
   composes: focusRing from '../../../styles/interactions.module.css';
   background: transparent;
   border: none;
-  color: var(--color-text-faint);
+  /* .inviteCard has a --color-surface background (issue #274). */
+  color: var(--color-text-faint-on-surface);
   cursor: pointer;
   font-size: 14px;
   line-height: 1;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -66,6 +66,16 @@
   /* WCAG AA override: the design's faint #9A938A is ~2.9:1 on paper
      (fails AA). Darkened to #767066 (~4.5:1) for eyebrow/caption/meta. */
   --color-text-faint:    #767066;   /* eyebrows, captions, placeholders */
+  /* WCAG AA override: --color-text-faint (#767066) is tuned against
+     --color-bg only (see its own comment above) — reused against
+     --color-surface it's ~4.35:1 (fails). Darkened for that specific
+     pairing (issue #274). */
+  --color-text-faint-on-surface: #706A60;   /* ~4.75:1 on --color-surface */
+  /* --color-text-faint already passes 4.5:1 against --color-field in light
+     mode (~4.91:1) — this token exists so consumers on --color-field can
+     reference one semantic name across both themes without knowing which
+     theme needs correction (dark mode does, see below). */
+  --color-text-faint-on-field: var(--color-text-faint);
 
   /* Borders */
   --color-border:        #ECE6DA;   /* hairlines, dividers, card edges */
@@ -190,6 +200,14 @@
      (fails AA — the PRD flagged this value for a manual check). Raised the
      lightness to #877F73 (~4.7:1) to pass. */
   --color-text-faint:    #877F73;
+  /* WCAG AA override: --color-text-faint (#877F73) reused against
+     --color-surface is ~4.40:1 (fails). Lightened for that pairing
+     (issue #274). */
+  --color-text-faint-on-surface: #8C8478;   /* ~4.71:1 on --color-surface */
+  /* --color-text-faint fails 4.5:1 against --color-field in dark mode too
+     (~4.44:1, previously unflagged — narrowly under threshold). Lightened
+     for that specific pairing. */
+  --color-text-faint-on-field: #898276;     /* ~4.61:1 on --color-field */
 
   --color-border:        #2A2823;
   --color-border-strong: #36342C;


### PR DESCRIPTION
Closes #274

## What changed
- Added two shared semantic tokens to `tokens.css`: `--color-text-faint-on-surface` and `--color-text-faint-on-field`, both themes.
- Fixed 8 AA contrast failures across 7 files by swapping `color: var(--color-text-faint)` for the correct context-specific token: `TagInput.chipRemove`, `ImageUpload.dropzoneHint`, `Login.footnote`, `UserManagement.closeButton` (on `--color-surface`); `Input.prefixIcon`, `RecipeList.updatedLabel`, `RecipeEditor` placeholder text, `RecipeEditor.checklistLabel` (on `--color-field`/`--color-surface`).

## Why
`--color-text-faint` is tuned for AA contrast against `--color-bg` only (per its own token comment). It's reused elsewhere against `--color-surface` and `--color-field`, neither of which had been audited — both compute under 4.5:1 in at least one theme, including a previously-unflagged dark-mode field failure (4.44:1, barely under threshold) and a dark-mode-and-light-mode surface failure that recurred in 4 separate components.

## How to verify
- Every consumer of `--color-text-faint` in the codebase was found via `grep -rn "color-text-faint" --include="*.css" src/` and its actual rendered background traced (not assumed) to compute precise WCAG relative-luminance contrast ratios.
- The new token values were independently confirmed in a live browser via `getComputedStyle`, matching the hand-calculated ratios exactly (all 4 pairings now ≥4.5:1).
- `pnpm test`, `pnpm lint`, `pnpm --package=typescript dlx tsc --noEmit -p .` all pass with no new errors.

## Decisions made
- Two failure patterns recurred broadly (4 sites on `--color-surface`, 3 on `--color-field`), meeting the issue's own "recurs broadly enough" trigger for a shared token instead of 7 separate component-local overrides (the narrower pattern used by the already-merged #267/#268).
- **A real gap caught by independent review**: my first pass missed `RecipeEditor.module.css`'s `.checklistLabel`, which composes `.sectionLabel` (plain `--color-text-faint`, correct for that class's primary bare-`<legend>` usage on `--color-bg`) but itself renders inside `.railCard`'s `--color-surface` background via the "Before publishing" checklist — a genuine, reachable AA failure I missed due to misidentifying the class during the initial audit. Caught, verified, and fixed before merge.
- Left two false-positive-looking sites alone after confirming they're genuinely safe: `RecipeDetailView.module.css`'s and `RecipeEditor.module.css`'s `.backLink` (both compose a faint-colored shared class, but get overridden to `--color-text-muted` by a more-specific same-file rule — the faint color never actually applies).

## Out of scope (filed as follow-up issue)
- **#299** — Consolidate the already-merged #268's `--ingredients-panel-faint-fg` (a component-local custom property) into this PR's new `--color-text-faint-on-surface` shared token — their values are byte-identical (both independently computed for the same `--color-surface` pairing), so this is pure deduplication. Deferred because it touches `RecipeDetailView`/`RecipeIngredients`, both explicitly out of scope for this issue (already covered by #268).