### PR TITLE
Extend measured-height mechanism to RecipePreview's sticky status banner

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,7 +1,8 @@
 import Button from '@components/Button'
 import ThemeToggle from '@components/ThemeToggle'
+import { useMeasuredHeightVar } from '@hooks/useMeasuredHeightVar'
 import type { FC } from 'react'
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import { Link as RouterLink, useLocation } from 'react-router-dom'
 import styles from './Header.module.css'
 
@@ -41,37 +42,8 @@ const Header: FC<HeaderProps> = ({
 }) => {
   const { pathname } = useLocation()
   const headerRef = useRef<HTMLElement>(null)
-  const lastHeightRef = useRef<number | null>(null)
 
-  useEffect(() => {
-    const element = headerRef.current
-    if (!element) return
-
-    // entry.borderBoxSize, not getBoundingClientRect() — borderBoxSize is by
-    // definition the content+padding+border box, so it already includes the
-    // header's border-block-end without forcing a synchronous layout read on
-    // every firing (getBoundingClientRect() falls back for the handful of
-    // older engines that don't support borderBoxSize). Also re-fires on wrap
-    // (single row -> two rows on narrow viewports), so --header-height stays
-    // accurate for consumers like PageShell/AdminLayout's
-    // scroll-margin-block-start without them needing wrap-aware media
-    // queries. The rounded height is cached so sub-pixel jitter mid-resize
-    // doesn't trigger redundant writes — every setProperty ripples a
-    // style/layout recalc out to those consumers, not just the header.
-    const observer = new ResizeObserver((entries) => {
-      const [entry] = entries
-      const height = entry.borderBoxSize?.[0]?.blockSize ?? entry.target.getBoundingClientRect().height
-      const roundedHeight = Math.round(height)
-
-      if (roundedHeight === lastHeightRef.current) return
-
-      lastHeightRef.current = roundedHeight
-      document.documentElement.style.setProperty('--header-height', `${roundedHeight}px`)
-    })
-    observer.observe(element)
-
-    return () => observer.disconnect()
-  }, [])
+  useMeasuredHeightVar(headerRef, '--header-height')
 
   const className = [
     styles.header,

--- a/src/hooks/useMeasuredHeightVar.test.ts
+++ b/src/hooks/useMeasuredHeightVar.test.ts
@@ -1,0 +1,105 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMeasuredHeightVar } from './useMeasuredHeightVar'
+
+// The shared MockResizeObserver in tests/setup.ts fires its callback exactly
+// once, synchronously, from `observe()` — it can't simulate a second resize.
+// This local mock captures the callback so tests can fire it repeatedly with
+// controlled entries.
+class ControllableResizeObserver {
+  static instances: ControllableResizeObserver[] = []
+  callback: ResizeObserverCallback
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    ControllableResizeObserver.instances.push(this)
+  }
+
+  fire(entry: Partial<ResizeObserverEntry>) {
+    this.callback([entry as ResizeObserverEntry], this as unknown as ResizeObserver)
+  }
+}
+
+const originalResizeObserver = window.ResizeObserver
+
+const makeEntry = (blockSize: number, element: Element): Partial<ResizeObserverEntry> => ({
+  target: element,
+  borderBoxSize: [{ blockSize, inlineSize: 0 } as ResizeObserverSize],
+})
+
+beforeEach(() => {
+  ControllableResizeObserver.instances = []
+  window.ResizeObserver = ControllableResizeObserver as unknown as typeof ResizeObserver
+})
+
+afterEach(() => {
+  window.ResizeObserver = originalResizeObserver
+  document.documentElement.style.removeProperty('--test-height')
+  vi.restoreAllMocks()
+})
+
+describe('useMeasuredHeightVar', () => {
+  it('sets the CSS custom property on document.documentElement when the observed element resizes', () => {
+    const element = document.createElement('div')
+    const ref = { current: element }
+
+    renderHook(() => useMeasuredHeightVar(ref, '--test-height'))
+
+    const [observer] = ControllableResizeObserver.instances
+    act(() => {
+      observer.fire(makeEntry(48, element))
+    })
+
+    expect(document.documentElement.style.getPropertyValue('--test-height')).toBe('48px')
+  })
+
+  it('skips the write when a later firing rounds to the same height (caching)', () => {
+    const element = document.createElement('div')
+    const ref = { current: element }
+
+    renderHook(() => useMeasuredHeightVar(ref, '--test-height'))
+
+    const [observer] = ControllableResizeObserver.instances
+    const setPropertySpy = vi.spyOn(document.documentElement.style, 'setProperty')
+
+    act(() => {
+      observer.fire(makeEntry(48, element))
+    })
+    expect(setPropertySpy).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      observer.fire(makeEntry(48.2, element)) // rounds to the same 48px — no redundant write
+    })
+    expect(setPropertySpy).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      observer.fire(makeEntry(60, element))
+    })
+    expect(setPropertySpy).toHaveBeenCalledTimes(2)
+    expect(document.documentElement.style.getPropertyValue('--test-height')).toBe('60px')
+  })
+
+  it('disconnects the observer on unmount', () => {
+    const element = document.createElement('div')
+    const ref = { current: element }
+
+    const { unmount } = renderHook(() => useMeasuredHeightVar(ref, '--test-height'))
+    const [observer] = ControllableResizeObserver.instances
+
+    unmount()
+
+    expect(observer.disconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when the ref is not yet attached to an element', () => {
+    const ref = { current: null }
+
+    renderHook(() => useMeasuredHeightVar(ref, '--test-height'))
+
+    expect(ControllableResizeObserver.instances).toHaveLength(0)
+  })
+})

