### PR TITLE
Constrain Grid's minWidth prop to a token/enum

### DIFF
--- a/src/components/Grid/Grid.test.tsx
+++ b/src/components/Grid/Grid.test.tsx
@@ -41,7 +41,7 @@ describe('Grid', () => {
 
   it('applies the auto-fit class and no fixed column class when minWidth is set', () => {
     render(
-      <Grid minWidth="320px">
+      <Grid minWidth="md">
         <div>Item</div>
       </Grid>
     )
@@ -56,18 +56,33 @@ describe('Grid', () => {
 
   it('sets the --grid-min-width custom property from minWidth', () => {
     render(
-      <Grid minWidth="320px">
+      <Grid minWidth="md">
         <div>Item</div>
       </Grid>
     )
 
     const list = screen.getByRole('list')
-    expect(list.style.getPropertyValue('--grid-min-width')).toBe('320px')
+    expect(list.style.getPropertyValue('--grid-min-width')).toBe(
+      'var(--grid-min-md)'
+    )
+  })
+
+  it('maps minWidth="sm" to the sm CSS custom property', () => {
+    render(
+      <Grid minWidth="sm">
+        <div>Item</div>
+      </Grid>
+    )
+
+    const list = screen.getByRole('list')
+    expect(list.style.getPropertyValue('--grid-min-width')).toBe(
+      'var(--grid-min-sm)'
+    )
   })
 
   it('lets minWidth override an explicit columns prop entirely', () => {
     render(
-      <Grid minWidth="320px" columns={4}>
+      <Grid minWidth="md" columns={4}>
         <div>Item</div>
       </Grid>
     )

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -5,7 +5,7 @@ import styles from './Grid.module.css'
 interface GridProps {
   children: ReactNode
   columns?: 1 | 2 | 3 | 4
-  minWidth?: string
+  minWidth?: 'sm' | 'md'
   className?: string
 }
 
@@ -14,6 +14,11 @@ const columnClassMap: Record<NonNullable<GridProps['columns']>, string> = {
   2: styles.cols2,
   3: styles.cols3,
   4: styles.cols4,
+}
+
+const minWidthVarMap: Record<NonNullable<GridProps['minWidth']>, string> = {
+  sm: 'var(--grid-min-sm)',
+  md: 'var(--grid-min-md)',
 }
 
 const Grid: FC<GridProps> = ({
@@ -31,7 +36,7 @@ const Grid: FC<GridProps> = ({
     .join(' ')
 
   const gridStyle = minWidth
-    ? ({ '--grid-min-width': minWidth } as CSSProperties)
+    ? ({ '--grid-min-width': minWidthVarMap[minWidth] } as CSSProperties)
     : undefined
 
   return (

--- a/src/pages/Apps/Apps.tsx
+++ b/src/pages/Apps/Apps.tsx
@@ -61,7 +61,7 @@ const Apps: FC = () => {
         <div className={styles.countRow}>
           <span>{APPS_COUNT_LABEL}</span>
         </div>
-        <Grid minWidth="320px" className={styles.gridSpacing}>
+        <Grid minWidth="md" className={styles.gridSpacing}>
           {APPS.map((app) => (
             <AppCard key={app.href} {...app} />
           ))}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -169,7 +169,7 @@ const Home: FC = () => {
                 written down so they&apos;re easy to make again.
               </Typography>
             </div>
-            <Grid minWidth="220px" className={styles.recipeGridSpacing}>
+            <Grid minWidth="sm" className={styles.recipeGridSpacing}>
               {recipes.map((recipe) => (
                 <RecipeCard key={recipe.id} recipe={recipe} eager hideTags />
               ))}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -177,6 +177,10 @@
   --max-w-prose-narrow: 46ch; /* short paragraph measure (in-progress notes, kitchen intro) */
   --max-w-sm:      24rem;  /* compact component box — dialogs, cards, toasts */
 
+  /* Grid auto-fit minmax tiers (Grid component's minWidth prop) */
+  --grid-min-sm: 220px;
+  --grid-min-md: 320px;
+
   /* ── Z-index ──────────────────────────────────────────────── */
   --z-header:  20;
   --z-overlay: 60;


### PR DESCRIPTION
Closes #286

## What changed
- Added two new design tokens to `src/styles/tokens.css`: `--grid-min-sm: 220px` and `--grid-min-md: 320px`.
- Narrowed `Grid`'s `minWidth` prop from a bare `string` to a closed `'sm' | 'md'` union, matching the existing closed-union style of the `columns` prop. Added a `minWidthVarMap` (mirroring the existing `columnClassMap` pattern) that resolves the enum to `var(--grid-min-sm)` / `var(--grid-min-md)` for the component's inline `--grid-min-width` custom property.
- Migrated both call sites: `Apps.tsx` (`minWidth="320px"` → `minWidth="md"`) and `Home.tsx` (`minWidth="220px"` → `minWidth="sm"`).
- Updated `Grid.test.tsx` for the new enum values and added a test covering the previously-untested `sm` branch.

## Why
`Grid`'s `minWidth` prop accepted an arbitrary CSS length string with no validation or shared vocabulary, unlike `columns` (a closed `1 | 2 | 3 | 4` union). The two real call sites were ad hoc magic numbers with no relationship enforced between them. This was filed as a follow-up during `/simplify`'s review of #247.

## How to verify
- `pnpm test` — 808/808 tests pass.
- `pnpm lint` — clean (only pre-existing, unrelated warnings in `icons.tsx`).
- `pnpm exec tsc --noEmit` — no errors.
- Visually: Apps and Home grids render identically (var references resolve to the same 320px/220px pixel values as before).

## Decisions made
- Exactly two enum tiers (`sm`/`md`), matching the two existing real call sites — per the issue's own out-of-scope note, no additional tiers were invented.
- New tokens named `--grid-min-sm`/`--grid-min-md` rather than a numeric/px-based scale, for consistency with how the rest of `tokens.css` names size tiers.

## Out of scope
None — `/simplify` review (reuse, simplification, efficiency, altitude angles) found nothing to flag on this diff; no follow-up issues were filed.