### PR TITLE
Centralize repeated success/warning-on-tint override colors into shared tokens

### DIFF
--- a/src/components/Callout/Callout.module.css
+++ b/src/components/Callout/Callout.module.css
@@ -47,16 +47,11 @@
 /* WCAG AA override (issue #272): --color-success on this tint (6%
    color-mix into --color-surface — an even lighter wash than
    StatusBadge's 10% alpha pill) computes to ~3.59:1, worse than the
-   failing 3.68:1 StatusBadge (#267) case. Reusing that issue's exact
-   override color here (~4.70:1 against this backdrop) for consistency.
-   Dark mode already passes (~7.10:1), so it resets to the shared token. */
+   failing 3.68:1 StatusBadge (#267) case. Uses the shared
+   --color-success-on-tint token, same override color StatusBadge uses,
+   for consistency — it already resolves correctly per theme. */
 .tip .label {
-  --callout-tip-fg: #1a754d; /* ~4.70:1 */
-  color: var(--callout-tip-fg);
-}
-
-[data-theme="dark"] .tip .label {
-  --callout-tip-fg: var(--color-success);
+  color: var(--color-success-on-tint);
 }
 
 .warning {
@@ -65,17 +60,12 @@
 }
 
 /* WCAG AA override (issue #272): same pattern as `.tip .label` above but
-   for --color-warning — this 6% tint computes to ~3.58:1 (fails AA).
-   Reusing StatusBadge's (#267) exact warning override color (~4.85:1
-   against this backdrop). Dark mode already passes (~7.38:1), so it
-   resets to the shared token. */
+   for --color-warning — this 6% tint computes to ~3.58:1 (fails AA). Uses
+   the shared --color-warning-on-tint token, same override color
+   StatusBadge (#267) uses, for consistency — it already resolves
+   correctly per theme. */
 .warning .label {
-  --callout-warning-fg: #8c5a08; /* ~4.85:1 */
-  color: var(--callout-warning-fg);
-}
-
-[data-theme="dark"] .warning .label {
-  --callout-warning-fg: var(--color-warning);
+  color: var(--color-warning-on-tint);
 }
 
 .info {

--- a/src/components/StatusBadge/StatusBadge.module.css
+++ b/src/components/StatusBadge/StatusBadge.module.css
@@ -24,27 +24,16 @@
 
 /* WCAG AA override (issue #267): --color-success/--color-warning on their
    pill backgrounds compute to ~3.68:1/~3.66:1 (fail AA's 4.5:1 for normal
-   text). Each is darkened via a component-local custom property, scoped to
-   StatusBadge only — see issue for why the shared tokens aren't changed.
-   Dark mode already passes for both, so it resets to the shared token. */
+   text). Uses the shared --color-success-on-tint/--color-warning-on-tint
+   tokens, which already resolve correctly per theme. */
 .success {
-  --status-success-fg: #1a754d; /* ~4.83:1 */
-  color: var(--status-success-fg);
+  color: var(--color-success-on-tint);
   background: var(--color-success-bg);
 }
 
-[data-theme="dark"] .success {
-  --status-success-fg: var(--color-success);
-}
-
 .warning {
-  --status-warning-fg: #8c5a08; /* ~4.96:1 */
-  color: var(--status-warning-fg);
+  color: var(--color-warning-on-tint);
   background: var(--color-warning-bg);
-}
-
-[data-theme="dark"] .warning {
-  --status-warning-fg: var(--color-warning);
 }
 
 .error {

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -84,20 +84,14 @@
    composited over this Toast's own --color-bg backdrop, computes to
    ~3.68:1 (fails AA's 4.5:1 for normal text) — the glyph is text content,
    not decorative, so this is a live failure, not just a hover-state blind
-   spot. Same failing token pairing StatusBadge (#267) hit; reusing its
-   exact override color here (~4.83:1 against this backdrop) rather than
-   tuning a new one, for visual consistency across "success text on its
-   own tint" everywhere in the app. Dark mode already passes (~6.87:1), so
-   it resets to the shared token. */
+   spot. Uses the shared --color-success-on-tint token, same override
+   color StatusBadge (#267) uses, for visual consistency across "success
+   text on its own tint" everywhere in the app — the token already
+   resolves correctly per theme. */
 .success::before {
   content: '✓';
   background: var(--color-success-bg);
-  --toast-success-fg: #1a754d; /* ~4.83:1 */
-  color: var(--toast-success-fg);
-}
-
-[data-theme="dark"] .success::before {
-  --toast-success-fg: var(--color-success);
+  color: var(--color-success-on-tint);
 }
 
 .error::before {

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -210,21 +210,16 @@
 /* WCAG AA override (issue #272): --color-success on --color-success-bg,
    composited over this row's --color-field backdrop, computes to ~3.83:1
    (fails AA's 4.5:1) — axe doesn't probe :hover states, which is likely
-   why this wasn't already flagged. Same failing pairing as StatusBadge
-   (#267); reusing its exact override color for consistency. Note
-   .row:hover also fires here (hovering a child hovers its ancestor),
-   layering --color-hover under this button's own background, which
-   brings the real margin to ~4.80:1 (not the ~5.01:1 you'd get against
-   --color-field alone) — still comfortably passes. Dark mode already
-   passes (~6.40:1), so it resets to the shared token. */
+   why this wasn't already flagged. Uses the shared --color-success-on-tint
+   token, same override color StatusBadge (#267) uses, for consistency.
+   Note .row:hover also fires here (hovering a child hovers
+   its ancestor), layering --color-hover under this button's own
+   background — accounting for that stacked hover, the token's value still
+   comfortably passes (not just against --color-field alone). The token
+   already resolves correctly per theme. */
 .rowActions .publishAction:hover {
-  --publish-action-fg: #1a754d; /* ~4.80:1, accounting for stacked .row:hover */
-  color: var(--publish-action-fg);
+  color: var(--color-success-on-tint);
   background: var(--color-success-bg);
-}
-
-[data-theme="dark"] .rowActions .publishAction:hover {
-  --publish-action-fg: var(--color-success);
 }
 
 .rowActions .deleteAction:hover {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -97,6 +97,15 @@
   --color-warning-bg:    rgba(194,129,12,0.12);
   --color-error:         #C0392B;
   --color-error-bg:      rgba(192,57,43,0.07);
+  /* WCAG AA override: --color-success/--color-warning on their own tint
+     backgrounds (pills, toasts, callouts, hover states) fall short of
+     4.5:1 in light mode — darkened for that specific "status text on its
+     own tint" pairing. Consolidates what were 5 identical component-local
+     overrides (StatusBadge, Toast, RecipeList, Callout ×2 — issues #267
+     and #272) into one shared token. Dark mode never needed the
+     correction, so it just resolves to the existing token there. */
+  --color-success-on-tint: #1a754d;   /* ~4.7–4.96:1 depending on consumer backdrop */
+  --color-warning-on-tint: #8c5a08;   /* ~4.85–4.96:1 depending on consumer backdrop */
 
   /* ── Short working aliases (used across pages + UI kits) ──── */
   --bg:         var(--color-bg);
@@ -225,4 +234,6 @@
   --color-warning-bg:    rgba(224,169,59,0.14);
   --color-error:         #E8786B;
   --color-error-bg:      rgba(232,120,107,0.12);
+  --color-success-on-tint: var(--color-success);
+  --color-warning-on-tint: var(--color-warning);
 }


### PR DESCRIPTION
Closes #276

## What changed
Added `--color-success-on-tint`/`--color-warning-on-tint` to `tokens.css` (`:root`: `#1a754d`/`#8c5a08`; `[data-theme="dark"]`: resolves to the existing `--color-success`/`--color-warning`). Updated the 5 existing sites that each hardcoded this same hex pair as their own component-local custom property — `StatusBadge` (`.success`/`.warning`), `Toast` (`.success::before`), `RecipeList` (`.rowActions .publishAction:hover`), `Callout` (`.tip .label`/`.warning .label`) — to reference the shared token directly, removing the now-redundant per-component custom properties and their `[data-theme="dark"]` reset rules.

## Why
Per #272's own AC, once the same WCAG-override value crossed 5 instances across 4 files, it warranted a shared token instead of 5 independently-maintained copies linked only by a comment convention.

## How to verify
Pure value substitution — `pnpm test` (790/790 pass), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean). No visual change: light mode resolves to the byte-identical hex; dark mode resolves to `var(--color-success)`/`var(--color-warning)`, exactly what each removed per-component dark reset already produced.

## Decisions made
Confirmed (via full-file reads + repo-wide grep) that all 6 local custom properties being removed (`--status-success-fg`, `--status-warning-fg`, `--toast-success-fg`, `--publish-action-fg`, `--callout-tip-fg`, `--callout-warning-fg`) were each used only once, solely by their own defining rule — no descendant inheritance, so safe to delete outright rather than keep as a local alias.

## Out of scope
None — no follow-ups filed.