### PR TITLE
De-scope RecipePreview's already-unblocked Link backLink selector

### DIFF
--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -79,12 +79,11 @@
   flex-wrap: wrap;
 }
 
-/* .bannerLeft .backLink (not bare): raises specificity above the shared
-   Link component's own `.link` (color: var(--color-link)) — a bare
-   `.backLink` ties with it, same root cause as the Typography fixes
-   throughout this epic (see RecipeDetailView.module.css's `.article
-   .backLink`). */
-.bannerLeft .backLink {
+/* Bare `.backLink` override: Link's own `.link` now lives in
+   `@layer component-defaults` (Link.module.css, #263), so this plain
+   unlayered class deterministically wins without needing the old
+   descendant-selector trick. */
+.backLink {
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
@@ -108,8 +107,12 @@
 }
 
 /* .bannerLeft .bannerMessage (not bare): raises specificity above
-   Typography's own `.body` (font-size/font-weight/color) — same tie-fix
-   pattern as `.backLink` above. */
+   Typography's own `.body` (font-size/font-weight/color) — a bare
+   `.bannerMessage` would tie with it. Unlike `.backLink` above (now a
+   bare override against Link's already-layered `.link`), Typography's
+   `.body` isn't in `@layer component-defaults` yet, so this rule still
+   needs the descendant-selector specificity bump; tracked as separate
+   follow-up work. */
 .bannerLeft .bannerMessage {
   margin: 0;
   font-size: var(--font-size-sm-plus);
@@ -130,11 +133,13 @@
    selector (`.bannerActions .editLink`, not bare `.editLink`) to raise
    specificity above the shared Link/Button components' own base classes —
    same specificity-tie fix documented throughout this epic (see
-   `.bannerLeft .backLink` above). Ghost/solid coloring, transition and
-   hover already come from Link's own `.ghost`/`.solid` via the `variant`
-   prop alone (RecipePreview.tsx) — no `composes:` needed here, this local
-   class only supplies this consumer's own size/shape deltas as a plain
-   unlayered override. */
+   `.bannerLeft .bannerMessage` above; `.backLink` no longer needs this
+   trick now that Link's `.link` lives in `@layer component-defaults`, but
+   Button's own base classes here are still unlayered). Ghost/solid
+   coloring, transition and hover already come from Link's own
+   `.ghost`/`.solid` via the `variant` prop alone (RecipePreview.tsx) — no
+   `composes:` needed here, this local class only supplies this consumer's
+   own size/shape deltas as a plain unlayered override. */
 .editLink,
 .viewLink {
   font-size: 13px;

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -127,29 +127,31 @@
 }
 
 /* ── Pill buttons ──────────────────────────────────────────────────
-   .editLink / .viewLink / .publishButton (below) and .notFoundBackLink
-   (further down) are four small action buttons sharing the same pill
-   shape (9px radius, 7px icon/label gap) — grouped via its own compound
-   selector (`.bannerActions .editLink`, not bare `.editLink`) to raise
-   specificity above the shared Link/Button components' own base classes —
-   same specificity-tie fix documented throughout this epic (see
-   `.bannerLeft .bannerMessage` above; `.backLink` no longer needs this
-   trick now that Link's `.link` lives in `@layer component-defaults`, but
-   Button's own base classes here are still unlayered). Ghost/solid
-   coloring, transition and hover already come from Link's own
-   `.ghost`/`.solid` via the `variant` prop alone (RecipePreview.tsx) — no
-   `composes:` needed here, this local class only supplies this consumer's
-   own size/shape deltas as a plain unlayered override. */
+   .editLink / .viewLink (below) and .notFoundBackLink (further down)
+   are Link-backed ghost/solid pill buttons; .publishButton (below) is
+   the one Button-backed pill among them. All four share the same pill
+   shape (9px radius, 7px icon/label gap).
+
+   .editLink/.viewLink/.notFoundBackLink are bare, unlayered overrides
+   now: Link's own `.link`/`.ghost`/`.solid` base classes already live in
+   `@layer component-defaults` (Link.module.css, #263), so a bare class
+   here deterministically wins without the old descendant-selector
+   trick — same de-scoping already applied to `.backLink` above.
+
+   `.bannerActions .publishButton` stays compound (`.bannerActions`-
+   prefixed, not bare) because Button.module.css has no `@layer` of its
+   own — its base classes are still unlayered, so this selector still
+   needs the extra specificity to win the tie (same trick documented for
+   `.bannerLeft .bannerMessage` above).
+
+   Ghost/solid coloring, transition and hover already come from Link's
+   own `.ghost`/`.solid` via the `variant` prop alone (RecipePreview.tsx)
+   — no `composes:` needed here, these local classes only supply each
+   consumer's own size/shape deltas as plain overrides. */
 .editLink,
 .viewLink {
   font-size: 13px;
   padding: 8px 15px;
-}
-
-.bannerActions .editLink,
-.bannerActions .viewLink,
-.bannerActions .publishButton,
-.notFoundBox .notFoundBackLink {
   /* 9px: design literal — --radius-md (10px) is the nearest token but is
      1px off. */
   border-radius: 9px;
@@ -160,11 +162,14 @@
    `.sm` padding, font-size and border-radius are replaced here; Button's
    `solid` variant colors already match the design's `.banner-solid`
    exactly, and its own transition (Button.module.css's `.button`) is left
-   untouched, so this rule stays out of the ghost-pill transition group
-   above. */
+   untouched, so this rule stays out of the ghost-pill group above. */
 .bannerActions .publishButton {
   padding: 8px 15px;
   font-size: 13px;
+  /* 9px: design literal — --radius-md (10px) is the nearest token but is
+     1px off. */
+  border-radius: 9px;
+  gap: 7px;
 }
 
 /* ── Main landmark ─────────────────────────────────────────────────────
@@ -243,10 +248,13 @@
   margin: 0 0 26px;
 }
 
-/* Ghost coloring/transition/hover come from Link's own `.ghost` via the
-   `variant="ghost"` prop alone, same as `.editLink` in the "Pill buttons"
+/* Bare `.notFoundBackLink` override: Link's own `.link`/`.ghost` base
+   classes already live in `@layer component-defaults` (Link.module.css,
+   #263), same de-scoping as `.editLink`/`.viewLink` in the "Pill buttons"
    group above — no `composes:` needed, only the shape/size differ here. */
 .notFoundBackLink {
   font-size: 14px;
   padding: 10px 18px;
+  border-radius: 9px;
+  gap: 7px;
 }

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -108,11 +108,11 @@
 
 /* .bannerLeft .bannerMessage (not bare): raises specificity above
    Typography's own `.body` (font-size/font-weight/color) — a bare
-   `.bannerMessage` would tie with it. Unlike `.backLink` above (now a
-   bare override against Link's already-layered `.link`), Typography's
-   `.body` isn't in `@layer component-defaults` yet, so this rule still
-   needs the descendant-selector specificity bump; tracked as separate
-   follow-up work. */
+   `.bannerMessage` would tie with it. Typography's `.body` is already
+   layered in `@layer component-defaults` too (same mechanism as
+   `.backLink` above), so this selector is equally eligible for the same
+   de-scoping — left untouched here since this issue is scoped to
+   Link-backed selectors only; tracked in #334. */
 .bannerLeft .bannerMessage {
   margin: 0;
   font-size: var(--font-size-sm-plus);


### PR DESCRIPTION
Closes #333

## What changed
- `RecipePreview.module.css`: de-scoped `.bannerLeft .backLink` → bare `.backLink`, since `Link`'s `.link` class is already inside `@layer component-defaults` (confirmed during #328/#330's review) — declarations unchanged.
- Fixed two now-stale comment cross-references (on `.bannerMessage` and the pill-buttons block) that would have claimed `.backLink` still used the descendant-selector trick after this de-scoping.
- Review-pass fixup: corrected a factually wrong claim I introduced in the `.bannerMessage` comment (it said Typography's `.body` "isn't in `@layer component-defaults` yet" — false; it's been layered since the same commit that layered Link's `.link`). Corrected to state `.body` is already layered too, just deliberately left untouched here since this issue is Link-scoped only (tracked in #334 instead).
- `/simplify` follow-up (3 independent review agents converged on this): split the "Pill buttons" compound selector group. `.editLink`/`.viewLink`/`.notFoundBackLink` are Link-backed (`variant="ghost"/"solid"`) and were just as layer-eligible as `.backLink` — only `.publishButton` (Button-backed, `Button.module.css` still has no `@layer`) genuinely needed the compound `.bannerActions`-prefixed form. De-scoped the three Link-backed classes to bare selectors, merged their declarations into single rules each (matching this epic's established "merge split rules" precedent), and merged `.publishButton`'s two rule blocks into one while keeping it compound.

## Why
Direct continuation of the migration already applied to `Login.module.css` (#326/#328) and `RecipeEditor.module.css` (#330) — `RecipePreview.module.css` was the next known already-unblocked (Link-backed) site.

## How to verify
- `src/pages/admin/RecipePreview/RecipePreview.module.css:82-89,129-176,246-260` — confirm all four pill-button/backLink selectors have correct bare-vs-compound treatment and unchanged declaration values.
- `src/components/Link/Link.module.css:10-68` — confirm `.link`/`.ghost`/`.solid` are inside `@layer component-defaults`.
- `src/components/Button/Button.module.css` — confirm no `@layer` exists yet (why `.publishButton` stays compound).
- `pnpm test` (800/800 passing), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean) all pass.
- No visual change expected — as with #328/#330, I don't have browser-automation tooling in this environment to capture a rendered screenshot, so the light/dark visual spot-check this issue's AC asks for hasn't been done by me directly; risk is low given the identical mechanism was already visually proven safe by the prior PRs in this chain.

## Decisions made
- Left `.bannerLeft .bannerMessage` (Typography-backed) untouched even though it's also unblocked — out of this issue's Link-only scope, bundled into #334 instead of reopening this PR.
- Folded the pill-buttons compound-selector split into this PR rather than deferring, since it's the identical Link mechanism already being fixed here, in the same file, and three independent `/simplify` review agents converged on recommending this over filing yet another follow-up.

## Out of scope (filed as follow-up issues)

- **#336** — Investigate `RecipeList.module.css`'s `.rowActions .actionButton`, which mixes Link-rendered and native-`<button>`-rendered usages under one class — needs verification before a mechanical de-scoping is safe, unlike the other sites in this chain.
- Updated **#334** (Typography sweep) to add `.header .subtitle` in both `RecipeList.module.css`/`UserManagement.module.css`, `UserManagement.module.css`'s `.inviteCardHeader .inviteHeading`, and `Recipes.module.css`'s public-page hero — all found during this PR's `/simplify` review but outside its Link-only scope.