### PR TITLE
Extend @layer component-defaults to text.module.css's shared classes

### DIFF
--- a/src/components/RecipeDetailView/RecipeDetailView.module.css
+++ b/src/components/RecipeDetailView/RecipeDetailView.module.css
@@ -8,24 +8,16 @@
   padding: clamp(28px, 5vw, 48px) var(--space-6) clamp(64px, 9vw, 96px);
 }
 
+/* Bare `.backLink` override: `metaText` (text.module.css) now lives in
+   `@layer component-defaults` (#292), so this plain unlayered class
+   deterministically wins without needing the old descendant-selector
+   trick. Same mechanism as `.title` below. */
 .backLink {
   composes: focusRing from '../../styles/interactions.module.css';
   composes: metaText from '../../styles/text.module.css';
-  margin-block-end: 28px;
-}
-
-/* .article .backLink (not bare): the descendant-selector specificity
-   boost is no longer needed to beat Link's own `.link` (color:
-   var(--color-link)) — that's now handled by `@layer component-defaults`
-   (Link.module.css, #263). But it's still needed to beat this same
-   rule's own composed `metaText` class (text.module.css), which bakes in
-   its own font-size (13px) and color (faint) at equal, single-class
-   specificity — a separate, pre-existing tie outside #263's scope
-   (Typography-variant/Link.link only). This back link wants 12px/muted,
-   not metaText's 13px/faint. */
-.article .backLink {
   font-size: 12px;
   color: var(--color-text-muted);
+  margin-block-end: 28px;
 }
 
 .hero {
@@ -54,21 +46,15 @@
   margin: 0 0 18px;
 }
 
