### PR TITLE
Migrate RecipeEditor's loadingBox to the shared stateBox pattern

### DIFF
--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -9,14 +9,13 @@
   box-sizing: border-box;
 }
 
+/* Shared box shape from stateBox.module.css. stateBox is imported directly
+   in RecipeEditor.tsx and composed in JS rather than via `composes:` here,
+   so Rollup can dedupe the shared rules across lazy admin chunks — see
+   stateBox.module.css's own header comment for why. */
 .loadingBox {
   border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-xl);
   padding: clamp(64px, 12vw, 120px) 24px;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 }
 
 /* ── Banners ─────────────────────────────────────────────────────── */

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -33,6 +33,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef, useState, type FC 
 import { useBlocker, useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import interactions from '../../../styles/interactions.module.css'
+import stateBox from '../../../styles/stateBox.module.css'
 import text from '../../../styles/text.module.css'
 import { pluralize } from '../../../utils/pluralize'
 import styles from './RecipeEditor.module.css'
@@ -546,7 +547,7 @@ const RecipeEditor: FC = () => {
   if (loading || (isNewPath && !form.id && !sessionExpired)) {
     return (
       <div className={styles.container}>
-        <div className={styles.loadingBox}>
+        <div className={`${stateBox.box} ${styles.loadingBox}`}>
           <Loading label="Loading recipe…" />
         </div>
       </div>


### PR DESCRIPTION
Closes #295

## What changed
`RecipeEditor.module.css`'s `.loadingBox` hand-rolled the same flex-column/centered/`radius-xl` shape `stateBox.module.css`'s `.box` already centralizes — a 4th independent copy #269's original audit missed. Now composes `stateBox.box` in JS, keeping only its genuinely distinct `border`/`padding` as a local override.

## Why
Closes the gap `stateBox.module.css`'s own comment ("hand-rolled three times") didn't account for — this instance existed all along, just outside #269's named scope.

## How to verify
`pnpm build:client`, then check `dist/client/assets/*.css` — `stateBox`'s `.box` rule (identified via its unique hash) appears in exactly one file, the existing dedicated shared chunk, confirmed both by the implementing pass and independently re-verified by the orchestrator with a fresh build.

## Decisions made

**AC1 deviation, matching already-merged precedent.** The issue's AC literally specifies `composes: box from '.../stateBox.module.css'`. Not followed: `stateBox.module.css` has no JS-level import of its own, so `composes:` inlines its rules as literal text per-consumer at CSS-transform time (no bundler-chunk-addressable module). `RecipeEditor` is independently `lazy()`-loaded with no eager ancestor shared with `RecipeList`/`UserManagement`/`RecipePreview` — the exact condition issue #296 (already merged into this branch) found causes duplication across separate lazy chunks. Following the literal AC would have reintroduced that same bug as a 4th instance. Used the JS-level import + JS-composed className pattern instead, matching `RecipeList.tsx`/`UserManagement.tsx`'s already-established, already-merged approach.

## Out of scope
None — no follow-ups filed.