### PR TITLE
Audit interactions/text/formField shared modules for the same composes-across-lazy-chunks duplication risk

### DIFF
--- a/src/components/AutosaveStatus/AutosaveStatus.module.css
+++ b/src/components/AutosaveStatus/AutosaveStatus.module.css
@@ -21,15 +21,11 @@
 }
 
 /* ── Saving — shared spinner composable, small size ───────────────
-   `spinner` (rotation/border/color) and `spinnerSm` (the 15px/2px-border
-   size override), both from interactions.module.css, are composed
-   directly in JS (see AutosaveStatus.tsx) rather than via a local
-   `.spinner` class — AutosaveStatus is only used within the (lazy)
-   RecipeEditor page today, but interactions.module.css has no JS import
-   of its own, so `composes:` here would inline a full copy on top of
-   the shared chunk RecipeEditor already pulls in. See that
-   file's own comment for why the keyframe needs `global(...)` and why
-   prefers-reduced-motion needs no local override (handled at the
+   `spinner`/`spinnerSm` (interactions.module.css) are composed directly
+   in JS (see AutosaveStatus.tsx) rather than via a local `.spinner`
+   class — see interactions.module.css's own header comment for why. See
+   that file's own comment for why the keyframe needs `global(...)` and
+   why prefers-reduced-motion needs no local override (handled at the
    `spin`/`shimmerSweep` keyframe level in animations.css). */
 
 .iconSaved {

--- a/src/components/AutosaveStatus/AutosaveStatus.module.css
+++ b/src/components/AutosaveStatus/AutosaveStatus.module.css
@@ -21,14 +21,16 @@
 }
 
 /* ── Saving — shared spinner composable, small size ───────────────
-   Composes both `spinner` (rotation/border/color) and `spinnerSm` (the
-   15px/2px-border size override) from interactions.module.css — see that
+   `spinner` (rotation/border/color) and `spinnerSm` (the 15px/2px-border
+   size override), both from interactions.module.css, are composed
+   directly in JS (see AutosaveStatus.tsx) rather than via a local
+   `.spinner` class — AutosaveStatus is only used within the (lazy)
+   RecipeEditor page today, but interactions.module.css has no JS import
+   of its own, so `composes:` here would inline a full copy on top of
+   the shared chunk RecipeEditor already pulls in. See that
    file's own comment for why the keyframe needs `global(...)` and why
    prefers-reduced-motion needs no local override (handled at the
    `spin`/`shimmerSweep` keyframe level in animations.css). */
-.spinner {
-  composes: spinner spinnerSm from '../../styles/interactions.module.css';
-}
 
 .iconSaved {
   display: inline-flex;
@@ -50,8 +52,9 @@
   color: var(--color-text-muted);
 }
 
