### PR TITLE
stateBox.module.css's shared CSS ships duplicated across 3 lazy admin chunks

### DIFF
--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -242,7 +242,10 @@
   }
 }
 
-/* ── Empty / loading / error states — shared box shape ────────────── */
+/* ── Empty / loading / error states — shared box shape from
+   stateBox.module.css. stateBox is imported directly in RecipeList.tsx
+   and composed in JS rather than via `composes:` here, so Rollup can
+   dedupe the shared rules across lazy admin chunks. ─────────────────── */
 
 .emptyBox {
   border: 1px dashed var(--color-border);

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -245,43 +245,16 @@
 /* ── Empty / loading / error states — shared box shape ────────────── */
 
 .emptyBox {
-  composes: box from '../../../styles/stateBox.module.css';
   border: 1px dashed var(--color-border);
   padding: clamp(48px, 8vw, 84px) 24px;
 }
 
-.loadingBox {
-  composes: box loading from '../../../styles/stateBox.module.css';
-}
-
-.errorBox {
-  composes: box error from '../../../styles/stateBox.module.css';
-}
-
 .emptyIcon {
-  composes: icon from '../../../styles/stateBox.module.css';
   background: var(--color-surface);
   border: var(--border-width) solid var(--color-border);
   color: var(--color-text-muted);
 }
 
-.errorIcon {
-  composes: icon iconError from '../../../styles/stateBox.module.css';
-}
-
-.emptyHeading {
-  composes: heading from '../../../styles/stateBox.module.css';
-}
-
-.errorHeading {
-  composes: heading from '../../../styles/stateBox.module.css';
-}
-
-.emptyBody {
-  composes: body from '../../../styles/stateBox.module.css';
-}
-
 .errorBody {
-  composes: body from '../../../styles/stateBox.module.css';
   max-width: 38ch;
 }

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -164,7 +164,7 @@ const RecipeList = () => {
   const renderBody = () => {
     if (loading) {
       return (
-        <div className={[stateBox.box, stateBox.loading].filter(Boolean).join(' ')}>
+        <div className={`${stateBox.box} ${stateBox.loading}`}>
           <Loading label="Loading recipes…" />
         </div>
       )
@@ -172,17 +172,12 @@ const RecipeList = () => {
 
     if (error) {
       return (
-        <div className={[stateBox.box, stateBox.error].filter(Boolean).join(' ')}>
-          <div className={[stateBox.icon, stateBox.iconError].filter(Boolean).join(' ')}>
-            {iconWarning}
-          </div>
+        <div className={`${stateBox.box} ${stateBox.error}`}>
+          <div className={`${stateBox.icon} ${stateBox.iconError}`}>{iconWarning}</div>
           <Typography variant="heading2" className={stateBox.heading}>
             Couldn&apos;t load recipes
           </Typography>
-          <Typography
-            variant="body"
-            className={[stateBox.body, styles.errorBody].filter(Boolean).join(' ')}
-          >
+          <Typography variant="body" className={`${stateBox.body} ${styles.errorBody}`}>
             Something went wrong reaching the server. Check your connection and try again.
           </Typography>
           <Button variant="outline" onClick={loadRecipes} iconLeft={iconRetry}>
@@ -194,10 +189,8 @@ const RecipeList = () => {
 
     if (sortedRecipes.length === 0) {
       return (
-        <div className={[stateBox.box, styles.emptyBox].filter(Boolean).join(' ')}>
-          <div className={[stateBox.icon, styles.emptyIcon].filter(Boolean).join(' ')}>
-            {iconDocument}
-          </div>
+        <div className={`${stateBox.box} ${styles.emptyBox}`}>
+          <div className={`${stateBox.icon} ${styles.emptyIcon}`}>{iconDocument}</div>
           <Typography variant="heading2" className={stateBox.heading}>
             No recipes yet
           </Typography>

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -18,6 +18,7 @@ import type { Recipe } from '@models/recipe'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
+import stateBox from '../../../styles/stateBox.module.css'
 import { pluralize } from '../../../utils/pluralize'
 import { relativeUpdatedLabel } from '../../../utils/relativeTime'
 import styles from './RecipeList.module.css'
@@ -163,7 +164,7 @@ const RecipeList = () => {
   const renderBody = () => {
     if (loading) {
       return (
-        <div className={styles.loadingBox}>
+        <div className={[stateBox.box, stateBox.loading].filter(Boolean).join(' ')}>
           <Loading label="Loading recipes…" />
         </div>
       )
@@ -171,12 +172,17 @@ const RecipeList = () => {
 
     if (error) {
       return (
-        <div className={styles.errorBox}>
-          <div className={styles.errorIcon}>{iconWarning}</div>
-          <Typography variant="heading2" className={styles.errorHeading}>
+        <div className={[stateBox.box, stateBox.error].filter(Boolean).join(' ')}>
+          <div className={[stateBox.icon, stateBox.iconError].filter(Boolean).join(' ')}>
+            {iconWarning}
+          </div>
+          <Typography variant="heading2" className={stateBox.heading}>
             Couldn&apos;t load recipes
           </Typography>
-          <Typography variant="body" className={styles.errorBody}>
+          <Typography
+            variant="body"
+            className={[stateBox.body, styles.errorBody].filter(Boolean).join(' ')}
+          >
             Something went wrong reaching the server. Check your connection and try again.
           </Typography>
           <Button variant="outline" onClick={loadRecipes} iconLeft={iconRetry}>
@@ -188,12 +194,14 @@ const RecipeList = () => {
 
     if (sortedRecipes.length === 0) {
       return (
-        <div className={styles.emptyBox}>
-          <div className={styles.emptyIcon}>{iconDocument}</div>
-          <Typography variant="heading2" className={styles.emptyHeading}>
+        <div className={[stateBox.box, styles.emptyBox].filter(Boolean).join(' ')}>
+          <div className={[stateBox.icon, styles.emptyIcon].filter(Boolean).join(' ')}>
+            {iconDocument}
+          </div>
+          <Typography variant="heading2" className={stateBox.heading}>
             No recipes yet
           </Typography>
-          <Typography variant="body" className={styles.emptyBody}>
+          <Typography variant="body" className={stateBox.body}>
             Your kitchen is empty. Create your first recipe to start building the collection.
           </Typography>
           <Link to="/admin/recipes/new" variant="solid" className={styles.newButton}>

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -204,12 +204,14 @@
 /* ── Not-found state ──────────────────────────────────────────────────
    Matches Admin Recipe Preview.dc.html's not-found block (lines 121-133):
    icon box + h1 + body + ghost back-link, centered. Design literal has no
-   border on its own outer wrapper, but this composes the shared
+   border on its own outer wrapper, but this uses the shared
    stateBox.module.css `.box` shape (same "adapt the established pattern,
    don't invent a new one" precedent as `.stateWrapper` above), sized/
-   centered per the design's own max-width:520px column. */
+   centered per the design's own max-width:520px column. stateBox is
+   imported directly in RecipePreview.tsx and composed in JS rather than
+   via `composes:` here, so Rollup can dedupe the shared rules across lazy
+   admin chunks. */
 .notFoundBox {
-  composes: box from '../../../styles/stateBox.module.css';
   max-width: 520px;
   margin-inline: auto;
   padding: clamp(56px, 9vw, 92px) 24px;
@@ -220,7 +222,6 @@
    the shared shape's default 52px icon, otherwise the same convention
    (surface fill, hairline border, muted icon color). */
 .notFoundIcon {
-  composes: icon from '../../../styles/stateBox.module.css';
   width: 54px;
   height: 54px;
   margin-bottom: 22px;
@@ -230,13 +231,11 @@
 }
 
 .notFoundHeading {
-  composes: heading from '../../../styles/stateBox.module.css';
   font-size: 24px;
   margin: 0 0 10px;
 }
 
 .notFoundBody {
-  composes: body from '../../../styles/stateBox.module.css';
   font-size: 15px;
   margin: 0 0 26px;
   max-width: 38ch;

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useMemo, useState, type FC } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { MAIN_LANDMARK_ID } from '../../../constants/mainLandmark'
+import stateBox from '../../../styles/stateBox.module.css'
 import styles from './RecipePreview.module.css'
 
 // Hoisted elements, not components — these never take props, so there's no
@@ -197,12 +198,20 @@ const RecipePreview: FC = () => {
   if (notFound || !recipe) {
     return (
       <main id={MAIN_LANDMARK_ID} tabIndex={-1} className={styles.main}>
-        <div className={styles.notFoundBox}>
-          <div className={styles.notFoundIcon}>{iconNotFound}</div>
-          <Typography variant="heading1" className={styles.notFoundHeading}>
+        <div className={[stateBox.box, styles.notFoundBox].filter(Boolean).join(' ')}>
+          <div className={[stateBox.icon, styles.notFoundIcon].filter(Boolean).join(' ')}>
+            {iconNotFound}
+          </div>
+          <Typography
+            variant="heading1"
+            className={[stateBox.heading, styles.notFoundHeading].filter(Boolean).join(' ')}
+          >
             Recipe not found
           </Typography>
-          <Typography variant="body" className={styles.notFoundBody}>
+          <Typography
+            variant="body"
+            className={[stateBox.body, styles.notFoundBody].filter(Boolean).join(' ')}
+          >
             This recipe may have been deleted, or the link is incorrect.
           </Typography>
           <Link

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -198,20 +198,12 @@ const RecipePreview: FC = () => {
   if (notFound || !recipe) {
     return (
       <main id={MAIN_LANDMARK_ID} tabIndex={-1} className={styles.main}>
-        <div className={[stateBox.box, styles.notFoundBox].filter(Boolean).join(' ')}>
-          <div className={[stateBox.icon, styles.notFoundIcon].filter(Boolean).join(' ')}>
-            {iconNotFound}
-          </div>
-          <Typography
-            variant="heading1"
-            className={[stateBox.heading, styles.notFoundHeading].filter(Boolean).join(' ')}
-          >
+        <div className={`${stateBox.box} ${styles.notFoundBox}`}>
+          <div className={`${stateBox.icon} ${styles.notFoundIcon}`}>{iconNotFound}</div>
+          <Typography variant="heading1" className={`${stateBox.heading} ${styles.notFoundHeading}`}>
             Recipe not found
           </Typography>
-          <Typography
-            variant="body"
-            className={[stateBox.body, styles.notFoundBody].filter(Boolean).join(' ')}
-          >
+          <Typography variant="body" className={`${stateBox.body} ${styles.notFoundBody}`}>
             This recipe may have been deleted, or the link is incorrect.
           </Typography>
           <Link

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -384,28 +384,13 @@
   }
 }
 
-/* ── Loading / error states — composes the shared box shape from
+/* ── Loading / error states — uses the shared box shape from
    stateBox.module.css, matching RecipeList.module.css's `.loadingBox`/
    `.errorBox` exactly (this is the third page in the epic to need this
-   treatment). ──────────────────────────────────────────────────────── */
-
-.loadingBox {
-  composes: box loading from '../../../styles/stateBox.module.css';
-}
-
-.errorBox {
-  composes: box error from '../../../styles/stateBox.module.css';
-}
-
-.errorIcon {
-  composes: icon iconError from '../../../styles/stateBox.module.css';
-}
-
-.errorHeading {
-  composes: heading from '../../../styles/stateBox.module.css';
-}
+   treatment). stateBox is imported directly in UserManagement.tsx and
+   composed in JS rather than via `composes:` here, so Rollup can dedupe
+   the shared rules across lazy admin chunks. ──────────────────────────── */
 
 .errorBody {
-  composes: body from '../../../styles/stateBox.module.css';
   max-width: 38ch;
 }

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -13,6 +13,7 @@ import type { AdminRole, AdminUser } from '@models/auth'
 import { useCallback, useEffect, useId, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import stateBox from '../../../styles/stateBox.module.css'
 import styles from './UserManagement.module.css'
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -159,7 +160,7 @@ const UserManagement = () => {
   const renderBody = () => {
     if (loading) {
       return (
-        <div className={styles.loadingBox}>
+        <div className={[stateBox.box, stateBox.loading].filter(Boolean).join(' ')}>
           <Loading label="Loading users…" />
         </div>
       )
@@ -167,12 +168,17 @@ const UserManagement = () => {
 
     if (error) {
       return (
-        <div className={styles.errorBox}>
-          <div className={styles.errorIcon}>{iconWarning}</div>
-          <Typography variant="heading2" className={styles.errorHeading}>
+        <div className={[stateBox.box, stateBox.error].filter(Boolean).join(' ')}>
+          <div className={[stateBox.icon, stateBox.iconError].filter(Boolean).join(' ')}>
+            {iconWarning}
+          </div>
+          <Typography variant="heading2" className={stateBox.heading}>
             Couldn&apos;t load users
           </Typography>
-          <Typography variant="body" className={styles.errorBody}>
+          <Typography
+            variant="body"
+            className={[stateBox.body, styles.errorBody].filter(Boolean).join(' ')}
+          >
             Something went wrong reaching the server. Check your connection and try again.
           </Typography>
           <Button variant="outline" onClick={loadUsers} iconLeft={iconRetry}>

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -160,7 +160,7 @@ const UserManagement = () => {
   const renderBody = () => {
     if (loading) {
       return (
-        <div className={[stateBox.box, stateBox.loading].filter(Boolean).join(' ')}>
+        <div className={`${stateBox.box} ${stateBox.loading}`}>
           <Loading label="Loading users…" />
         </div>
       )
@@ -168,17 +168,12 @@ const UserManagement = () => {
 
     if (error) {
       return (
-        <div className={[stateBox.box, stateBox.error].filter(Boolean).join(' ')}>
-          <div className={[stateBox.icon, stateBox.iconError].filter(Boolean).join(' ')}>
-            {iconWarning}
-          </div>
+        <div className={`${stateBox.box} ${stateBox.error}`}>
+          <div className={`${stateBox.icon} ${stateBox.iconError}`}>{iconWarning}</div>
           <Typography variant="heading2" className={stateBox.heading}>
             Couldn&apos;t load users
           </Typography>
-          <Typography
-            variant="body"
-            className={[stateBox.body, styles.errorBody].filter(Boolean).join(' ')}
-          >
+          <Typography variant="body" className={`${stateBox.body} ${styles.errorBody}`}>
             Something went wrong reaching the server. Check your connection and try again.
           </Typography>
           <Button variant="outline" onClick={loadUsers} iconLeft={iconRetry}>

--- a/src/styles/stateBox.module.css
+++ b/src/styles/stateBox.module.css
@@ -4,6 +4,14 @@
    near-identical but independently re-typed, silently drifting on any
    future tweak. See issue #269.
 
+   Consumed by RecipeList/UserManagement/RecipePreview via a direct JS
+   import + classNames composed in JS, not via CSS Modules' `composes:
+   ... from`. A shared module reused only by independently lazy-loaded
+   consumers must be imported this way — `composes:` inlines the
+   referenced rules as literal text into each composing file at
+   CSS-transform time, so the bundler has no shared module instance to
+   dedupe and ships a full copy into every consumer's own chunk.
+
    Split across two layers, both registered in order in `src/index.css`
    (`@layer component-defaults, composed-overrides;`):
 


### PR DESCRIPTION
Closes #296

## What changed
Converted `RecipeList`, `UserManagement`, and `RecipePreview` from CSS Modules `composes: ... from stateBox.module.css` to a direct JS import of `stateBox.module.css` in each `.tsx`, with classNames composed at render time via template literals.

## Why
`composes: ... from` inlines the referenced rules as literal text into each composing file at CSS-transform time (ICSS import semantics) — there's no shared, bundler-chunk-addressable module for the composed portion, so no build-config lever (eager `@import`, JS side-effect import, Rollup `manualChunks`) can deduplicate it. Importing `stateBox.module.css` as a real JS module gives Rollup a genuine shared module instance it hoists into its own chunk automatically.

## How to verify
`pnpm build:client`, then check `dist/client/assets/*.css` — `stateBox.module.css`'s compiled rules (identifiable by their unique CSS-Modules hash suffix) now appear in exactly one file (a dedicated `stateBox-*.css` chunk), where they previously appeared in three (RecipeList/UserManagement/RecipePreview's own chunks). Verified independently by the orchestrator with a fresh build, ruling out false-positive substring matches from unrelated components' own `.loading`/`.iconError`-named classes.

## Decisions made
**AC1 deviation, user-approved.** The issue's AC1 suggested "import from an eagerly-loaded ancestor common to all three admin routes." Investigation found this isn't achievable: (1) `composes:`'s CSS-transform-time text-inlining means no eager import of any kind — CSS `@import`, JS side-effect import, or `manualChunks` — actually dedupes it (confirmed empirically against real builds); and (2) `RecipeList`/`UserManagement` share `AdminRootLayout`, but `RecipePreview` uses a different layout (`RecipePreviewLayout`) — there's no single route-wrapper common to all three anyway. The user was informed of both findings and explicitly chose the JS-level-import approach instead, which achieves the actual goal (AC2's empirical build-output requirement) via a different, genuinely-idiomatic-for-CSS-Modules mechanism.

Live browser verification of the "no visual change" AC wasn't performed — these are authenticated admin pages behind production login. Relying instead on: the pre-existing test suite's explicit loading/error/empty-state tests (including axe accessibility checks on those exact branches) passing unmodified, plus a manual line-by-line diff trace confirming every element ends up with the identical final class list.

## Out of scope (filed as follow-up issues)

- **#304** — Extract a shared `<StateBox>` component. `/simplify` found RecipeList's and UserManagement's loading/error render blocks are still near-duplicated at the JSX level (stateBox.module.css only deduplicated the CSS shape, not the render structure). Deferred: it's a real component extraction touching 2+ files' render logic, beyond this issue's CSS-dedup scope.
- **#305** — Audit `interactions.module.css`/`text.module.css`/`formField.module.css` for the same `composes`-across-lazy-chunks risk. Deferred: explicitly out of scope per this issue's own "Out of scope" section, which called for a separate audit issue if warranted.