### PR TITLE
Consolidate --ingredients-panel-faint-fg into the shared faint-on-surface token

### DIFF
--- a/src/components/RecipeDetailView/RecipeDetailView.module.css
+++ b/src/components/RecipeDetailView/RecipeDetailView.module.css
@@ -138,18 +138,6 @@
   border-radius: var(--radius-xl);
   background: var(--color-surface);
   padding: 22px 22px 14px;
-  /* WCAG AA override: --color-text-faint is tuned against --color-bg
-     (#FBFAF7), not this panel's --color-surface (#F4F1EA), so it falls
-     short here — #767066 on #F4F1EA is ~4.35:1 (fails 4.5:1). Darkened
-     locally to #706A60 (~4.75:1) for text inside this panel. */
-  --ingredients-panel-faint-fg: #706A60;
-}
-
-[data-theme="dark"] .ingredientsPanel {
-  /* Same shortfall in dark mode: --color-text-faint (#877F73) on this
-     panel's dark --color-surface (#1C1A15) is ~4.40:1 (fails 4.5:1).
-     Lightened locally to #8C8478 (~4.71:1). */
-  --ingredients-panel-faint-fg: #8C8478;
 }
 
 .ingredientsHead {
@@ -172,13 +160,13 @@
 .servesLabel {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
-  color: var(--ingredients-panel-faint-fg, var(--color-text-faint));
+  color: var(--color-text-faint-on-surface);
   white-space: nowrap;
 }
 
 .ingredientsHint {
   font-size: var(--font-size-xs);
-  color: var(--ingredients-panel-faint-fg, var(--color-text-faint));
+  color: var(--color-text-faint-on-surface);
   margin: 0 0 var(--space-3);
 }
 

--- a/src/components/RecipeIngredients/RecipeIngredients.module.css
+++ b/src/components/RecipeIngredients/RecipeIngredients.module.css
@@ -62,13 +62,9 @@
 .checkbox:checked ~ .name {
   text-decoration: line-through;
   /* WCAG AA override: --color-text-faint fails 4.5:1 against this
-     panel's --color-surface (4.35:1 light / 4.40:1 dark) — see
-     RecipeDetailView.module.css's .ingredientsPanel comment. Reuses
-     the same panel-scoped custom property (inherited down the DOM
-     tree from the .ingredientsPanel ancestor this always renders
-     inside), falling back to the original token if ever rendered
-     without that ancestor. */
-  color: var(--ingredients-panel-faint-fg, var(--color-text-faint));
+     panel's --color-surface (4.35:1 light / 4.40:1 dark) — use the
+     shared --color-text-faint-on-surface token instead. */
+  color: var(--color-text-faint-on-surface);
 }
 
 .qty {
@@ -79,7 +75,7 @@
 }
 
 .checkbox:checked ~ .qty {
-  color: var(--ingredients-panel-faint-fg, var(--color-text-faint));
+  color: var(--color-text-faint-on-surface);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Closes #299

## What changed
Retrofitted `RecipeDetailView.module.css` (`.servesLabel`, `.ingredientsHint`) and `RecipeIngredients.module.css` (checked-state `.name`/`.qty` colors) to reference `--color-text-faint-on-surface` directly. Removed the now-redundant `--ingredients-panel-faint-fg` custom property and its two declaring rules (`.ingredientsPanel` light/dark).

## Why
`#274` had independently added `--color-text-faint-on-surface` to `tokens.css` for the same `--color-text-faint`-on-`--color-surface` contrast failure that `#268` had already fixed locally via `--ingredients-panel-faint-fg` — byte-identical hex values computed twice. This consolidates both onto one source of truth.

## How to verify
- `pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit` all pass with no new errors.
- Visually: recipe detail page's serves label, ingredients hint, and checked-ingredient strikethrough text should look unchanged in both light and dark theme. Verified via Playwright screenshot + computed-style check — light `rgb(112,106,96)` / dark `rgb(140,132,120)`, matching the removed property's values exactly (`#706A60` / `#8C8478`).

## Decisions made
`RecipeIngredients.module.css` actually had two checked-state rules using the old property (`.name` and `.qty`), though the issue text described it as singular — both were updated, since leaving either on the old variable's fallback (`var(--color-text-faint)`) would have reintroduced the original contrast failure once the property was removed.

## Out of scope
None — `/simplify` (reuse, simplification, efficiency, altitude passes) found no issues; no follow-ups filed.