### PR TITLE
De-scope Login's .column .footnote/.belowCard descendant selectors

### DIFF
--- a/src/pages/admin/Login/Login.module.css
+++ b/src/pages/admin/Login/Login.module.css
@@ -90,7 +90,7 @@
   gap: 7px; /* no --space-* token lands on 7px (--space-1=4px, --space-2=8px) */
 }
 
-/* Bare `.footnote` override: Typography's own `caption` variant now lives in
+/* Bare `.footnote` override: Typography's own `.caption` now lives in
    `@layer component-defaults` (Typography.module.css, #263), so this plain
    unlayered class deterministically wins without needing the old
    descendant-selector trick. Same mechanism as `.heading`/`.subheading`
@@ -104,7 +104,7 @@
   text-align: center;
 }
 
-/* Bare `.belowCard` override: Typography's own `caption` variant now lives in
+/* Bare `.belowCard` override: Typography's own `.caption` now lives in
    `@layer component-defaults` (Typography.module.css, #263), so this plain
    unlayered class deterministically wins without needing the old
    descendant-selector trick. Same mechanism as `.heading`/`.subheading`

--- a/src/pages/admin/Login/Login.module.css
+++ b/src/pages/admin/Login/Login.module.css
@@ -90,14 +90,12 @@
   gap: 7px; /* no --space-* token lands on 7px (--space-1=4px, --space-2=8px) */
 }
 
-/* .column .footnote / .column .belowCard (not bare classes): both compose
-   Typography's `caption` variant, which is also layered in
-   `@layer component-defaults` (Typography.module.css) same as `.heading3`/
-   `.body` above. These two weren't de-scoped to bare `.footnote`/
-   `.belowCard` in this pass — out of #326's stated scope, which covers
-   only `.cardHeader .heading`/`.subheading` — so they still use the
-   parent-scoped descendant-selector fix for now. */
-.column .footnote {
+/* Bare `.footnote` override: Typography's own `caption` variant now lives in
+   `@layer component-defaults` (Typography.module.css, #263), so this plain
+   unlayered class deterministically wins without needing the old
+   descendant-selector trick. Same mechanism as `.heading`/`.subheading`
+   above. */
+.footnote {
   font-size: 12.5px; /* no token lands between --font-size-xs (11px) and --font-size-sm (13px) */
   line-height: var(--line-height-normal);
   /* Renders inside <Card fill>, whose .fill sets --color-surface (issue #274). */
@@ -106,7 +104,12 @@
   text-align: center;
 }
 
-.column .belowCard {
+/* Bare `.belowCard` override: Typography's own `caption` variant now lives in
+   `@layer component-defaults` (Typography.module.css, #263), so this plain
+   unlayered class deterministically wins without needing the old
+   descendant-selector trick. Same mechanism as `.heading`/`.subheading`
+   above. */
+.belowCard {
   text-align: center;
   font-size: 12px; /* no --font-size-* token lands on 12px (--font-size-xs=11px, --font-size-sm=13px) */
   color: var(--color-text-faint);


### PR DESCRIPTION
Closes #328

## What changed
- `Login.module.css`: de-scoped `.column .footnote` → bare `.footnote` and `.column .belowCard` → bare `.belowCard`. Declarations unchanged; only the selectors and their explanatory comments changed.
- Replaced the combined comment with two per-rule comments describing the `@layer component-defaults` mechanism, matching the style already used for `.heading`/`.subheading` (#326) and `RecipeDetailView.module.css`'s per-rule convention.
- Review-pass fixup: corrected comment notation to say `` `.caption` `` (matching the leading-dot style `.heading`/`.subheading`'s comments use for `.heading3`/`.body`) instead of "caption variant".

This completes the migration in `Login.module.css` — the file now has zero remaining old-style `.parent .child` descendant-selector specificity workarounds.

## Why
Direct follow-up to #326: that issue's own `/simplify` pass confirmed `.caption` (which backs `.footnote`/`.belowCard` via `Login.tsx:224,230`'s `<Typography variant="caption">`) is already inside `@layer component-defaults` in `Typography.module.css`, so the same de-scoping applies here with no open technical question — #326 just scoped it out to keep that PR narrow.

## How to verify
- `src/pages/admin/Login/Login.module.css:93-116` — confirm `.footnote`/`.belowCard` are bare selectors with unchanged declarations.
- `src/components/Typography/Typography.module.css:57-62` — confirm `.caption` is inside `@layer component-defaults`.
- `pnpm test` (800/800 passing), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean) all pass.
- No visual change expected — this PR is a pure CSS-specificity-mechanism swap with byte-identical declarations. I don't have browser-automation tooling in this environment to capture a rendered screenshot, so I'm flagging that the light/dark spot-check this issue's AC asks for hasn't been done by me directly — worth a quick manual check before merge, though the risk is low given the same `@layer` mechanism was already visually proven safe by #326.

## Decisions made
- Left any Button/Tag-backed descendant selectors in other files untouched — those are blocked on Button/Tag not yet migrating into `@layer component-defaults`, a separate and larger effort (see follow-ups below).

## Out of scope (filed as follow-up issues)

- **#330** — De-scope `RecipeEditor.module.css`'s `.container .backLink`/`.previewWrap .previewLink`. Unlike most remaining sites, `Link`'s `.link` class is already layered, so this one's unblocked today — just hasn't been revisited.
- **#331** — Add a greppable CI gate that flags stale descendant-selector specificity workarounds (cross-referencing layered class names against `.parent .childName` selectors), so this exact pattern (independently rediscovered five times now: #263/#292/#320/#326/#328) stops requiring a manual `/simplify` pass to catch.