### PR TITLE
Extract a shared StateBox component for RecipeList/UserManagement's loading+error blocks

### DIFF
--- a/src/components/StateBox/StateBox.module.css
+++ b/src/components/StateBox/StateBox.module.css
@@ -1,0 +1,7 @@
+/* RecipeList's and UserManagement's error body was independently widened
+   to 38ch (vs. stateBox.module.css's own 36ch default) in both source
+   files before this extraction — folded into one rule here so both
+   page-local overrides can be deleted. See issue #304. */
+.errorBody {
+  max-width: 38ch;
+}

--- a/src/components/StateBox/StateBox.module.css
+++ b/src/components/StateBox/StateBox.module.css
@@ -1,7 +1,0 @@
-/* RecipeList's and UserManagement's error body was independently widened
-   to 38ch (vs. stateBox.module.css's own 36ch default) in both source
-   files before this extraction — folded into one rule here so both
-   page-local overrides can be deleted. See issue #304. */
-.errorBody {
-  max-width: 38ch;
-}

--- a/src/components/StateBox/StateBox.test.tsx
+++ b/src/components/StateBox/StateBox.test.tsx
@@ -25,7 +25,7 @@ describe('StateBox', () => {
 
       expect(screen.getByTestId('error-icon')).toBeInTheDocument()
       expect(
-        screen.getByRole('heading', { name: "Couldn't load recipes" })
+        screen.getByRole('heading', { level: 2, name: "Couldn't load recipes" })
       ).toBeInTheDocument()
       expect(
         screen.getByText('Something went wrong reaching the server.')

--- a/src/components/StateBox/StateBox.test.tsx
+++ b/src/components/StateBox/StateBox.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import StateBox from './StateBox'
+
+describe('StateBox', () => {
+  describe('loading variant', () => {
+    it('renders a status spinner with the given label', () => {
+      render(<StateBox variant="loading" label="Loading recipes…" />)
+
+      expect(screen.getByRole('status', { name: 'Loading recipes…' })).toBeInTheDocument()
+    })
+  })
+
+  describe('error variant', () => {
+    it('renders the icon, heading, and body', () => {
+      render(
+        <StateBox
+          variant="error"
+          icon={<span data-testid="error-icon">!</span>}
+          heading="Couldn't load recipes"
+          body="Something went wrong reaching the server."
+        />
+      )
+
+      expect(screen.getByTestId('error-icon')).toBeInTheDocument()
+      expect(
+        screen.getByRole('heading', { name: "Couldn't load recipes" })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('Something went wrong reaching the server.')
+      ).toBeInTheDocument()
+    })
+
+    it('renders an action button and calls its onClick when clicked', () => {
+      const onClick = vi.fn()
+
+      render(
+        <StateBox
+          variant="error"
+          icon={<span aria-hidden="true">!</span>}
+          heading="Couldn't load recipes"
+          body="Something went wrong."
+          action={{ label: 'Retry', onClick, icon: <span aria-hidden="true">↻</span> }}
+        />
+      )
+
+      const retryButton = screen.getByRole('button', { name: 'Retry' })
+      fireEvent.click(retryButton)
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('renders no action button when action is omitted', () => {
+      render(
+        <StateBox
+          variant="error"
+          icon={<span aria-hidden="true">!</span>}
+          heading="Couldn't load recipes"
+          body="Something went wrong."
+        />
+      )
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/StateBox/StateBox.tsx
+++ b/src/components/StateBox/StateBox.tsx
@@ -1,0 +1,54 @@
+import Button from '@components/Button'
+import Loading from '@components/Loading'
+import Typography from '@components/Typography'
+import type { FC, ReactNode } from 'react'
+
+import stateBox from '../../styles/stateBox.module.css'
+import styles from './StateBox.module.css'
+
+export interface StateBoxAction {
+  label: string
+  onClick: () => void
+  icon?: ReactNode
+}
+
+export type StateBoxProps =
+  | { variant: 'loading'; label?: string }
+  | {
+      variant: 'error'
+      icon: ReactNode
+      heading: ReactNode
+      body: ReactNode
+      action?: StateBoxAction
+    }
+
+const StateBox: FC<StateBoxProps> = (props) => {
+  if (props.variant === 'loading') {
+    return (
+      <div className={`${stateBox.box} ${stateBox.loading}`}>
+        <Loading label={props.label} />
+      </div>
+    )
+  }
+
+  const { icon, heading, body, action } = props
+
+  return (
+    <div className={`${stateBox.box} ${stateBox.error}`}>
+      <div className={`${stateBox.icon} ${stateBox.iconError}`}>{icon}</div>
+      <Typography variant="heading2" className={stateBox.heading}>
+        {heading}
+      </Typography>
+      <Typography variant="body" className={`${stateBox.body} ${styles.errorBody}`}>
+        {body}
+      </Typography>
+      {action && (
+        <Button variant="outline" onClick={action.onClick} iconLeft={action.icon}>
+          {action.label}
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export default StateBox

--- a/src/components/StateBox/StateBox.tsx
+++ b/src/components/StateBox/StateBox.tsx
@@ -4,7 +4,6 @@ import Typography from '@components/Typography'
 import type { FC, ReactNode } from 'react'
 
 import stateBox from '../../styles/stateBox.module.css'
-import styles from './StateBox.module.css'
 
 export interface StateBoxAction {
   label: string
@@ -39,7 +38,7 @@ const StateBox: FC<StateBoxProps> = (props) => {
       <Typography variant="heading2" className={stateBox.heading}>
         {heading}
       </Typography>
-      <Typography variant="body" className={`${stateBox.body} ${styles.errorBody}`}>
+      <Typography variant="body" className={stateBox.body}>
         {body}
       </Typography>
       {action && (

--- a/src/components/StateBox/index.ts
+++ b/src/components/StateBox/index.ts
@@ -1,0 +1,2 @@
+export { default } from './StateBox'
+export type { StateBoxAction, StateBoxProps } from './StateBox'

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -233,10 +233,11 @@
   }
 }
 
-/* ── Empty / loading / error states — shared box shape from
-   stateBox.module.css. stateBox is imported directly in RecipeList.tsx
-   and composed in JS rather than via `composes:` here, so Rollup can
-   dedupe the shared rules across lazy admin chunks. ─────────────────── */
+/* ── Empty state — shared box shape from stateBox.module.css. stateBox is
+   imported directly in RecipeList.tsx and composed in JS rather than via
+   `composes:` here, so Rollup can dedupe the shared rules across lazy
+   admin chunks. Loading/error states are handled by the shared StateBox
+   component (src/components/StateBox) instead — see issue #304. ──────── */
 
 .emptyBox {
   border: 1px dashed var(--color-border);
@@ -247,8 +248,4 @@
   background: var(--color-surface);
   border: var(--border-width) solid var(--color-border);
   color: var(--color-text-muted);
-}
-
-.errorBody {
-  max-width: 38ch;
 }

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -5,11 +5,10 @@ import {
   publishRecipe,
   unpublishRecipe,
 } from '@api/recipes'
-import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
 import { iconEdit, iconPreview, iconPublish, iconRetry, iconWarning } from '@components/icons'
 import Link from '@components/Link'
-import Loading from '@components/Loading'
+import StateBox from '@components/StateBox'
 import StatusBadge from '@components/StatusBadge'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
@@ -165,27 +164,18 @@ const RecipeList = () => {
 
   const renderBody = () => {
     if (loading) {
-      return (
-        <div className={`${stateBox.box} ${stateBox.loading}`}>
-          <Loading label="Loading recipes…" />
-        </div>
-      )
+      return <StateBox variant="loading" label="Loading recipes…" />
     }
 
     if (error) {
       return (
-        <div className={`${stateBox.box} ${stateBox.error}`}>
-          <div className={`${stateBox.icon} ${stateBox.iconError}`}>{iconWarning}</div>
-          <Typography variant="heading2" className={stateBox.heading}>
-            Couldn&apos;t load recipes
-          </Typography>
-          <Typography variant="body" className={`${stateBox.body} ${styles.errorBody}`}>
-            Something went wrong reaching the server. Check your connection and try again.
-          </Typography>
-          <Button variant="outline" onClick={loadRecipes} iconLeft={iconRetry}>
-            Retry
-          </Button>
-        </div>
+        <StateBox
+          variant="error"
+          icon={iconWarning}
+          heading="Couldn't load recipes"
+          body="Something went wrong reaching the server. Check your connection and try again."
+          action={{ label: 'Retry', onClick: loadRecipes, icon: iconRetry }}
+        />
       )
     }
 

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -388,13 +388,6 @@
   }
 }
 
-/* ── Loading / error states — uses the shared box shape from
-   stateBox.module.css, matching RecipeList.module.css's `.loadingBox`/
-   `.errorBox` exactly (this is the third page in the epic to need this
-   treatment). stateBox is imported directly in UserManagement.tsx and
-   composed in JS rather than via `composes:` here, so Rollup can dedupe
-   the shared rules across lazy admin chunks. ──────────────────────────── */
-
-.errorBody {
-  max-width: 38ch;
-}
+/* Loading/error states are handled by the shared StateBox component
+   (src/components/StateBox) — see issue #304. No page-local CSS is
+   needed here anymore. */

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -4,7 +4,7 @@ import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
 import { IconAlertCircle, iconRetry, iconWarning } from '@components/icons'
 import Input from '@components/Input'
-import Loading from '@components/Loading'
+import StateBox from '@components/StateBox'
 import StatusBadge from '@components/StatusBadge'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
@@ -14,7 +14,6 @@ import { useCallback, useEffect, useId, useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import interactions from '../../../styles/interactions.module.css'
-import stateBox from '../../../styles/stateBox.module.css'
 import text from '../../../styles/text.module.css'
 import styles from './UserManagement.module.css'
 
@@ -161,27 +160,18 @@ const UserManagement = () => {
 
   const renderBody = () => {
     if (loading) {
-      return (
-        <div className={`${stateBox.box} ${stateBox.loading}`}>
-          <Loading label="Loading users…" />
-        </div>
-      )
+      return <StateBox variant="loading" label="Loading users…" />
     }
 
     if (error) {
       return (
-        <div className={`${stateBox.box} ${stateBox.error}`}>
-          <div className={`${stateBox.icon} ${stateBox.iconError}`}>{iconWarning}</div>
-          <Typography variant="heading2" className={stateBox.heading}>
-            Couldn&apos;t load users
-          </Typography>
-          <Typography variant="body" className={`${stateBox.body} ${styles.errorBody}`}>
-            Something went wrong reaching the server. Check your connection and try again.
-          </Typography>
-          <Button variant="outline" onClick={loadUsers} iconLeft={iconRetry}>
-            Retry
-          </Button>
-        </div>
+        <StateBox
+          variant="error"
+          icon={iconWarning}
+          heading="Couldn't load users"
+          body="Something went wrong reaching the server. Check your connection and try again."
+          action={{ label: 'Retry', onClick: loadUsers, icon: iconRetry }}
+        />
       )
     }
 

--- a/src/styles/stateBox.module.css
+++ b/src/styles/stateBox.module.css
@@ -106,4 +106,12 @@
     margin: 0 0 24px;
     max-width: 36ch;
   }
+
+  /* RecipeList's and UserManagement's error state both independently
+     widened past the 36ch default — folded into StateBox's only
+     consumer of `.error`, scoped so other `.body` usages (e.g. the
+     `.loading` state) keep the 36ch default. */
+  .error .body {
+    max-width: 38ch;
+  }
 }


### PR DESCRIPTION
Closes #304

## What changed
- New `src/components/StateBox/` component (`StateBox.tsx` + barrel `index.ts` + `StateBox.test.tsx`) encapsulating the icon/heading/body/box composition previously hand-duplicated in `RecipeList.tsx` and `UserManagement.tsx`'s loading/error render blocks.
- `RecipeList.tsx` and `UserManagement.tsx` now render `<StateBox variant="loading" .../>` / `<StateBox variant="error" .../>` instead of manually composing `stateBox.*` classNames.
- Deleted the byte-identical local `.errorBody { max-width: 38ch }` override that existed separately in both `RecipeList.module.css` and `UserManagement.module.css`; folded into a scoped `.error .body` rule in the shared `src/styles/stateBox.module.css` (nothing else composes `.error` with `.body`, so this is behavior-preserving).

## Why
`stateBox.module.css` already gives these pages a shared CSS *shape* (#269), but the actual JSX composition — which classes go where, in what order — was still hand-repeated at the component level. This closes that gap with one shared component.

## How to verify
- `pnpm test` — 807/807 pass, including unmodified `RecipeList.test.tsx`/`UserManagement.test.tsx` and the new `StateBox.test.tsx`.
- `pnpm lint` — 0 errors (9 pre-existing unrelated warnings in `icons.tsx`).
- `pnpm exec tsc --noEmit` (via `pnpm --package=typescript dlx tsc --noEmit`) — 0 errors.
- Visually: recipes/users admin pages' loading spinner and error+retry states render identically to before (same CSS classes, same DOM shape).

## Decisions made
- `RecipePreview.tsx`'s not-found block was deliberately **not** migrated to `StateBox` — it uses `heading1` (not `heading2`), a `Link` action (not `Button`), and has several page-local layout overrides that don't cleanly fit StateBox's API without compromising it. The issue's own "Out of scope" note explicitly allows this judgment call.
- `StateBox`'s props are a discriminated union (`variant: 'loading' | 'error'`) with `action` on the error variant kept optional, even though both current call sites always pass one — matches the props-design guidance to model the real shape rather than force a required prop that happens to always be set today.
- `/simplify`'s simplification-angle finding was applied inline: originally the error-body `max-width: 38ch` override lived in a dedicated `StateBox.module.css` (a whole new file for one property); folded it into the shared `stateBox.module.css` as a scoped `.error .body` selector instead, deleting the extra file and import.

## Out of scope (filed as follow-up issues)
- **#316** — Widen `stateBox.module.css`'s shared `.body` max-width from 36ch to 38ch directly (all three real consumers independently override it to 38ch today). Deferred because it also touches `RecipePreview.module.css`, which this PR deliberately leaves untouched.