+/* Bare `.meta` override: `metaText` (text.module.css) now lives in
+   `@layer component-defaults` (#292), so this plain unlayered class
+   deterministically wins without needing the old descendant-selector
+   trick. Same mechanism as `.title` above. */
 .meta {
   composes: metaText from '../../styles/text.module.css';
-  margin: 0 0 20px;
-}
-
-/* .header .meta (not a same-rule override): overriding a composed
-   property directly in the rule that composes it does NOT reliably
-   win — verified empirically (the composed class's own value won the
-   tie in practice, the opposite of what "compose then override" is
-   often assumed to do). Needs the same descendant-selector treatment
-   as the Typography fixes elsewhere in this file. This meta line
-   wants 12.5px/muted, not metaText's own baked-in 13px/faint. */
-.header .meta {
   font-size: 12.5px;
   color: var(--color-text-muted);
+  margin: 0 0 20px;
 }
 
 .tags {

--- a/src/styles/text.module.css
+++ b/src/styles/text.module.css
@@ -12,118 +12,129 @@
    directly as a JS module and compose classNames in JS instead. See
    interactions.module.css's own header comment for the full rationale. */
 
-/* Mono, uppercase, tracked, faint — section/hero kicker text. Pair with
-   `Typography` (e.g. `variant="caption" as="p"` or `as="h2"` for an
-   eyebrow that doubles as the section heading). */
-.eyebrow {
-  font-family: var(--font-mono);
-  /* 12px: matches Apps'/Blog's own hero eyebrow exactly; --font-size-xs
-     (11px) is a token tuned for other mono-eyebrow contexts (Tag,
-     Toast, StatusBadge, etc.), not this one. */
-  font-size: 12px;
-  letter-spacing: var(--tracking-eyebrow);
-  text-transform: uppercase;
-  color: var(--color-text-faint);
-  /* 22px: matches Apps'/Blog's own hero eyebrow margin exactly; was
-     --space-5 (20px), 2px short. */
-  margin: 0 0 22px;
-}
+/* These rules are wrapped in a low-priority @layer so a consumer's plain
+   (unlayered) className always wins over them, regardless of source/bundle
+   order or matching specificity — per the CSS Cascade spec, any unlayered
+   rule beats any layered rule. Same mechanism as Typography.module.css and
+   Link.module.css (#263); applied here to fix the identical non-
+   deterministic-specificity bug for these shared text composables (#292).
+   Replaces the old per-callsite descendant-selector trick (`.parent
+   .child`) formerly needed to out-specificity these vs a bare override. */
+@layer component-defaults {
+  /* Mono, uppercase, tracked, faint — section/hero kicker text. Pair with
+     `Typography` (e.g. `variant="caption" as="p"` or `as="h2"` for an
+     eyebrow that doubles as the section heading). */
+  .eyebrow {
+    font-family: var(--font-mono);
+    /* 12px: matches Apps'/Blog's own hero eyebrow exactly; --font-size-xs
+       (11px) is a token tuned for other mono-eyebrow contexts (Tag,
+       Toast, StatusBadge, etc.), not this one. */
+    font-size: 12px;
+    letter-spacing: var(--tracking-eyebrow);
+    text-transform: uppercase;
+    color: var(--color-text-faint);
+    /* 22px: matches Apps'/Blog's own hero eyebrow margin exactly; was
+       --space-5 (20px), 2px short. */
+    margin: 0 0 22px;
+  }
 
-/* Page hero/heading/lead — shared layout for the top-of-page intro block
-   used by top-level page components (e.g. Blog, Apps). Bottom padding is
-   a custom property, not a fixed value — Apps' and Blog's own hero
-   sections want slightly different fluid values there
-   (clamp(40px,6vw,60px) vs clamp(36px,5vw,52px)), set via each page's
-   own `.hero` overriding `--page-hero-pad-end`. The fallback keeps this
-   composable usable on its own if a future page composes it without
-   setting one. */
-.pageHero {
-  max-width: var(--max-w-reading);
-  margin-inline: auto;
-  padding-block: clamp(64px, 11vw, 108px) var(--page-hero-pad-end, var(--space-6));
-  padding-inline: var(--space-6);
-}
+  /* Page hero/heading/lead — shared layout for the top-of-page intro block
+     used by top-level page components (e.g. Blog, Apps). Bottom padding is
+     a custom property, not a fixed value — Apps' and Blog's own hero
+     sections want slightly different fluid values there
+     (clamp(40px,6vw,60px) vs clamp(36px,5vw,52px)), set via each page's
+     own `.hero` overriding `--page-hero-pad-end`. The fallback keeps this
+     composable usable on its own if a future page composes it without
+     setting one. */
+  .pageHero {
+    max-width: var(--max-w-reading);
+    margin-inline: auto;
+    padding-block: clamp(64px, 11vw, 108px) var(--page-hero-pad-end, var(--space-6));
+    padding-inline: var(--space-6);
+  }
 
-.pageHeading {
-  font-size: var(--font-display-hero);
-  line-height: var(--line-height-tight);
-  letter-spacing: var(--tracking-tight);
-  /* 22px: matches Apps'/Blog's own hero heading margin exactly; no
-     spacing token lands on it. */
-  margin: 0 0 22px;
-}
+  .pageHeading {
+    font-size: var(--font-display-hero);
+    line-height: var(--line-height-tight);
+    letter-spacing: var(--tracking-tight);
+    /* 22px: matches Apps'/Blog's own hero heading margin exactly; no
+       spacing token lands on it. */
+    margin: 0 0 22px;
+  }
 
-.pageLead {
-  /* Fluid, matching Apps'/Blog's own hero lead exactly — distinct from
-     Typography's shared bodyLarge variant (18px fixed), which this
-     previously relied on with no override. */
-  font-size: clamp(17px, 2.6vw, 19px);
-  max-width: var(--max-w-prose);
-  color: var(--color-text-muted);
-  margin: 0;
-}
+  .pageLead {
+    /* Fluid, matching Apps'/Blog's own hero lead exactly — distinct from
+       Typography's shared bodyLarge variant (18px fixed), which this
+       previously relied on with no override. */
+    font-size: clamp(17px, 2.6vw, 19px);
+    max-width: var(--max-w-prose);
+    color: var(--color-text-muted);
+    margin: 0;
+  }
 
-/* Mono, muted, small — "no results" empty-state message text, matching the
-   design's noResults message exactly. Distinct from Typography's shared
-   bodyLarge variant (sans-serif, full-contrast text), which pages
-   previously relied on with no override. Margin is each consumer's own —
-   Blog's and Recipes' empty states each want a slightly different value. */
-.emptyStateMessage {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-  margin: 0;
-}
+  /* Mono, muted, small — "no results" empty-state message text, matching
+     the design's noResults message exactly. Distinct from Typography's
+     shared bodyLarge variant (sans-serif, full-contrast text), which pages
+     previously relied on with no override. Margin is each consumer's own —
+     Blog's and Recipes' empty states each want a slightly different
+     value. */
+  .emptyStateMessage {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    margin: 0;
+  }
 
-/* Mono, tracked, faint meta text — used for byline/count-row style labels
-   (e.g. post date/reading time, item counts). */
-.metaText {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-sm);
-  letter-spacing: var(--tracking-meta);
-  color: var(--color-text-faint);
-}
+  /* Mono, tracked, faint meta text — used for byline/count-row style labels
+     (e.g. post date/reading time, item counts). */
+  .metaText {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    letter-spacing: var(--tracking-meta);
+    color: var(--color-text-faint);
+  }
 
-/* Mono, bordered chip "look" — shared by BlogPost's and RecipeDetailView's
-   own tag-link chips (both otherwise hand-wrote the same declarations).
-   Pair with `composes: focusRing chipHover from interactions.module.css`
-   for the interactive hover/focus behavior; each consumer still sets its
-   own padding (Blog and Recipe use slightly different design literals). */
-.tagChipBase {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-xs);
-  letter-spacing: var(--tracking-meta);
-  color: var(--color-text-muted);
-  background: var(--color-surface);
-  border: var(--border-width) solid var(--color-border);
-  border-radius: var(--radius-sm);
-  text-decoration: none;
-}
+  /* Mono, bordered chip "look" — shared by BlogPost's and RecipeDetailView's
+     own tag-link chips (both otherwise hand-wrote the same declarations).
+     Pair with `composes: focusRing chipHover from interactions.module.css`
+     for the interactive hover/focus behavior; each consumer still sets its
+     own padding (Blog and Recipe use slightly different design literals). */
+  .tagChipBase {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    letter-spacing: var(--tracking-meta);
+    color: var(--color-text-muted);
+    background: var(--color-surface);
+    border: var(--border-width) solid var(--color-border);
+    border-radius: var(--radius-sm);
+    text-decoration: none;
+  }
 
