### PR TITLE
Remove orphaned SOCIAL_LINKS_WITH_EMAIL_SUBJECT export

### DIFF
--- a/src/constants/socialLinks.ts
+++ b/src/constants/socialLinks.ts
@@ -13,10 +13,3 @@ export const SOCIAL_LINKS: SocialLink[] = [
   { name: 'LinkedIn', href: 'https://www.linkedin.com/in/akli-aissat-b08119115/' },
   { name: 'Email', href: `mailto:${EMAIL_ADDRESS}` },
 ]
-
-// This email-subject variant prefills a subject line; Footer's stays a bare mailto per Resolved
-// Decision #1 (docs/prds/paper-redesign.md), which specifies Footer's bare mailto explicitly —
-// this split is intentional, not drift to be fixed.
-export const SOCIAL_LINKS_WITH_EMAIL_SUBJECT: SocialLink[] = SOCIAL_LINKS.map((link) =>
-  link.name === 'Email' ? { ...link, href: `mailto:${EMAIL_ADDRESS}?subject=Hello` } : link
-)


### PR DESCRIPTION
Closes #323

## What changed

Removes `SOCIAL_LINKS_WITH_EMAIL_SUBJECT` and its explanatory comment from `src/constants/socialLinks.ts`. `SOCIAL_LINKS` (still used by `Footer`) is untouched.

## Why

This export existed solely for `SocialCard.tsx`'s consumption. #318 deleted `SocialCard.tsx` entirely, leaving this export with zero remaining consumers anywhere in `src/`.

## How to verify

- Independently re-verified via grep (including git history) that this export was never imported anywhere outside its own file.
- `pnpm test` (800/800 passed), `pnpm lint` (0 errors), `pnpm --package=typescript dlx tsc --noEmit` (0 errors).
- `grep -rn "SOCIAL_LINKS_WITH_EMAIL_SUBJECT" src` returns no matches.

## Decisions made

`SocialLinkName`/`SocialLink` (the type/interface) are also no longer consumed outside this file, but left untouched — they still type `SOCIAL_LINKS` itself, so they're not orphaned, just no longer needed as an external export beyond that. Not filing a follow-up for this; it's below the threshold of actionable dead code.