### PR TITLE
Migrate IngredientList/StepList to List role restoration

### DIFF
--- a/src/components/IngredientList/IngredientList.test.tsx
+++ b/src/components/IngredientList/IngredientList.test.tsx
@@ -33,6 +33,14 @@ describe('IngredientList', () => {
     expect(itemInputs[1]).toHaveValue('Sugar')
   })
 
+  it('exposes list/listitem roles for the rendered rows (Safari/VoiceOver list semantics)', () => {
+    const onChange = vi.fn()
+    render(<IngredientList ingredients={twoIngredients} onChange={onChange} />)
+
+    expect(screen.getByRole('list')).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+  })
+
   it('"Add ingredient" button adds a new empty row', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -1,6 +1,7 @@
 import Button from '@components/Button'
 import { iconChevronDown, iconChevronUp, iconPlus, iconRemove } from '@components/icons'
 import Input from '@components/Input'
+import List, { ListItem } from '@components/List'
 import { useReorderableList } from '@hooks/useReorderableList'
 import type { Ingredient } from '@models/recipe'
 import type { FC } from 'react'
@@ -46,9 +47,9 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
 
   return (
     <>
-      <ul className={styles.container}>
+      <List className={styles.container}>
         {ingredients.map((ingredient, index) => (
-          <li key={index} className={styles.row}>
+          <ListItem key={index} className={styles.row}>
             <div className={styles.quantityField}>
               <Input
                 ariaLabel={`Ingredient ${index + 1} quantity`}
@@ -102,9 +103,9 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
                 {iconRemove}
               </Button>
             </div>
-          </li>
+          </ListItem>
         ))}
-      </ul>
+      </List>
       <Button onClick={handleAdd} variant="outline" iconLeft={iconPlus} className={styles.addButton}>
         Add ingredient
       </Button>

--- a/src/components/StepList/StepList.test.tsx
+++ b/src/components/StepList/StepList.test.tsx
@@ -45,6 +45,22 @@ describe('StepList', () => {
     expect(textareas[1]).toHaveValue('Mix ingredients')
   })
 
+  it('exposes list/listitem roles for the rendered rows (Safari/VoiceOver list semantics)', () => {
+    const onChange = vi.fn()
+    render(
+      <StepList
+        steps={twoSteps}
+        onChange={onChange}
+        getToken={mockGetToken}
+        recipeId="test-recipe-id"
+        slug="beans-on-toast"
+      />
+    )
+
+    expect(screen.getByRole('list')).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+  })
+
   it('step numbers auto-update', () => {
     const onChange = vi.fn()
     render(

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -2,6 +2,7 @@ import Button from '@components/Button'
 import { iconChevronDown, iconChevronUp, iconPlus, iconRemove } from '@components/icons'
 import ImageUpload from '@components/ImageUpload'
 import Input from '@components/Input'
+import List, { ListItem } from '@components/List'
 import Textarea from '@components/Textarea'
 import { useReorderableList } from '@hooks/useReorderableList'
 import { stepImageType, type RecipeImage, type Step } from '@models/recipe'
@@ -86,9 +87,9 @@ const StepList: FC<StepListProps> = ({
 
   return (
     <>
-      <ul className={styles.container}>
+      <List className={styles.container}>
         {steps.map((step, index) => (
-          <li key={step.stepId} className={styles.row}>
+          <ListItem key={step.stepId} className={styles.row}>
             <div className={styles.header}>
               <span className={styles.stepNumber}>{index + 1}</span>
               <div className={styles.actions}>
@@ -150,9 +151,9 @@ const StepList: FC<StepListProps> = ({
                 )}
               </div>
             )}
-          </li>
+          </ListItem>
         ))}
-      </ul>
+      </List>
       <Button onClick={handleAdd} variant="outline" iconLeft={iconPlus} className={styles.addButton}>
         Add step
       </Button>


### PR DESCRIPTION
Closes #312

## What changed

Migrated `IngredientList.tsx` and `StepList.tsx` from raw `<ul>`/`<li>` to the shared `List`/`ListItem` primitive (`src/components/List/`, introduced in #280), closing an accessibility gap: both components render `list-style: none` lists but never had the `role="list"`/`role="listitem"` restoration applied, unlike the 8 sites already migrated in #280.

Added a test to each of `IngredientList.test.tsx` and `StepList.test.tsx` asserting the list/listitem roles are present via `getByRole`/`getAllByRole`.

## Why

`list-style: none` drops the implicit list/listitem semantics of `<ul>`/`<li>` in Safari/VoiceOver. These two components share the exact CSS pattern that caused the bug at the 8 other sites already fixed in #280, so this closes the same gap here.

## How to verify

- `pnpm test` — 803/803 passing, including the 2 new role assertions.
- `pnpm lint` / `pnpm exec tsc --noEmit` — clean.
- Visually: no layout change to the recipe editor's ingredient list or step list (only `className` passthrough, no CSS touched).

## Decisions made

- Straight 1:1 element swap — both components' `.map()` renders had no non-list-item children, fragments, or conditional siblings, so no `FileMeta`-style judgment call was needed (unlike #280, where some sites needed decorative separators left outside `ListItem`).

## Out of scope

None — no new findings surfaced during `/simplify` review (reuse, simplification, efficiency, and altitude passes all came back clean on this diff).