### PR TITLE
Simplify RecipeDetailView's remaining Typography-variant descendant selectors

### DIFF
--- a/src/components/RecipeDetailView/RecipeDetailView.module.css
+++ b/src/components/RecipeDetailView/RecipeDetailView.module.css
@@ -81,13 +81,12 @@
   }
 }
 
-/* Descendant selector (not a bare `.intro` class rule) deliberately raises
-   specificity above Typography's own `.bodyLarge` (font-size/line-height/
-   color) — a bare `.intro` ties with `.bodyLarge` (both single-class
-   selectors on the same element), leaving the winner dependent on
-   stylesheet load order rather than this override. Same root cause fixed
-   on Input's `.field` earlier — see RecipeSearch.module.css. */
-.header .intro {
+/* Bare `.intro` override: Typography's own `.bodyLarge` now lives in
+   `@layer component-defaults` (Typography.module.css, #263), so this
+   plain unlayered class deterministically wins without needing the old
+   descendant-selector trick. Same mechanism as `.title`/`.backLink`
+   above (#263/#292). */
+.intro {
   font-size: clamp(17px, 2.6vw, 19px);
   line-height: 1.7;
   color: var(--color-text);
@@ -134,9 +133,12 @@
   margin-block-end: 6px;
 }
 
-/* .ingredientsPanel .ingredientsHeading (not bare): raises specificity
-   above Typography's own `.heading2`. */
-.ingredientsPanel .ingredientsHeading {
+/* Bare `.ingredientsHeading` override: Typography's own `.heading2` now
+   lives in `@layer component-defaults` (Typography.module.css, #263), so
+   this plain unlayered class deterministically wins without needing the
+   old descendant-selector trick. Same mechanism as `.title`/`.backLink`
+   above (#263/#292). */
+.ingredientsHeading {
   font-size: 18px;
   font-weight: var(--font-weight-semibold);
   letter-spacing: -0.01em;
@@ -156,9 +158,12 @@
   margin: 0 0 var(--space-3);
 }
 
-/* .grid .methodHeading (not bare): raises specificity above Typography's
-   own `.heading2`. */
-.grid .methodHeading {
+/* Bare `.methodHeading` override: Typography's own `.heading2` now lives
+   in `@layer component-defaults` (Typography.module.css, #263), so this
+   plain unlayered class deterministically wins without needing the old
+   descendant-selector trick. Same mechanism as `.title`/`.backLink`
+   above (#263/#292). */
+.methodHeading {
   font-size: clamp(22px, 3vw, 26px);
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-snug);


### PR DESCRIPTION
Closes #320

## What changed

De-scopes `RecipeDetailView.module.css`'s three remaining descendant-selector overrides — `.header .intro`, `.ingredientsPanel .ingredientsHeading`, `.grid .methodHeading` — to their bare classes, merging each pair's declarations unchanged. Same `@layer component-defaults` mechanism already applied to `.title` (#263) and `.backLink`/`.meta` (#292) in this same file.

## Why

`Typography`'s `.bodyLarge`/`.heading2` variant classes already live in `@layer component-defaults`, and `Typography.tsx`'s `combinedClassName` puts both the layered variant class and the unlayered local class on the same element — so the old descendant-selector specificity boost is dead weight. This closes out the last three sites in the file.

## How to verify

- Independently confirmed `RecipeDetailView.tsx` passes `styles.intro`/`styles.ingredientsHeading`/`styles.methodHeading` into `<Typography variant="bodyLarge"|"heading2">` — the exact mechanism this relies on.
- Browser-verified computed styles (Playwright, dev server) on `/recipes/mild-thai-basa-coconut-rice` in both light and dark themes — all three elements render with the exact expected font-size/color/weight/letter-spacing/margin values, matching what the deleted descendant-selector rules declared.
- `pnpm test` (800/800 passed), `pnpm lint` (0 errors), `pnpm --package=typescript dlx tsc --noEmit` (0 errors).

## Decisions made

An altitude review confirmed `RecipeDetailView.module.css` now has zero remaining descendant-selector "specificity boost" patterns — this diff fully closes out that cleanup for this file.

## Out of scope (filed as follow-up issues)

- **#326** — De-scope `Login.module.css`'s `.cardHeader .heading`/`.cardHeader .subheading` (same obsolete pattern against `Typography`'s already-layered `heading3`/`body` variants) and fix a stale comment that cited this file's now-outdated `.header .title`/`.header .intro` as the "established fix." Deferred because it's a different component's file, outside this issue's stated scope.