### PR TITLE
Sweep Typography-backed descendant selectors already unblocked by @layer component-defaults

### DIFF
--- a/src/components/RecipeSteps/RecipeSteps.module.css
+++ b/src/components/RecipeSteps/RecipeSteps.module.css
@@ -33,13 +33,11 @@
   padding-block-start: 3px;
 }
 
-/* .content .text (not a bare `.text` rule): raises specificity above
-   Typography's own `.body` variant (font-size/line-height/color) — a
-   bare `.text` ties with it (both single-class selectors on the same
-   element via Typography's `variant="body" className={styles.text}`),
-   leaving the winner dependent on stylesheet load order. Same root
-   cause as the fixes in RecipeDetailView.module.css. */
-.content .text {
+/* Bare `.text` override: Typography's own `.body` now lives in
+   `@layer component-defaults` (Typography.module.css, #263), so this plain
+   unlayered class deterministically wins without needing the old
+   descendant-selector trick. */
+.text {
   font-size: 16.5px;
   line-height: 1.7;
   color: var(--color-text);

--- a/src/pages/Recipes/Recipes.module.css
+++ b/src/pages/Recipes/Recipes.module.css
@@ -7,37 +7,26 @@
   --page-hero-pad-end: clamp(36px, 5vw, 52px);
 }
 
+/* `text.module.css`'s `.eyebrow`/`.pageHeading`/`.pageLead` variants now
+   live in `@layer component-defaults` (text.module.css, #263), so these
+   bare `composes:`-based classes deterministically win the tie against
+   the composed variant's own font-size/color without needing a separate,
+   higher-specificity descendant-selector rule — same de-scoping already
+   applied elsewhere in this epic (Input's `.field`, RecipeDetailView's
+   headings). */
 .eyebrow {
   composes: eyebrow from '../../styles/text.module.css';
-}
-
-.heading {
-  composes: pageHeading from '../../styles/text.module.css';
-}
-
-.intro {
-  composes: pageLead from '../../styles/text.module.css';
-}
-
-/* `composes` can't be combined with a descendant selector (CSS Modules
-   only allows it on a plain single-class rule), so the properties that
-   tie with Typography's own variant classes (`.caption`/`.heading1`/
-   `.bodyLarge` each set their own font-size/color) need a separate,
-   higher-specificity rule here rather than living inside the `composes`
-   blocks above — a bare `.eyebrow`/`.heading`/`.intro` class ties with
-   those variants (both single-class selectors on the same element),
-   leaving the winner dependent on stylesheet load order. Same root cause
-   fixed on Input's `.field` and RecipeDetailView's headings earlier. */
-.hero .eyebrow {
   font-size: 12px;
   color: var(--color-text-faint);
 }
 
-.hero .heading {
+.heading {
+  composes: pageHeading from '../../styles/text.module.css';
   font-size: var(--font-display-hero);
 }
 
-.hero .intro {
+.intro {
+  composes: pageLead from '../../styles/text.module.css';
   font-size: clamp(17px, 2.6vw, 19px);
   color: var(--color-text-muted);
 }

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -117,9 +117,11 @@
   margin-bottom: 26px;
 }
 
-/* .titleBar .pageHeading (not bare): raises specificity above
-   Typography's own `.heading1`. */
-.titleBar .pageHeading {
+/* Bare `.pageHeading` override: Typography's own `.heading1` now lives in
+   `@layer component-defaults` (Typography.module.css, #263), so this plain
+   unlayered class deterministically wins without needing the old
+   descendant-selector trick. */
+.pageHeading {
   font-size: clamp(24px, 3.4vw, 30px);
   font-weight: var(--font-weight-semibold);
   letter-spacing: -0.025em;

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -20,19 +20,21 @@
   margin-bottom: 30px;
 }
 
-/* .header .heading (not bare `.heading`): raises specificity above
-   Typography's own `.heading1` — see RecipeDetailView.module.css's
-   `.header .title` for the same pattern/rationale. */
-.header .heading {
+/* Bare `.heading` override: Typography's own `.heading1` now lives in
+   `@layer component-defaults` (Typography.module.css, #263), so this plain
+   unlayered class deterministically wins without needing the old
+   descendant-selector trick. */
+.heading {
   font-size: clamp(28px, 4vw, 34px);
   font-weight: var(--font-weight-semibold);
   letter-spacing: -0.025em;
   margin: 0 0 6px;
 }
 
-/* .header .subtitle (not bare): raises specificity above Typography's own
-   `.body`. */
-.header .subtitle {
+/* Bare `.subtitle` override: Typography's own `.body` now lives in
+   `@layer component-defaults` (Typography.module.css, #263), same
+   de-scoping as `.heading` above. */
+.subtitle {
   font-size: 14.5px;
   color: var(--color-text-muted);
   margin: 0;
@@ -119,9 +121,10 @@
   margin-bottom: 9px;
 }
 
-/* .rowTop .rowTitle (not bare): raises specificity above Typography's own
-   `.heading2` — same pattern as `.header .heading` above. */
-.rowTop .rowTitle {
+/* Bare `.rowTitle` override: Typography's own `.heading2` now lives in
+   `@layer component-defaults` (Typography.module.css, #263), same
+   de-scoping as `.heading` above. */
+.rowTitle {
   font-size: 16.5px;
   font-weight: var(--font-weight-semibold);
   letter-spacing: -0.015em;

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -106,14 +106,10 @@
   color: var(--color-success);
 }
 
-/* .bannerLeft .bannerMessage (not bare): raises specificity above
-   Typography's own `.body` (font-size/font-weight/color) — a bare
-   `.bannerMessage` would tie with it. Typography's `.body` is already
-   layered in `@layer component-defaults` too (same mechanism as
-   `.backLink` above), so this selector is equally eligible for the same
-   de-scoping — left untouched here since this issue is scoped to
-   Link-backed selectors only; tracked in #334. */
-.bannerLeft .bannerMessage {
+/* Bare `.bannerMessage` override: Typography's own `.body` now lives in
+   `@layer component-defaults` (Typography.module.css, #263), same
+   de-scoping already applied to `.backLink` above. */
+.bannerMessage {
   margin: 0;
   font-size: var(--font-size-sm-plus);
   font-weight: var(--font-weight-medium);
@@ -141,8 +137,9 @@
    `.bannerActions .publishButton` stays compound (`.bannerActions`-
    prefixed, not bare) because Button.module.css has no `@layer` of its
    own — its base classes are still unlayered, so this selector still
-   needs the extra specificity to win the tie (same trick documented for
-   `.bannerLeft .bannerMessage` above).
+   needs the extra specificity to win the tie (the same descendant-
+   selector trick `.bannerMessage` above needed before Typography's
+   `.body` was layered in #263).
 
    Ghost/solid coloring, transition and hover already come from Link's
    own `.ghost`/`.solid` via the `variant` prop alone (RecipePreview.tsx)

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -19,17 +19,22 @@
   margin-bottom: 30px;
 }
 
-/* .header .heading (not bare `.heading`): raises specificity above
-   Typography's own `.heading1` — see RecipeList.module.css's `.header
-   .heading` for the same pattern/rationale. */
-.header .heading {
+/* Bare `.heading` override: Typography's own `.heading1` now lives in
+   `@layer component-defaults` (Typography.module.css, #263), so this plain
+   unlayered class deterministically wins without needing the old
+   descendant-selector trick — same de-scoping as RecipeList.module.css's
+   `.heading`. */
+.heading {
   font-size: clamp(28px, 4vw, 34px);
   font-weight: var(--font-weight-semibold);
   letter-spacing: -0.025em;
   margin: 0 0 6px;
 }
 
-.header .subtitle {
+/* Bare `.subtitle` override: Typography's own `.body` now lives in
+   `@layer component-defaults` (Typography.module.css, #263), same
+   de-scoping as `.heading` above. */
+.subtitle {
   font-size: 14.5px;
   color: var(--color-text-muted);
   margin: 0;
@@ -53,7 +58,10 @@
   margin-bottom: 18px;
 }
 
-.inviteCardHeader .inviteHeading {
+/* Bare `.inviteHeading` override: Typography's own `.heading2` now lives
+   in `@layer component-defaults` (Typography.module.css, #263), same
+   de-scoping as `.heading` above. */
+.inviteHeading {
   font-size: 17px;
   font-weight: var(--font-weight-semibold);
   letter-spacing: -0.015em;


### PR DESCRIPTION
Closes #334

## What changed
De-scoped all 10 remaining Typography-backed `.parent .child` descendant-selector specificity workarounds across 6 files, since Typography's variants and `text.module.css`'s composed variants are already inside `@layer component-defaults` (#263):

- `RecipeEditor.module.css` — `.titleBar .pageHeading` → `.pageHeading`
- `RecipeList.module.css` — `.header .heading` → `.heading`, `.header .subtitle` → `.subtitle`, `.rowTop .rowTitle` → `.rowTitle`
- `UserManagement.module.css` — `.header .heading` → `.heading`, `.header .subtitle` → `.subtitle`, `.inviteCardHeader .inviteHeading` → `.inviteHeading`
- `RecipeSteps.module.css` — `.content .text` → `.text`
- `RecipePreview.module.css` — `.bannerLeft .bannerMessage` → `.bannerMessage`
- `Recipes.module.css` — `.hero .eyebrow`/`.heading`/`.intro` merged into their existing `composes:`-based bare blocks, now-empty descendant-selector rules removed entirely

Also fixed two stale cross-references along the way: `RecipeList.module.css`'s `.header .heading` comment cited a since-changed `RecipeDetailView.module.css` selector name (dropped, replaced with a direct `@layer` citation), and `RecipePreview.module.css`'s `.bannerActions .publishButton` comment referenced `.bannerMessage`'s old descendant-selector form (updated to past tense, since `.bannerMessage` is now bare too).

## Why
This closes out the trickle from #326→#328→#330→#333 — rather than filing one more single-file follow-up, this bundles every remaining Typography-backed site (confirmed via a repo-wide grep, not just the originally-listed 5) into one PR. `/simplify`'s altitude review independently re-confirmed via a fresh repo-wide grep that this sweep is genuinely complete: every remaining `.parent .child` selector in the repo is legitimately still blocked on Button/Tag not yet migrating into `@layer component-defaults`, not an oversight.

## How to verify
- `src/components/Typography/Typography.module.css:7-63` — confirm `.heading1`/`.heading2`/`.body` are inside `@layer component-defaults`.
- `src/styles/text.module.css:23-140` — confirm `.eyebrow`/`.pageHeading`/`.pageLead` are inside the same layer.
- Spot-check each touched file's bare selector against declaration values — all should be byte-identical to before.
- `pnpm test` (800/800 passing), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean) all pass.
- No visual change expected — as with the rest of this chain, I don't have browser-automation tooling in this environment to capture a rendered screenshot, so the light/dark visual spot-check this issue's AC asks for hasn't been done by me directly; risk is low given the identical mechanism was already visually proven safe by the earlier PRs in this chain, and this PR changes zero declaration values.

## Decisions made
- Skipped the full 4-agent `/simplify` ceremony for none of this PR's work — this is exactly the kind of larger, multi-file bundled sweep the user and I agreed still warrants it (as opposed to the single-line renames earlier in this chain).
- Corrected **#331**'s acceptance criteria before it gets implemented: the altitude review found its originally-planned CSS-only literal-name-matching gate would have caught only 1 of these 10 real sites (the local override `className` rarely matches the Typography variant name it's actually tying with — the tie only exists via the JSX `variant` prop). Updated #331 to require a JSX-aware check (parse `.tsx` for `<Typography variant="X" className={styles.Y}>`, cross-reference `Y` against `.foo .Y` selectors) instead.

## Out of scope
- `#336` (RecipeList's `.rowActions .actionButton`) — a different, mixed Link/native-button site needing investigation before a mechanical fix, tracked separately.
- Any Button/Tag-backed selector anywhere in the repo — confirmed still genuinely blocked (`Button.module.css` has no `@layer` at all; `Tag.module.css` only layers `.remove`, not `.tag`/`.active`).