-/* Semibold, slightly-larger-than-body text CTA — shared by Home's
-   "All" row-section link, Apps' "Read the blog" link, and Blog's
-   "Show all posts" link. Each still sets its own color/cursor/border
-   as needed (Apps' Link component already tones its own color). */
-.ctaText {
-  font-size: var(--font-size-sm-plus);
-  font-weight: var(--font-weight-semibold);
-}
+  /* Semibold, slightly-larger-than-body text CTA — shared by Home's
+     "All" row-section link, Apps' "Read the blog" link, and Blog's
+     "Show all posts" link. Each still sets its own color/cursor/border
+     as needed (Apps' Link component already tones its own color). */
+  .ctaText {
+    font-size: var(--font-size-sm-plus);
+    font-weight: var(--font-weight-semibold);
+  }
 
-/* Divider line filling a flex row's remaining width — Apps' and
-   Blog's own countRow both need this trailing rule after a count
-   label (and, on Blog, an optional active-tag name + clear button). */
-.dividerFill::after {
-  content: '';
-  flex: 1;
-  height: var(--border-width);
-  background: var(--color-border);
-}
+  /* Divider line filling a flex row's remaining width — Apps' and
+     Blog's own countRow both need this trailing rule after a count
+     label (and, on Blog, an optional active-tag name + clear button). */
+  .dividerFill::after {
+    content: '';
+    flex: 1;
+    height: var(--border-width);
+    background: var(--color-border);
+  }
 
-/* 12px/0.02em — the title-bar label size used by both FileTree's
-   `.title` and CodeBlock's `.filenameHeader`, matching the design's
-   `.code-head` exactly. Neither metaText's font-size (13px) nor
-   --tracking-meta (0.04em) land on this specific size. */
-.codeHeaderLabel {
-  font-size: 12px;
-  letter-spacing: 0.02em;
+  /* 12px/0.02em — the title-bar label size used by both FileTree's
+     `.title` and CodeBlock's `.filenameHeader`, matching the design's
+     `.code-head` exactly. Neither metaText's font-size (13px) nor
+     --tracking-meta (0.04em) land on this specific size. */
+  .codeHeaderLabel {
+    font-size: 12px;
+    letter-spacing: 0.02em;
+  }
 }


