### PR TITLE
Extract shared isExternalHref classification; consider Tag composing Link

### DIFF
--- a/src/components/AppCard/AppCard.tsx
+++ b/src/components/AppCard/AppCard.tsx
@@ -4,6 +4,7 @@ import Tag from '@components/Tag'
 import Typography from '@components/Typography'
 import type { FC } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
+import { isExternalHref } from '../../utils/url'
 import styles from './AppCard.module.css'
 
 export interface AppCardProps {
@@ -13,9 +14,6 @@ export interface AppCardProps {
   image: ImageProps
   tag?: string
 }
-
-const isExternalHref = (href: string) =>
-  /^https?:\/\//.test(href) || href.startsWith('mailto:') || href.startsWith('tel:')
 
 const AppCard: FC<AppCardProps> = ({ title, description, href, image, tag }) => {
   const content = (

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,5 +1,6 @@
 import { FC, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
+import { isExternalHref } from '../../utils/url'
 import styles from './Link.module.css'
 
 export interface LinkProps {
@@ -39,8 +40,7 @@ const Link: FC<LinkProps> = ({
   ariaLabel,
   className: externalClassName,
 }) => {
-  const isExternal =
-    /^https?:\/\//.test(to) || to.startsWith('mailto:') || to.startsWith('tel:')
+  const isExternal = isExternalHref(to)
 
   const className = [
     styles.link,

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, FC, MouseEvent, ReactNode } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
+import { isExternalHref } from '../../utils/url'
 import styles from './Tag.module.css'
 
 interface TagBaseProps {
@@ -63,10 +64,8 @@ const Tag: FC<TagProps> = (props) => {
 
   if (props.as === 'a') {
     const href = props.to
-    const isExternal =
-      /^https?:\/\//.test(href) || href.startsWith('mailto:') || href.startsWith('tel:')
 
-    if (isExternal) {
+    if (isExternalHref(href)) {
       return (
         <a
           href={href}

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,0 +1,19 @@
+import { isExternalHref } from './url'
+
+describe('isExternalHref', () => {
+  it('treats http(s) URLs as external', () => {
+    expect(isExternalHref('https://example.com')).toBe(true)
+  })
+
+  it('treats mailto: links as external', () => {
+    expect(isExternalHref('mailto:hello@akli.dev')).toBe(true)
+  })
+
+  it('treats tel: links as external', () => {
+    expect(isExternalHref('tel:+15555555555')).toBe(true)
+  })
+
+  it('treats relative paths as internal', () => {
+    expect(isExternalHref('/apps')).toBe(false)
+  })
+})

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,3 @@
+/** `isExternalHref('https://example.com')` -> `true`; `isExternalHref('/apps')` -> `false`. */
+export const isExternalHref = (href: string): boolean =>
+  /^https?:\/\//.test(href) || href.startsWith('mailto:') || href.startsWith('tel:')


### PR DESCRIPTION
Closes #288

## What changed
Extracted `isExternalHref(href: string): boolean` to `src/utils/url.ts` (with tests) and updated `Link.tsx`, `AppCard.tsx`, `Tag.tsx` to import it, removing their three independent copies of the same external-vs-internal URL regex.

## Why
The classification determines security-relevant behavior (`target="_blank" rel="noreferrer"` vs. internal routing) — three independently-maintained copies was a real drift risk for a future policy change (new protocol, different `rel` value).

## How to verify
`pnpm test` — 790/790 pass, including `Link.test.tsx`/`AppCard.test.tsx`/`Tag.test.tsx` unmodified. `grep -rn "https?:\\/\\/" src` shows the regex now lives only in `src/utils/url.ts`.

## Decisions made

**Link-composition question, evaluated and not implemented (per the issue's own "otherwise document why not" allowance):**
- `Tag`'s `as="a"` branch takes `onClick`/`style` props `Link`'s `LinkProps` interface doesn't expose at all, and builds its className from an entirely separate visual system (`styles.tag`/`active`) versus `Link`'s tone/variant/nudge/underline machinery. Composing would mean bloating `Link`'s prop surface solely for `Tag`'s chip use case while suppressing all its own opinionated classes — a worse trade-off than the small, symmetrical branch duplication that remains.
- `AppCard` wraps a multi-element layout (decorative image, optional `Tag` chip, title+arrow row, description) inside `<article>` — `Link`'s children/icon-based API has no equivalent for this structure.

Both cases keep their own `<a>`/`RouterLink` branching, now calling the shared classification instead of re-implementing it.

## Out of scope
None — no follow-ups filed. This is a small, self-contained extraction.