### PR TITLE
De-scope RecipeEditor's already-unblocked Link descendant selectors

### DIFF
--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -92,17 +92,15 @@
 
 /* ── Back link ───────────────────────────────────────────────────── */
 
-/* `focusRing` (interactions.module.css) and `metaText` (text.module.css)
+/* Bare `.backLink` override: Link's own `.link` now lives in
+   `@layer component-defaults` (Link.module.css, #263), so this plain
+   unlayered class deterministically wins without needing the old
+   descendant-selector trick — same mechanism as `.bannerAction` above.
+   `focusRing` (interactions.module.css) and `metaText` (text.module.css)
    are composed in JS rather than via `composes:` here — see
    `.timeoutSpinner` above for the shared-across-lazy-chunks rationale. */
 .backLink {
   margin-bottom: 20px;
-}
-
-/* .container .backLink (not bare): raises specificity above the shared
-   Link component's own `.link` — see RecipeDetailView.module.css's
-   `.article .backLink` for the same pattern/rationale. */
-.container .backLink {
   font-size: 12px;
   color: var(--color-text-muted);
 }
@@ -425,9 +423,10 @@
   padding-top: 14px;
 }
 
-/* .previewWrap .previewLink (not bare): raises specificity above Link's
-   own `.link` — see `.container .backLink` above for the same pattern. */
-.previewWrap .previewLink {
+/* Bare `.previewLink` override: Link's own `.link` now lives in
+   `@layer component-defaults` (Link.module.css, #263) — same mechanism
+   as `.backLink` above. */
+.previewLink {
   font-size: 13px;
   color: var(--color-text-muted);
 }

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -94,11 +94,12 @@
 
 /* Bare `.backLink` override: Link's own `.link` now lives in
    `@layer component-defaults` (Link.module.css, #263), so this plain
-   unlayered class deterministically wins without needing the old
-   descendant-selector trick — same mechanism as `.bannerAction` above.
-   `focusRing` (interactions.module.css) and `metaText` (text.module.css)
-   are composed in JS rather than via `composes:` here — see
-   `.timeoutSpinner` above for the shared-across-lazy-chunks rationale. */
+   unlayered class deterministically wins — same mechanism as
+   `.bannerAction` above.
+
+   Separately: `focusRing`/`metaText` are composed in JS rather than via
+   `composes:` here — see `.timeoutSpinner` above for the
+   shared-across-lazy-chunks rationale. */
 .backLink {
   margin-bottom: 20px;
   font-size: 12px;


### PR DESCRIPTION
Closes #330

## What changed
- `RecipeEditor.module.css`: de-scoped `.container .backLink` and `.previewWrap .previewLink` to bare `.backLink`/`.previewLink`, since `Link`'s `.link` class is already inside `@layer component-defaults` (confirmed during #328's review) — no dependency to wait on.
- Merged `.backLink`'s two previously-separate rule blocks (a bare margin-only rule + a descendant-scoped font/color rule) into one consolidated bare rule, following the exact precedent `RecipeDetailView.module.css` set for the same split-rule situation (#320).
- Comments updated to the established `@layer component-defaults` explanation style, cross-referencing `.bannerAction` (already migrated in this same file) and `.backLink` for `.previewLink`.
- `/simplify` fixup: split the merged `.backLink` comment (which stitched two independent rationales together) into two short paragraphs for readability, no content change.

## Why
Direct continuation of the migration already applied to `Login.module.css` (#326/#328) and `RecipeDetailView.module.css` (#320) — `RecipeEditor.module.css` was the last known already-unblocked (Link-backed) site still using the older, non-deterministic descendant-selector pattern.

## How to verify
- `src/pages/admin/RecipeEditor/RecipeEditor.module.css:93-107,425-432` — confirm `.backLink`/`.previewLink` are bare selectors with unchanged declaration values.
- `src/components/Link/Link.module.css:10-22` — confirm `.link` is inside `@layer component-defaults`.
- `pnpm test` (800/800 passing), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean) all pass.
- No visual change expected — pure specificity-mechanism swap with byte-identical declaration values. As with #328, I don't have browser-automation tooling in this environment to capture a rendered screenshot, so the light/dark visual spot-check this issue's AC asks for hasn't been done by me directly; risk is low given the identical mechanism was already visually proven safe by #326/#330's own precedents.

## Decisions made
- Left `.titleBar .pageHeading` (Typography-backed) and `.actionsCol .discardButton` (Button-backed) untouched in this same file — the former is unblocked but out of this issue's stated Link-only scope (now bundled into #334's Typography sweep instead of reopening this PR); the latter is genuinely blocked on Button not yet migrating into `@layer component-defaults`.

## Out of scope (filed as follow-up issues)

- **#333** — De-scope `RecipePreview.module.css`'s `.bannerLeft .backLink` (Link-backed, standalone, same trivial shape as this PR).
- **#334** — Sweep five Typography-backed sites across `RecipeEditor.module.css`, `RecipeList.module.css`, `UserManagement.module.css`, and `RecipeSteps.module.css` that are equally unblocked but weren't caught when #330 was filed — bundled into one issue per the reviewing agent's recommendation, rather than trickling in one-file-at-a-time.
- Added a process note to **#331** (the greppable-gate issue) recording that future single-file follow-ups like this one should be preceded by a triage-by-mechanism pass, so a whole "already unblocked" bucket closes together instead of trickling.