### PR DESCRIPTION
Closes #292

## What changed

Wraps `src/styles/text.module.css`'s shared classes (`eyebrow`, `pageHero`, `pageHeading`, `pageLead`, `emptyStateMessage`, `metaText`, `tagChipBase`, `ctaText`, `dividerFill`) in `@layer component-defaults` — the same low-priority layer `Typography.module.css` and `Link.module.css` already use (#263), registered once in `src/index.css:16`. Per the CSS Cascade spec, any unlayered rule beats any layered rule regardless of specificity or source order, which eliminates the non-deterministic tie these shared classes previously had against a composing consumer's own override.

De-scopes the two sites the issue names as proof: `RecipeDetailView.module.css`'s `.article .backLink` → bare `.backLink`, and `.header .meta` → bare `.meta`. Both descendant-selector rules existed only to win a specificity tie against `metaText` that the layer now resolves automatically — merged their declarations into the bare rule and deleted the now-redundant descendant-selector rule.

## Why

Same bug class #263 fixed for Typography/Link variants, applied to the third shared base-style source (`text.module.css`) per the issue.

## How to verify

- `pnpm test` (808/808 passed), `pnpm lint` (0 errors), `pnpm --package=typescript dlx tsc --noEmit` (0 errors) — all green, no new failures.
- Browser-verified computed styles (not just unit tests, per the issue's own verification bar) via Playwright against the dev server in both light and dark themes:
  - RecipeDetailView `/recipes/mild-thai-basa-coconut-rice`: `.backLink` renders `font-size: 12px`, `color: var(--color-text-muted)`; `.meta` renders `font-size: 12.5px`, `color: var(--color-text-muted)` — both matching the exact values the deleted descendant-selector rules used to hardcode, now applied deterministically instead of by source-order luck.
  - Spot-checked other `text.module.css` consumers (Blog's `metaText`/`pageHeading`, Apps' `ctaText`) render unchanged.

## Decisions made

**A real, verified visual change on `BlogPost.module.css` is a side effect of this diff, disclosed here rather than silently shipped:**

`BlogPost.module.css`'s `.metaLabel` composes `metaText` and overrides `font-size: 12px` in the same rule; `.backLink`, `.meta`, `.sectionLabel`, and `.relatedMeta` all compose `.metaLabel`, and `.backLink` additionally overrides `color: var(--color-text-muted)`. I built and browser-measured both branches to confirm:

- **Before this diff** (`epic/paper-redesign`): `.backLink`/`.meta` render at `13px` / `rgb(118, 112, 102)` (faint) — `metaText`'s own baked-in values were silently winning the specificity tie against `.metaLabel`'s and `.backLink`'s own overrides, due to source/bundle order. This is a pre-existing latent bug, not introduced by this diff.
- **After this diff**: `.backLink` renders at `12px` / `rgb(111, 105, 97)` (muted); `.meta` renders at `12px` / faint (unchanged, since `.meta` never overrides color). These are exactly the values `BlogPost.module.css`'s own comments already document as intended ("12px mono meta text... the design sets to this exact size"; `.backLink`'s explicit `color: var(--color-text-muted)` declaration).

This is a deterministic correctness fix consistent with the file's own documented design intent, not a regression — but it's a genuine visual change on a page outside this issue's stated file scope (`text.module.css` + `RecipeDetailView.module.css` only), so I'm surfacing it explicitly rather than letting it pass silently. No code change was made to `BlogPost.module.css` — the fix is a mechanical, unavoidable consequence of moving `metaText` into the layer, which is the entire point of this issue.

## Out of scope (filed as follow-up issues)

- **#320** — Simplify `RecipeDetailView.module.css`'s remaining Typography-variant descendant selectors (`.header .intro`, `.ingredientsPanel .ingredientsHeading`, `.grid .methodHeading`). Deferred because these override Typography's classes (layered in #263), a different mechanism than this issue's `text.module.css`/`metaText` scope — surfaced by `/simplify`'s altitude pass as pre-existing, unrelated dead weight this diff doesn't make worse.