--- a/src/hooks/useMeasuredHeightVar.ts
+++ b/src/hooks/useMeasuredHeightVar.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef, type RefObject } from 'react'
+
+// Writes an element's live-measured border-box height to a CSS custom
+// property on the document root via ResizeObserver, so consumers (e.g.
+// `scroll-margin-block-start` on a landmark that sits below a sticky
+// element) can track the element's real rendered size instead of a
+// hand-tuned token approximation.
+export const useMeasuredHeightVar = (
+  ref: RefObject<HTMLElement | null>,
+  propertyName: string
+): void => {
+  const lastHeightRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    // entry.borderBoxSize, not getBoundingClientRect() — borderBoxSize is by
+    // definition the content+padding+border box, so it already includes the
+    // element's border-block-end without forcing a synchronous layout read on
+    // every firing (getBoundingClientRect() falls back for the handful of
+    // older engines that don't support borderBoxSize). Also re-fires on wrap
+    // (e.g. single row -> two rows on narrow viewports), so the custom
+    // property stays accurate for consumers like
+    // scroll-margin-block-start without them needing wrap-aware media
+    // queries. The rounded height is cached so sub-pixel jitter mid-resize
+    // doesn't trigger redundant writes — every setProperty ripples a
+    // style/layout recalc out to those consumers, not just the observed
+    // element.
+    const observer = new ResizeObserver((entries) => {
+      const [entry] = entries
+      const height = entry.borderBoxSize?.[0]?.blockSize ?? entry.target.getBoundingClientRect().height
+      const roundedHeight = Math.round(height)
+
+      if (roundedHeight === lastHeightRef.current) return
+
+      lastHeightRef.current = roundedHeight
+      document.documentElement.style.setProperty(propertyName, `${roundedHeight}px`)
+    })
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [ref, propertyName])
+}

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -180,19 +180,17 @@
 
 /* Applied only to the loaded-recipe state's `.main`, where the sticky
    status banner precedes it in normal flow. SC 2.4.11: reserves room
-   above the landmark roughly equal to the banner's own rendered height
-   (measured ~64.5px: 13px block padding either side + the 32px
-   ThemeToggle icon-button plus border), so the banner — pinned via
-   `position: sticky` — never fully covers focus/scroll landing here or
-   on a near-top descendant. `--space-16` (64px) is the same token
-   Layout.module.css/AdminLayout.module.css already use for this exact
-   purpose, sized for Header instead — coincidentally near-identical here.
-   The loading/not-found states render no banner above them at all (Admin
+   above the landmark equal to the banner's live-measured rendered height
+   (`--banner-height`, kept in sync by a ResizeObserver on the banner
+   element — same live-measurement pattern as Header's --header-height),
+   so the banner — pinned via `position: sticky` — never fully covers
+   focus/scroll landing here or on a near-top descendant. The
+   loading/not-found states render no banner above them at all (Admin
    Recipe Preview.dc.html gates the banner behind the same `isRecipe`
    check as the loaded article), so plain `.main` alone is correct there —
    there is nothing sticky left to obscure. */
 .mainWithBanner {
-  scroll-margin-block-start: var(--space-16);
+  scroll-margin-block-start: var(--banner-height);
 }
 
 .stateWrapper {

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -12,8 +12,9 @@ import {
   useImageProcessingPoll,
   type ImageReadyUpdate,
 } from '@hooks/useImageProcessingPoll'
+import { useMeasuredHeightVar } from '@hooks/useMeasuredHeightVar'
 import { applyStepReadiness, type Recipe } from '@models/recipe'
-import { useCallback, useEffect, useMemo, useState, type FC } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type FC } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { MAIN_LANDMARK_ID } from '../../../constants/mainLandmark'
@@ -121,6 +122,9 @@ const RecipePreview: FC = () => {
   const { id } = useParams<{ id: string }>()
   const { getAccessToken, logout } = useAuth()
   const navigate = useNavigate()
+  const bannerRef = useRef<HTMLDivElement>(null)
+
+  useMeasuredHeightVar(bannerRef, '--banner-height')
 
   const [recipe, setRecipe] = useState<Recipe | undefined>()
   const [loading, setLoading] = useState(true)
@@ -228,6 +232,7 @@ const RecipePreview: FC = () => {
   return (
     <div className={styles.container}>
       <div
+        ref={bannerRef}
         className={[styles.banner, bannerToneClassName].join(' ')}
         role="status"
         aria-live="polite"


### PR DESCRIPTION
Closes #290

## What changed
Extracted `Header.tsx`'s `ResizeObserver` → CSS-custom-property measurement effect into a reusable `useMeasuredHeightVar(ref, propertyName)` hook (`src/hooks/useMeasuredHeightVar.ts`, with tests). `Header.tsx` now consumes it for `--header-height` (pure extraction). `RecipePreview.tsx`'s sticky status banner now uses it for a new `--banner-height`, and `RecipePreview.module.css`'s `.mainWithBanner` consumes `var(--banner-height)` instead of the static `var(--space-16)` approximation.

## Why
`--space-16` (64px) was a coincidental near-match for the banner's real ~64.5px rendered height — the same class of silent-drift bug #249 fixed for Header's scroll-margin, just not yet applied to RecipePreview's own sticky element.

## How to verify
`pnpm test` — 794/794 pass, including `Header.test.tsx`'s existing `--header-height` test passing unmodified (confirming the extraction is behavior-preserving) and the new hook's 4 tests (property write on resize, caching skip on same-rounded-height, disconnect on unmount, no-op when ref unattached).

## Decisions made
None of note — straightforward extraction, no AC deviations.

## Out of scope
None — no follow-ups filed.