+/* `focusRing` composed in JS — see `.spinner`'s removed rule above for
+   rationale. */
 .retryButton {
-  composes: focusRing from '../../styles/interactions.module.css';
   margin-left: auto;
   padding: 0;
   /* 12.5px: design literal (--font-size-sm=13px is the nearest token). */

--- a/src/components/AutosaveStatus/AutosaveStatus.tsx
+++ b/src/components/AutosaveStatus/AutosaveStatus.tsx
@@ -2,6 +2,8 @@ import { IconAlertCircle } from '@components/icons'
 import type { AutosaveStatus as AutosaveStatusValue } from '@hooks/useAutosave'
 import type { FC, ReactNode } from 'react'
 import { useEffect, useState } from 'react'
+
+import interactions from '../../styles/interactions.module.css'
 import styles from './AutosaveStatus.module.css'
 
 export interface AutosaveStatusProps {
@@ -86,7 +88,10 @@ const AutosaveStatus: FC<AutosaveStatusProps> = ({ status, lastSavedAt, onRetry 
     <span className={styles.container}>
       <span role="status" aria-live={ariaLive} className={styles.liveRegion}>
         {status === 'saving' && (
-          <span aria-hidden="true" className={styles.spinner} />
+          <span
+            aria-hidden="true"
+            className={`${interactions.spinner} ${interactions.spinnerSm}`}
+          />
         )}
         {statusIcon && (
           <span aria-hidden="true" className={ICON_CLASS[status]}>
@@ -103,7 +108,7 @@ const AutosaveStatus: FC<AutosaveStatusProps> = ({ status, lastSavedAt, onRetry 
       {status === 'error' && (
         <button
           type="button"
-          className={styles.retryButton}
+          className={`${interactions.focusRing} ${styles.retryButton}`}
           onClick={() => { onRetry() }}
         >
           Retry

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -12,8 +12,15 @@
   background-color: var(--color-surface);
 }
 
+/* `surfaceHover`/`focusRing` (interactions.module.css) are composed in
+   JS (see Card.tsx) rather than via `composes:` here. Card is currently
+   only used by the (lazy) Login page, but interactions.module.css has
+   no JS import of its own anywhere in the codebase — `composes:`
+   inlines its rules as literal text at CSS-transform time (ICSS import
+   semantics), so any independently lazy-loaded consumer duplicates a
+   full copy with no bundler-chunk-addressable module to dedupe against
+   (same rationale as stateBox.module.css). */
 .hover {
-  composes: surfaceHover from '../../styles/interactions.module.css';
   transition: background-color var(--duration-fast) var(--easing-default);
 }
 
@@ -24,7 +31,6 @@
 }
 
 .asButton {
-  composes: focusRing from '../../styles/interactions.module.css';
   width: 100%;
   font: inherit;
   color: inherit;

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -13,13 +13,8 @@
 }
 
 /* `surfaceHover`/`focusRing` (interactions.module.css) are composed in
-   JS (see Card.tsx) rather than via `composes:` here. Card is currently
-   only used by the (lazy) Login page, but interactions.module.css has
-   no JS import of its own anywhere in the codebase — `composes:`
-   inlines its rules as literal text at CSS-transform time (ICSS import
-   semantics), so any independently lazy-loaded consumer duplicates a
-   full copy with no bundler-chunk-addressable module to dedupe against
-   (same rationale as stateBox.module.css). */
+   JS (see Card.tsx) rather than via `composes:` here — see
+   interactions.module.css's own header comment for why. */
 .hover {
   transition: background-color var(--duration-fast) var(--easing-default);
 }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,4 +1,6 @@
 import type { CSSProperties, ElementType, MouseEvent, ReactNode } from 'react'
+
+import interactions from '../../styles/interactions.module.css'
 import styles from './Card.module.css'
 
 export interface CardProps {
@@ -34,7 +36,9 @@ const Card = ({
     styles.card,
     fill && styles.fill,
     hover && styles.hover,
+    hover && interactions.surfaceHover,
     Component === 'button' && styles.asButton,
+    Component === 'button' && interactions.focusRing,
     extraClassName,
   ]
     .filter(Boolean)

--- a/src/components/ImageUpload/ImageUpload.module.css
+++ b/src/components/ImageUpload/ImageUpload.module.css
@@ -12,12 +12,8 @@
 
 /* ── Empty state — cover (large dropzone) ─────────────────────── */
 /* `focusRing`/`uploadHover` (interactions.module.css) are composed in JS
-   (see ImageUpload.tsx) rather than via `composes:` here — ImageUpload
-   is only used within the (lazy) RecipeEditor page today, but
-   interactions.module.css has no JS import of its own, so `composes:`
-   would inline a full copy here on top of the shared chunk RecipeEditor
-   already pulls in for its own directly-composed classes (see
-   RecipeList.module.css's `.actionButton` for the pattern). */
+   (see ImageUpload.tsx) rather than via `composes:` here — see
+   interactions.module.css's own header comment for why. */
 .dropzone {
   display: flex;
   flex-direction: column;

--- a/src/components/ImageUpload/ImageUpload.module.css
+++ b/src/components/ImageUpload/ImageUpload.module.css
@@ -11,9 +11,14 @@
 }
 
 /* ── Empty state — cover (large dropzone) ─────────────────────── */
+/* `focusRing`/`uploadHover` (interactions.module.css) are composed in JS
+   (see ImageUpload.tsx) rather than via `composes:` here — ImageUpload
+   is only used within the (lazy) RecipeEditor page today, but
+   interactions.module.css has no JS import of its own, so `composes:`
+   would inline a full copy here on top of the shared chunk RecipeEditor
+   already pulls in for its own directly-composed classes (see
+   RecipeList.module.css's `.actionButton` for the pattern). */
 .dropzone {
-  composes: focusRing from '../../styles/interactions.module.css';
-  composes: uploadHover from '../../styles/interactions.module.css';
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -93,8 +98,8 @@
    top-right icon-button position/shape, kept non-destructive in tone
    (not the design's literal danger/trash treatment, since it doesn't
    delete anything). */
+/* `focusRing` composed in JS — see `.dropzone` above for rationale. */
 .replaceButton {
-  composes: focusRing from '../../styles/interactions.module.css';
   position: absolute;
   top: 10px;
   right: 10px;

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -6,6 +6,7 @@ import ProcessingPlaceholder from '@components/ProcessingPlaceholder'
 import { parseImageType, recipeImageUrl, type ImageType } from '@models/recipe'
 import { useEffect, useId, useRef, useState, type ChangeEvent, type FC } from 'react'
 
+import interactions from '../../styles/interactions.module.css'
 import styles from './ImageUpload.module.css'
 
 export interface ImageUploadProps {
@@ -208,7 +209,7 @@ const ImageUpload: FC<ImageUploadProps> = ({
           />
           <button
             type="button"
-            className={styles.replaceButton}
+            className={`${interactions.focusRing} ${styles.replaceButton}`}
             onClick={handleClick}
             aria-label="Replace image"
           >
@@ -227,7 +228,11 @@ const ImageUpload: FC<ImageUploadProps> = ({
     }
 
     return isCover ? (
-      <button type="button" className={styles.dropzone} onClick={handleClick}>
+      <button
+        type="button"
+        className={`${interactions.focusRing} ${interactions.uploadHover} ${styles.dropzone}`}
+        onClick={handleClick}
+      >
         <span aria-hidden="true" className={styles.dropzoneIcon}>
           {iconUploadCloud}
         </span>

--- a/src/components/IngredientList/IngredientList.module.css
+++ b/src/components/IngredientList/IngredientList.module.css
@@ -52,14 +52,12 @@
 
 /* `iconButtonHover`/`dangerIconButtonHover` (interactions.module.css)
    are composed directly in JS (see IngredientList.tsx) instead of via
-   local `.moveAction`/`.removeAction` classes — IngredientList is only
-   used within the (lazy) RecipeEditor page today, but
-   interactions.module.css has no JS import of its own, so `composes:`
-   here would inline a full copy on top of the shared chunk RecipeEditor
-   already pulls in. Each icon button still picks up
-   exactly one hover treatment: reordering buttons get the neutral
-   hover, remove gets the danger hover — never both on the same element,
-   so there's no same-specificity `:hover` rule to referee. */
+   local `.moveAction`/`.removeAction` classes — see
+   interactions.module.css's own header comment for why. Each icon
+   button still picks up exactly one hover treatment: reordering buttons
+   get the neutral hover, remove gets the danger hover — never both on
+   the same element, so there's no same-specificity `:hover` rule to
+   referee. */
 
 /* Descendant-scoped (not a bare `.actionButton` rule) to safely out-rank
    Button's own `.button`/`.outline` single-class selectors regardless of

--- a/src/components/IngredientList/IngredientList.module.css
+++ b/src/components/IngredientList/IngredientList.module.css
@@ -50,20 +50,16 @@
   gap: var(--space-2);
 }
 
-/* Bare single-class rules carrying `composes` — CSS Modules only allows
-   `composes` on a plain single local-class selector, not a compound/
-   descendant one. `.moveAction`/`.removeAction` are additive classes
-   (joined with `.actionButton` in the component) so each icon button
-   picks up exactly one hover treatment: reordering buttons get the
-   neutral hover, remove gets the danger hover — never both on the same
-   element, so there's no same-specificity `:hover` rule to referee. */
-.moveAction {
-  composes: iconButtonHover from '../../styles/interactions.module.css';
-}
-
-.removeAction {
-  composes: dangerIconButtonHover from '../../styles/interactions.module.css';
-}
+/* `iconButtonHover`/`dangerIconButtonHover` (interactions.module.css)
+   are composed directly in JS (see IngredientList.tsx) instead of via
+   local `.moveAction`/`.removeAction` classes — IngredientList is only
+   used within the (lazy) RecipeEditor page today, but
+   interactions.module.css has no JS import of its own, so `composes:`
+   here would inline a full copy on top of the shared chunk RecipeEditor
+   already pulls in. Each icon button still picks up
+   exactly one hover treatment: reordering buttons get the neutral
+   hover, remove gets the danger hover — never both on the same element,
+   so there's no same-specificity `:hover` rule to referee. */
 
 /* Descendant-scoped (not a bare `.actionButton` rule) to safely out-rank
    Button's own `.button`/`.outline` single-class selectors regardless of

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -8,6 +8,9 @@ import type { FC } from 'react'
 import interactions from '../../styles/interactions.module.css'
 import styles from './IngredientList.module.css'
 
+const moveActionClassName = `${interactions.iconButtonHover} ${styles.actionButton}`
+const removeActionClassName = `${interactions.dangerIconButtonHover} ${styles.actionButton}`
+
 export interface IngredientListProps {
   ingredients: Ingredient[]
   onChange: (ingredients: Ingredient[]) => void
@@ -76,7 +79,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
                 ariaLabel={`Move up ingredient ${index + 1}`}
                 variant="outline"
                 disabled={index === 0}
-                className={`${interactions.iconButtonHover} ${styles.actionButton}`}
+                className={moveActionClassName}
               >
                 {iconChevronUp}
               </Button>
@@ -85,7 +88,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
                 ariaLabel={`Move down ingredient ${index + 1}`}
                 variant="outline"
                 disabled={index === ingredients.length - 1}
-                className={`${interactions.iconButtonHover} ${styles.actionButton}`}
+                className={moveActionClassName}
               >
                 {iconChevronDown}
               </Button>
@@ -94,7 +97,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
                 ariaLabel={`Remove ingredient ${index + 1}`}
                 variant="outline"
                 disabled={ingredients.length <= 1}
-                className={`${interactions.dangerIconButtonHover} ${styles.actionButton}`}
+                className={removeActionClassName}
               >
                 {iconRemove}
               </Button>

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -5,6 +5,7 @@ import { useReorderableList } from '@hooks/useReorderableList'
 import type { Ingredient } from '@models/recipe'
 import type { FC } from 'react'
 
+import interactions from '../../styles/interactions.module.css'
 import styles from './IngredientList.module.css'
 
 export interface IngredientListProps {
@@ -75,7 +76,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
                 ariaLabel={`Move up ingredient ${index + 1}`}
                 variant="outline"
                 disabled={index === 0}
-                className={`${styles.actionButton} ${styles.moveAction}`}
+                className={`${interactions.iconButtonHover} ${styles.actionButton}`}
               >
                 {iconChevronUp}
               </Button>
@@ -84,7 +85,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
                 ariaLabel={`Move down ingredient ${index + 1}`}
                 variant="outline"
                 disabled={index === ingredients.length - 1}
-                className={`${styles.actionButton} ${styles.moveAction}`}
+                className={`${interactions.iconButtonHover} ${styles.actionButton}`}
               >
                 {iconChevronDown}
               </Button>
@@ -93,7 +94,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
                 ariaLabel={`Remove ingredient ${index + 1}`}
                 variant="outline"
                 disabled={ingredients.length <= 1}
-                className={`${styles.actionButton} ${styles.removeAction}`}
+                className={`${interactions.dangerIconButtonHover} ${styles.actionButton}`}
               >
                 {iconRemove}
               </Button>

--- a/src/components/StepList/StepList.module.css
+++ b/src/components/StepList/StepList.module.css
@@ -55,13 +55,10 @@
   gap: var(--space-2);
 }
 
-.moveAction {
-  composes: iconButtonHover from '../../styles/interactions.module.css';
-}
-
-.removeAction {
-  composes: dangerIconButtonHover from '../../styles/interactions.module.css';
-}
+/* `iconButtonHover`/`dangerIconButtonHover` (interactions.module.css)
+   are composed directly in JS (see StepList.tsx) instead of via local
+   `.moveAction`/`.removeAction` classes — same rationale as
+   IngredientList.module.css's own doc comment. */
 
 .actions .actionButton {
   width: 30px;

--- a/src/components/StepList/StepList.module.css
+++ b/src/components/StepList/StepList.module.css
@@ -57,8 +57,8 @@
 
 /* `iconButtonHover`/`dangerIconButtonHover` (interactions.module.css)
    are composed directly in JS (see StepList.tsx) instead of via local
-   `.moveAction`/`.removeAction` classes — same rationale as
-   IngredientList.module.css's own doc comment. */
+   `.moveAction`/`.removeAction` classes — see interactions.module.css's
+   own header comment for why. */
 
 .actions .actionButton {
   width: 30px;

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -10,6 +10,9 @@ import { useCallback, type FC } from 'react'
 import interactions from '../../styles/interactions.module.css'
 import styles from './StepList.module.css'
 
+const moveActionClassName = `${interactions.iconButtonHover} ${styles.actionButton}`
+const removeActionClassName = `${interactions.dangerIconButtonHover} ${styles.actionButton}`
+
 export interface StepListProps {
   steps: Step[]
   onChange: (steps: Step[]) => void
@@ -94,7 +97,7 @@ const StepList: FC<StepListProps> = ({
                   ariaLabel={`Move up step ${index + 1}`}
                   variant="outline"
                   disabled={index === 0}
-                  className={`${interactions.iconButtonHover} ${styles.actionButton}`}
+                  className={moveActionClassName}
                 >
                   {iconChevronUp}
                 </Button>
@@ -103,7 +106,7 @@ const StepList: FC<StepListProps> = ({
                   ariaLabel={`Move down step ${index + 1}`}
                   variant="outline"
                   disabled={index === steps.length - 1}
-                  className={`${interactions.iconButtonHover} ${styles.actionButton}`}
+                  className={moveActionClassName}
                 >
                   {iconChevronDown}
                 </Button>
@@ -112,7 +115,7 @@ const StepList: FC<StepListProps> = ({
                   ariaLabel={`Remove step ${index + 1}`}
                   variant="outline"
                   disabled={steps.length <= 1}
-                  className={`${interactions.dangerIconButtonHover} ${styles.actionButton}`}
+                  className={removeActionClassName}
                 >
                   {iconRemove}
                 </Button>

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -7,6 +7,7 @@ import { useReorderableList } from '@hooks/useReorderableList'
 import { stepImageType, type RecipeImage, type Step } from '@models/recipe'
 import { useCallback, type FC } from 'react'
 
+import interactions from '../../styles/interactions.module.css'
 import styles from './StepList.module.css'
 
 export interface StepListProps {
@@ -93,7 +94,7 @@ const StepList: FC<StepListProps> = ({
                   ariaLabel={`Move up step ${index + 1}`}
                   variant="outline"
                   disabled={index === 0}
-                  className={`${styles.actionButton} ${styles.moveAction}`}
+                  className={`${interactions.iconButtonHover} ${styles.actionButton}`}
                 >
                   {iconChevronUp}
                 </Button>
@@ -102,7 +103,7 @@ const StepList: FC<StepListProps> = ({
                   ariaLabel={`Move down step ${index + 1}`}
                   variant="outline"
                   disabled={index === steps.length - 1}
-                  className={`${styles.actionButton} ${styles.moveAction}`}
+                  className={`${interactions.iconButtonHover} ${styles.actionButton}`}
                 >
                   {iconChevronDown}
                 </Button>
@@ -111,7 +112,7 @@ const StepList: FC<StepListProps> = ({
                   ariaLabel={`Remove step ${index + 1}`}
                   variant="outline"
                   disabled={steps.length <= 1}
-                  className={`${styles.actionButton} ${styles.removeAction}`}
+                  className={`${interactions.dangerIconButtonHover} ${styles.actionButton}`}
                 >
                   {iconRemove}
                 </Button>

--- a/src/components/TagInput/TagInput.module.css
+++ b/src/components/TagInput/TagInput.module.css
@@ -65,10 +65,7 @@
    src/styles/formField.module.css for the full rationale (issue #244),
    including why transition stays local. `fieldFocusRing`
    (interactions.module.css) is composed in JS instead (see TagInput.tsx)
-   — TagInput is only used within the (lazy) RecipeEditor page today,
-   but interactions.module.css has no JS import of its own, so
-   `composes:` here would inline a full copy on top of the shared chunk
-   RecipeEditor already pulls in. */
+   — see interactions.module.css's own header comment for why. */
 .input {
   composes: field from '../../styles/formField.module.css';
   transition: border-color var(--duration-fast) var(--easing-default);

--- a/src/components/TagInput/TagInput.module.css
+++ b/src/components/TagInput/TagInput.module.css
@@ -63,10 +63,14 @@
    radius/padding) is shared byte-for-byte with Input and Textarea's
    `.field` via the `field` composable — see
    src/styles/formField.module.css for the full rationale (issue #244),
-   including why transition stays local. */
+   including why transition stays local. `fieldFocusRing`
+   (interactions.module.css) is composed in JS instead (see TagInput.tsx)
+   — TagInput is only used within the (lazy) RecipeEditor page today,
+   but interactions.module.css has no JS import of its own, so
+   `composes:` here would inline a full copy on top of the shared chunk
+   RecipeEditor already pulls in. */
 .input {
   composes: field from '../../styles/formField.module.css';
-  composes: fieldFocusRing from '../../styles/interactions.module.css';
   transition: border-color var(--duration-fast) var(--easing-default);
 }
 
@@ -86,8 +90,9 @@
   list-style: none;
 }
 
+/* `chipHover` (interactions.module.css) composed in JS — see `.input`
+   above for rationale. */
 .option {
-  composes: chipHover from '../../styles/interactions.module.css';
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   letter-spacing: var(--tracking-meta);

--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -1,6 +1,7 @@
 import Tag from '@components/Tag'
 import { useId, useState, type FC, type KeyboardEvent } from 'react'
 
+import interactions from '../../styles/interactions.module.css'
 import styles from './TagInput.module.css'
 
 export interface TagInputProps {
@@ -110,7 +111,7 @@ const TagInput: FC<TagInputProps> = ({
           value={inputValue}
           onChange={(e) => handleInputChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          className={styles.input}
+          className={`${interactions.fieldFocusRing} ${styles.input}`}
           placeholder={placeholder}
         />
 
@@ -126,7 +127,7 @@ const TagInput: FC<TagInputProps> = ({
                 id={`${listboxId}-option-${index}`}
                 role="option"
                 aria-selected={index === highlightedIndex}
-                className={styles.option}
+                className={`${interactions.chipHover} ${styles.option}`}
                 onClick={() => addTag(tag)}
               >
                 {tag}

--- a/src/components/Textarea/Textarea.module.css
+++ b/src/components/Textarea/Textarea.module.css
@@ -7,10 +7,8 @@
    full rationale (issue #244), including why transition stays local.
    line-height/resize/min-height stay here — genuinely Textarea-only.
    `fieldFocusRing` (interactions.module.css) is composed in JS instead
-   (see Textarea.tsx) — Textarea is only used within the (lazy)
-   RecipeEditor page today, but interactions.module.css has no JS import
-   of its own, so `composes:` here would inline a full copy on top of
-   the shared chunk RecipeEditor already pulls in. */
+   (see Textarea.tsx) — see interactions.module.css's own header comment
+   for why. */
 .field {
   composes: field from '../../styles/formField.module.css';
   line-height: var(--line-height-relaxed);

--- a/src/components/Textarea/Textarea.module.css
+++ b/src/components/Textarea/Textarea.module.css
@@ -5,10 +5,14 @@
    radius/padding) is shared byte-for-byte with Input and TagInput via
    the `field` composable — see src/styles/formField.module.css for the
    full rationale (issue #244), including why transition stays local.
-   line-height/resize/min-height stay here — genuinely Textarea-only. */
+   line-height/resize/min-height stay here — genuinely Textarea-only.
+   `fieldFocusRing` (interactions.module.css) is composed in JS instead
+   (see Textarea.tsx) — Textarea is only used within the (lazy)
+   RecipeEditor page today, but interactions.module.css has no JS import
+   of its own, so `composes:` here would inline a full copy on top of
+   the shared chunk RecipeEditor already pulls in. */
 .field {
   composes: field from '../../styles/formField.module.css';
-  composes: fieldFocusRing from '../../styles/interactions.module.css';
   line-height: var(--line-height-relaxed);
   resize: vertical;
   min-height: var(--space-20);

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -1,4 +1,6 @@
 import type { ChangeEvent, FC } from 'react'
+
+import interactions from '../../styles/interactions.module.css'
 import styles from './Textarea.module.css'
 
 export interface TextareaProps {
@@ -29,7 +31,9 @@ const Textarea: FC<TextareaProps> = ({
   ariaDescribedBy,
   className: extraClassName,
 }) => {
-  const className = [styles.field, extraClassName].filter(Boolean).join(' ')
+  const className = [interactions.fieldFocusRing, styles.field, extraClassName]
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <textarea

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -63,10 +63,8 @@
 }
 
 /* `spinner`/`spinnerSm` (interactions.module.css) are composed in JS
-   rather than via `composes:` here, so Rollup can dedupe the shared
-   rules across lazy admin chunks instead of inlining a full copy into
-   each of RecipeList/RecipeEditor/UserManagement's independently
-   lazy-loaded chunks (same rationale as stateBox.module.css). */
+   rather than via `composes:` here — see interactions.module.css's own
+   header comment for why. */
 .timeoutSpinner {
   flex-shrink: 0;
   border-top-color: var(--color-warning);

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -62,8 +62,12 @@
   flex-shrink: 0;
 }
 
+/* `spinner`/`spinnerSm` (interactions.module.css) are composed in JS
+   rather than via `composes:` here, so Rollup can dedupe the shared
+   rules across lazy admin chunks instead of inlining a full copy into
+   each of RecipeList/RecipeEditor/UserManagement's independently
+   lazy-loaded chunks (same rationale as stateBox.module.css). */
 .timeoutSpinner {
-  composes: spinner spinnerSm from '../../../styles/interactions.module.css';
   flex-shrink: 0;
   border-top-color: var(--color-warning);
 }
@@ -91,9 +95,10 @@
 
 /* ── Back link ───────────────────────────────────────────────────── */
 
+/* `focusRing` (interactions.module.css) and `metaText` (text.module.css)
+   are composed in JS rather than via `composes:` here — see
+   `.timeoutSpinner` above for the shared-across-lazy-chunks rationale. */
 .backLink {
-  composes: focusRing from '../../../styles/interactions.module.css';
-  composes: metaText from '../../../styles/text.module.css';
   margin-bottom: 20px;
 }
 
@@ -183,12 +188,10 @@
     box-shadow var(--duration-fast) var(--easing-default);
 }
 
-.input {
-  composes: fieldFocusRing from '../../../styles/interactions.module.css';
-}
-
+/* `fieldFocusRing` (interactions.module.css) is composed in JS rather
+   than via `composes:` on `.input`/`.textarea` below — see
+   `.timeoutSpinner` above for the shared-across-lazy-chunks rationale. */
 .textarea {
-  composes: fieldFocusRing from '../../../styles/interactions.module.css';
   resize: vertical;
   line-height: var(--line-height-relaxed);
   /* 84px: design literal, no --space-* token lands on it. */
@@ -236,8 +239,10 @@
    text link" pattern in this codebase), not the shared Button component,
    which always carries border/padding chrome the design's inline
    `.lnk`-style actions don't want here. */
+/* `focusRing` (interactions.module.css) is composed in JS rather than
+   via `composes:` here — see `.timeoutSpinner` above for the
+   shared-across-lazy-chunks rationale. */
 .textButton {
-  composes: focusRing from '../../../styles/interactions.module.css';
   padding: 0;
   font: inherit;
   font-size: 12.5px;

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -32,6 +32,8 @@ import type { Ingredient, Recipe, Step, Tag } from '@models/recipe'
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type FC } from 'react'
 import { useBlocker, useLocation, useNavigate, useParams } from 'react-router-dom'
 
+import interactions from '../../../styles/interactions.module.css'
+import text from '../../../styles/text.module.css'
 import { pluralize } from '../../../utils/pluralize'
 import styles from './RecipeEditor.module.css'
 
@@ -574,12 +576,21 @@ const RecipeEditor: FC = () => {
 
       {timedOut && (
         <div role="status" aria-live="polite" className={styles.timeoutBanner}>
-          <span className={styles.timeoutSpinner} aria-hidden="true" />
+          <span
+            className={`${interactions.spinner} ${interactions.spinnerSm} ${styles.timeoutSpinner}`}
+            aria-hidden="true"
+          />
           <span>Processing is taking longer than expected — try refreshing the page.</span>
         </div>
       )}
 
-      <Link to="/admin/recipes" icon="←" iconSide="left" nudge="left" className={styles.backLink}>
+      <Link
+        to="/admin/recipes"
+        icon="←"
+        iconSide="left"
+        nudge="left"
+        className={`${interactions.focusRing} ${text.metaText} ${styles.backLink}`}
+      >
         Back to recipes
       </Link>
 
@@ -609,7 +620,7 @@ const RecipeEditor: FC = () => {
                 type="text"
                 value={form.title}
                 onChange={(e) => setField('title', e.target.value)}
-                className={styles.input}
+                className={`${interactions.fieldFocusRing} ${styles.input}`}
               />
             </div>
 
@@ -630,7 +641,7 @@ const RecipeEditor: FC = () => {
                   setSlugError(null)
                   setField('slug', e.target.value)
                 }}
-                className={styles.input}
+                className={`${interactions.fieldFocusRing} ${styles.input}`}
               />
               <div className={styles.slugHintRow}>
                 <p id="recipe-slug-preview" className={styles.hint}>
@@ -640,7 +651,7 @@ const RecipeEditor: FC = () => {
                   <button
                     type="button"
                     onClick={() => dispatch({ type: 'RESET_SLUG_TO_TITLE' })}
-                    className={styles.textButton}
+                    className={`${interactions.focusRing} ${styles.textButton}`}
                   >
                     Reset to title
                   </button>
@@ -669,7 +680,7 @@ const RecipeEditor: FC = () => {
                 id="recipe-intro"
                 value={form.intro}
                 onChange={(e) => setField('intro', e.target.value)}
-                className={styles.textarea}
+                className={`${interactions.fieldFocusRing} ${styles.textarea}`}
               />
             </div>
           </section>
@@ -701,7 +712,7 @@ const RecipeEditor: FC = () => {
                   type="text"
                   value={form.coverImageAlt}
                   onChange={(e) => setField('coverImageAlt', e.target.value)}
-                  className={styles.input}
+                  className={`${interactions.fieldFocusRing} ${styles.input}`}
                 />
               </div>
             )}
@@ -719,7 +730,7 @@ const RecipeEditor: FC = () => {
                   type="number"
                   value={form.prepTime}
                   onChange={(e) => setField('prepTime', Number(e.target.value))}
-                  className={styles.input}
+                  className={`${interactions.fieldFocusRing} ${styles.input}`}
                 />
               </div>
               <div className={styles.field}>
@@ -731,7 +742,7 @@ const RecipeEditor: FC = () => {
                   type="number"
                   value={form.cookTime}
                   onChange={(e) => setField('cookTime', Number(e.target.value))}
-                  className={styles.input}
+                  className={`${interactions.fieldFocusRing} ${styles.input}`}
                 />
               </div>
               <div className={styles.field}>
@@ -743,7 +754,7 @@ const RecipeEditor: FC = () => {
                   type="number"
                   value={form.servings}
                   onChange={(e) => setField('servings', Number(e.target.value))}
-                  className={styles.input}
+                  className={`${interactions.fieldFocusRing} ${styles.input}`}
                 />
               </div>
             </div>

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -140,11 +140,13 @@
   gap: 7px;
 }
 
+/* `tagChipBase` (text.module.css) is composed in JS rather than via
+   `composes:` here, so Rollup can dedupe the shared rules across lazy
+   admin chunks — see `.actionButton` below for the same rationale. This
+   design's chip padding (3px 8px) is smaller than RecipeDetailView's tag
+   (5px 10px) — each `tagChipBase` consumer sets its own padding, per
+   that composable's own doc comment. */
 .tagChip {
-  composes: tagChipBase from '../../../styles/text.module.css';
-  /* This design's chip padding (3px 8px) is smaller than
-     RecipeDetailView's tag (5px 10px) — each `tagChipBase` consumer sets
-     its own padding, per that composable's own doc comment. */
   padding: 3px 8px;
   display: inline-block;
 }
@@ -166,17 +168,15 @@
   gap: 4px;
 }
 
-/* CSS Modules only allows `composes` on a rule with a single bare local
-   class selector, not a compound/descendant one — `composes` inside
-   `.rowActions .actionButton { ... }` fails the build entirely
-   ("composition is only allowed when selector is single :local class
-   name"). Split: the bare `.actionButton` class carries the composed
-   focusRing; the descendant-scoped rule below carries the specificity-tie
-   fix (same rationale as `.header .newButton` above) and everything else. */
-.actionButton {
-  composes: focusRing from '../../../styles/interactions.module.css';
-}
-
+/* `.actionButton` carries no CSS of its own — `focusRing`
+   (interactions.module.css) is composed in JS instead of via
+   `composes:`, so Rollup can dedupe the shared rules across lazy admin
+   chunks rather than inlining a full copy into each of
+   RecipeList/RecipeEditor/UserManagement's independently lazy-loaded
+   chunks (same rationale as stateBox.module.css, see that file's own
+   doc comment). The descendant-scoped rule below carries the
+   specificity-tie fix (same rationale as `.header .newButton` above)
+   and everything else. */
 .rowActions .actionButton {
   /* display/align-items/font-family are already inherited from Link's own
      `.link` for Edit/Preview, but the native Publish/Delete `<button>`s

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -141,11 +141,10 @@
 }
 
 /* `tagChipBase` (text.module.css) is composed in JS rather than via
-   `composes:` here, so Rollup can dedupe the shared rules across lazy
-   admin chunks — see `.actionButton` below for the same rationale. This
-   design's chip padding (3px 8px) is smaller than RecipeDetailView's tag
-   (5px 10px) — each `tagChipBase` consumer sets its own padding, per
-   that composable's own doc comment. */
+   `composes:` here — see text.module.css's own header comment for why.
+   This design's chip padding (3px 8px) is smaller than
+   RecipeDetailView's tag (5px 10px) — each `tagChipBase` consumer sets
+   its own padding, per that composable's own doc comment. */
 .tagChip {
   padding: 3px 8px;
   display: inline-block;
@@ -170,11 +169,8 @@
 
 /* `.actionButton` carries no CSS of its own — `focusRing`
    (interactions.module.css) is composed in JS instead of via
-   `composes:`, so Rollup can dedupe the shared rules across lazy admin
-   chunks rather than inlining a full copy into each of
-   RecipeList/RecipeEditor/UserManagement's independently lazy-loaded
-   chunks (same rationale as stateBox.module.css, see that file's own
-   doc comment). The descendant-scoped rule below carries the
+   `composes:` — see interactions.module.css's own header comment for
+   why. The descendant-scoped rule below carries the
    specificity-tie fix (same rationale as `.header .newButton` above)
    and everything else. */
 .rowActions .actionButton {

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -18,7 +18,9 @@ import type { Recipe } from '@models/recipe'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
+import interactions from '../../../styles/interactions.module.css'
 import stateBox from '../../../styles/stateBox.module.css'
+import text from '../../../styles/text.module.css'
 import { pluralize } from '../../../utils/pluralize'
 import { relativeUpdatedLabel } from '../../../utils/relativeTime'
 import styles from './RecipeList.module.css'
@@ -224,7 +226,7 @@ const RecipeList = () => {
                 </div>
                 <ul className={styles.rowMeta}>
                   {recipe.tags.map((tag) => (
-                    <li key={tag} className={styles.tagChip}>
+                    <li key={tag} className={`${text.tagChipBase} ${styles.tagChip}`}>
                       {tag}
                     </li>
                   ))}
@@ -236,7 +238,7 @@ const RecipeList = () => {
               <div className={styles.rowActions}>
                 <Link
                   to={`/admin/recipes/${recipe.id}/edit`}
-                  className={styles.actionButton}
+                  className={`${interactions.focusRing} ${styles.actionButton}`}
                   nudge="none"
                 >
                   {iconEdit}
@@ -244,7 +246,7 @@ const RecipeList = () => {
                 </Link>
                 <Link
                   to={`/admin/recipes/${recipe.id}/preview`}
-                  className={styles.actionButton}
+                  className={`${interactions.focusRing} ${styles.actionButton}`}
                   nudge="none"
                 >
                   {iconPreview}
@@ -252,7 +254,7 @@ const RecipeList = () => {
                 </Link>
                 <button
                   type="button"
-                  className={`${styles.actionButton} ${styles.publishAction}`}
+                  className={`${interactions.focusRing} ${styles.actionButton} ${styles.publishAction}`}
                   onClick={() => handlePublish(recipe)}
                 >
                   {isPublished ? iconUnpublish : iconPublish}
@@ -260,7 +262,7 @@ const RecipeList = () => {
                 </button>
                 <button
                   type="button"
-                  className={`${styles.actionButton} ${styles.deleteAction}`}
+                  className={`${interactions.focusRing} ${styles.actionButton} ${styles.deleteAction}`}
                   onClick={() => setDeleteTarget(recipe)}
                 >
                   {iconDelete}

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -60,8 +60,12 @@
   margin: 0;
 }
 
+/* `focusRing` (interactions.module.css) is composed in JS rather than
+   via `composes:` here, so Rollup can dedupe the shared rules across
+   lazy admin chunks instead of inlining a full copy into each of
+   RecipeList/RecipeEditor/UserManagement's independently lazy-loaded
+   chunks (same rationale as stateBox.module.css). */
 .closeButton {
-  composes: focusRing from '../../../styles/interactions.module.css';
   background: transparent;
   border: none;
   /* .inviteCard has a --color-surface background (issue #274). */
@@ -136,8 +140,8 @@
   gap: 2px;
 }
 
+/* `focusRing` composed in JS — see `.closeButton` above for rationale. */
 .roleOption {
-  composes: focusRing from '../../../styles/interactions.module.css';
   font-family: inherit;
   font-size: 13px;
   font-weight: var(--font-weight-medium);
@@ -209,9 +213,11 @@
   font-size: 14px;
 }
 
-.sendSpinner {
-  composes: spinner spinnerSm from '../../../styles/interactions.module.css';
-}
+/* The invite-submit spinner composes `spinner`/`spinnerSm`
+   (interactions.module.css) directly in JS instead of via a local
+   `.sendSpinner` class — see `.closeButton` above for rationale; no
+   local declarations were needed here beyond the composed ones, so
+   there's no local class left to carry. */
 
 /* ── User row list ────────────────────────────────────────────────
    `<ul>/<li>`, not `<table>` — matches the established pattern from
@@ -291,9 +297,10 @@
 /* Static "You" label — composes the shared mono-chip look (not the
    interactive Tag component, which carries button/active/removable
    machinery this static badge doesn't need) exactly like RecipeList
-   .module.css's own `.tagChip` does. */
+   .module.css's own `.tagChip` does. `tagChipBase` (text.module.css) is
+   composed in JS rather than via `composes:` here — see `.closeButton`
+   above for the shared-across-lazy-chunks rationale. */
 .selfTag {
-  composes: tagChipBase from '../../../styles/text.module.css';
   font-size: 10px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -345,11 +352,10 @@
 
 /* Matches RecipeList.module.css's `.rowActions .actionButton`/
    `.deleteAction` ("act" button) pattern exactly — small icon+text button,
-   neutral by default, danger tint on hover. */
-.removeAction {
-  composes: focusRing from '../../../styles/interactions.module.css';
-}
-
+   neutral by default, danger tint on hover. `.removeAction` carries no
+   CSS of its own — `focusRing` (interactions.module.css) is composed in
+   JS instead of via `composes:` — see `.closeButton` above for the
+   shared-across-lazy-chunks rationale. */
 .rowActionSlot .removeAction {
   display: inline-flex;
   align-items: center;

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -61,10 +61,8 @@
 }
 
 /* `focusRing` (interactions.module.css) is composed in JS rather than
-   via `composes:` here, so Rollup can dedupe the shared rules across
-   lazy admin chunks instead of inlining a full copy into each of
-   RecipeList/RecipeEditor/UserManagement's independently lazy-loaded
-   chunks (same rationale as stateBox.module.css). */
+   via `composes:` here — see interactions.module.css's own header
+   comment for why. */
 .closeButton {
   background: transparent;
   border: none;

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -13,7 +13,9 @@ import type { AdminRole, AdminUser } from '@models/auth'
 import { useCallback, useEffect, useId, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import interactions from '../../../styles/interactions.module.css'
 import stateBox from '../../../styles/stateBox.module.css'
+import text from '../../../styles/text.module.css'
 import styles from './UserManagement.module.css'
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -193,7 +195,7 @@ const UserManagement = () => {
               </Typography>
               <button
                 type="button"
-                className={styles.closeButton}
+                className={`${interactions.focusRing} ${styles.closeButton}`}
                 onClick={resetInviteForm}
                 aria-label="Close"
               >
@@ -239,7 +241,7 @@ const UserManagement = () => {
                     <button
                       key={role}
                       type="button"
-                      className={styles.roleOption}
+                      className={`${interactions.focusRing} ${styles.roleOption}`}
                       aria-pressed={inviteRole === role}
                       onClick={() => setInviteRole(role)}
                     >
@@ -267,7 +269,10 @@ const UserManagement = () => {
                     className={styles.formActionButton}
                     iconLeft={
                       inviteSubmitting ? (
-                        <span className={styles.sendSpinner} aria-hidden="true" />
+                        <span
+                          className={`${interactions.spinner} ${interactions.spinnerSm}`}
+                          aria-hidden="true"
+                        />
                       ) : undefined
                     }
                   >
@@ -295,7 +300,9 @@ const UserManagement = () => {
                   </span>
                   <div className={styles.rowIdentity}>
                     <span className={styles.rowEmail}>{userRow.email}</span>
-                    {isSelf && <span className={styles.selfTag}>You</span>}
+                    {isSelf && (
+                      <span className={`${text.tagChipBase} ${styles.selfTag}`}>You</span>
+                    )}
                   </div>
                 </div>
                 <div className={styles.rowMeta}>
@@ -314,7 +321,7 @@ const UserManagement = () => {
                     {!isSelf && (
                       <button
                         type="button"
-                        className={styles.removeAction}
+                        className={`${interactions.focusRing} ${styles.removeAction}`}
                         onClick={() => setRemoveTarget(userRow)}
                         title="Remove user"
                       >

--- a/src/styles/interactions.module.css
+++ b/src/styles/interactions.module.css
@@ -19,7 +19,26 @@
    no `backdrop-filter` `@supports` fallback here: nothing in scope today
    uses `backdrop-filter` (the sticky header's blur, and its solid-bg
    fallback, land with the Header rebuild in issue #224) — see the note
-   above `.focusRing` for the fallback pattern to reuse when that lands. */
+   above `.focusRing` for the fallback pattern to reuse when that lands.
+
+   `composes: x from` inlines this file's rules as literal text into the
+   composing file at CSS-transform time (ICSS import semantics) — there is
+   no bundler-chunk-addressable module for the composed portion, since this
+   file has no JS import of its own. That's harmless for a consumer that's
+   part of a chunk Rollup already treats as shared (an eagerly-loaded file,
+   or the sole lazy chunk that ever needs it) — one inlined copy, same as
+   any other CSS. It becomes a real bug when two or more consumers are each
+   independently `lazy()`-loaded with no eager common ancestor: every rule
+   this file contributes gets duplicated verbatim into each of those
+   separate chunks. When adding a new consumer, check whether it lands in
+   that situation; if so, don't `composes` from this file — import it
+   directly as a real JS module in the consumer's own `.tsx` and compose
+   classNames at render time instead (`import interactions from
+   '.../interactions.module.css'`, then e.g. `` `${interactions.focusRing}
+   ${styles.button}` ``), which gives Rollup a genuine shared module to
+   hoist into its own chunk. See RecipeList/RecipeEditor/UserManagement/
+   Card for the JS-import pattern, and Button/Link/Header for consumers
+   correctly left on `composes:` because they don't hit this. */
 
 /* ── Links — icon nudge ──────────────────────────────────────
    Apply `linkIcon` to the icon element, and one direction class to the

--- a/src/styles/text.module.css
+++ b/src/styles/text.module.css
@@ -3,7 +3,14 @@
    `composes: x from '../../styles/interactions.module.css'` pattern used
    for interaction utilities (see interactions.module.css) — consuming
    files `composes` from here (relative path from a page two levels down
-   in src/pages/<Name>/) rather than duplicating the declarations. */
+   in src/pages/<Name>/) rather than duplicating the declarations.
+
+   Same lazy-chunk-duplication caveat as interactions.module.css: when a
+   new consumer is one of two or more independently `lazy()`-loaded
+   chunks with no eager common ancestor, `composes` here duplicates this
+   file's rules per chunk instead of sharing them — import this file
+   directly as a JS module and compose classNames in JS instead. See
+   interactions.module.css's own header comment for the full rationale. */
 
 /* Mono, uppercase, tracked, faint — section/hero kicker text. Pair with
    `Typography` (e.g. `variant="caption" as="p"` or `as="h2"` for an


### PR DESCRIPTION
Closes #305

## What changed
Audited `interactions.module.css`, `text.module.css`, `formField.module.css` for the same CSS-Modules-`composes`-across-lazy-chunks duplication bug found (and fixed) in #296.

- **`interactions.module.css` / `text.module.css`: confirmed at risk, fixed.** `RecipeList`, `RecipeEditor`, `UserManagement` (all independently lazy, no eager common ancestor) and `Card` (used only by lazy `Login`) all composed from these files with no bundler-addressable shared module for the composed portion. Converted every `composes: X from interactions.module.css` / `composes: Y from text.module.css` in 7 components (AutosaveStatus, Card, ImageUpload, IngredientList, StepList, TagInput, Textarea) and 3 admin pages (RecipeEditor, RecipeList, UserManagement) to direct JS imports + JS-composed classNames, matching #296's pattern.
- **`formField.module.css`: audited, confirmed not at risk, no change made.** Its only consumers (Input, TagInput, Textarea) either have an eager ancestor (Input, via RecipeSearch) or land in a single shared lazy chunk (TagInput + Textarea, both only in RecipeEditor) — never split across 2+ separate lazy chunks, so there's no cross-chunk duplication to fix.

## Why
Per #296's own "Out of scope" note, this closes the gap for the other shared/composed CSS modules rather than leaving each rediscovered independently.

## How to verify
`pnpm build:client`, then check `dist/client/assets/*.css`. `interactions.module.css`/`text.module.css`'s rules now emit in two dedicated shared chunks (referenced by 8 different JS chunks — RecipeList, RecipeEditor, UserManagement, Login, etc.), and no longer appear in any individual lazy admin/Login chunk. Verified independently by the orchestrator with two separate fresh builds (before and after the /simplify cleanup commit), using each file's unique CSS-Modules hash suffix rather than coincidental class-name substrings.

## Decisions made

**`formField.module.css` "half-fixed" concern, investigated and ruled out.** `/simplify`'s altitude pass raised a plausible-sounding concern: TagInput and Textarea both still `composes: field from formField.module.css`, seemingly the identical bug pattern left unfixed. Verified empirically with a real build: `formField`'s `.field` rule (identified via its distinctive `--input-bg` custom property) appears **exactly once** in RecipeEditor's own compiled chunk, even though both TagInput.module.css and Textarea.module.css independently inline it. This is because TagInput and Textarea land in the *same single* lazy chunk (not split across separate ones) — Rollup's CSS bundler collapses the two byte-identical inlined copies within that one output file, which minification can do within a file but never across separate chunk boundaries. This is a structurally different situation from stateBox/interactions/text's original bug, and matches the audit's own AC allowance for modules "never split into separate lazy chunks." No code change was needed.

**Comment duplication.** `/simplify` found the "why JS-import instead of composes" rationale was restated nearly verbatim across ~10 files. Consolidated into a single canonical explanation in `interactions.module.css`/`text.module.css`'s own header comments; the 10 per-file comments now just point to it.

**Efficiency.** `/simplify` found `IngredientList.tsx`/`StepList.tsx` were rebuilding static per-row action-button classNames inside `.map()` on every render. Hoisted to module-level constants.

## Out of scope
None — no follow-up issues were filed. All `/simplify` findings were either applied inline (comment consolidation, classList hoisting) or investigated and found to be non-issues (formField.module.css).