### PR TITLE
Investigate RecipeList's .rowActions .actionButton descendant selector

### DIFF
--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -173,9 +173,18 @@
 /* `.actionButton` carries no CSS of its own — `focusRing`
    (interactions.module.css) is composed in JS instead of via
    `composes:` — see interactions.module.css's own header comment for
-   why. The descendant-scoped rule below carries the
-   specificity-tie fix (same rationale as `.header .newButton` above)
-   and everything else. */
+   why. This class is applied to both `<Link>` (Edit/Preview, no
+   `variant` prop) and native `<button>` (Publish/Delete) elements.
+   Unlike the rest of this epic's `@layer component-defaults`
+   de-scoping (#263/#326/#328/#330/#333/#334), this one genuinely still
+   needs the `.rowActions`-scoped compound selector: Link's own default
+   `tone="inherit"` class (`.inherit`, Link.module.css) is deliberately
+   left UNLAYERED (only `.link`/`.ghost`/`.solid` are layered), so a
+   bare `.actionButton` would tie in specificity with `.inherit` — both
+   unlayered, single-class selectors — leaving the color winner
+   dependent on unguaranteed source/bundle order. The compound form's
+   higher specificity is what reliably wins here; it's not a leftover
+   of the old pre-#263 convention. */
 .rowActions .actionButton {
   /* display/align-items/font-family are already inherited from Link's own
      `.link` for Edit/Preview, but the native Publish/Delete `<button>`s


### PR DESCRIPTION
Closes #336

## What changed
Investigated whether `RecipeList.module.css`'s `.rowActions .actionButton` (shared between `<Link>`-rendered Edit/Preview and native `<button>`-rendered Publish/Delete row actions) could join the rest of this epic's `@layer component-defaults` de-scoping chain (#326/#328/#330/#333/#334). **Conclusion: no, it genuinely needs to stay compound.** No selector was changed — only the explanatory comment above `.rowActions .actionButton` was rewritten to document why, and a stale `.header .newButton` cross-reference (which didn't parse against this file's actual content — `.newButton` here is already bare and never needed the specificity trick) was dropped.

## Why
An initial attempt did de-scope this to a bare `.actionButton`, reasoning that Link's `.link` base class is fully inside `@layer component-defaults` and therefore always loses to any unlayered rule regardless of specificity — the same mechanism that made the rest of this chain safe. A review pass caught that this reasoning was incomplete: `Link.tsx` defaults its `tone` prop to `'inherit'`, applying `.inherit` alongside `.link` whenever no `variant` prop is passed — true for both `<Link>` instances here (Edit/Preview pass no `variant`). `.inherit` is deliberately left **unlayered** in `Link.module.css` (only `.link`/`.ghost`/`.solid` are layered — see that file's own header comment: "tone/underline/icon/nudge classes stay unlayered ... not something a raw className collides with," an assumption that doesn't hold for `.actionButton`). Pre-existing compound selector `(0,2,0)` beats `.inherit` `(0,1,0)` purely on specificity, safe regardless of layering. A bare `.actionButton` `(0,1,0)` would **tie** with `.inherit` `(0,1,0)` — both unlayered — leaving the color winner dependent on unguaranteed CSS source/bundle order, risking a visual regression on two admin pages' worth of row actions.

I reverted the initial de-scoping attempt before it was ever pushed and implemented the corrected, comment-only resolution instead.

## How to verify
- `src/pages/admin/RecipeList/RecipeList.module.css:173-186` — confirm the comment accurately explains the `.inherit`-collision reasoning and that `.rowActions .actionButton` (and its `svg`/`:hover`/`.publishAction:hover`/`.deleteAction:hover`/reduced-motion siblings) are all unchanged, still compound.
- `src/components/Link/Link.tsx:35,45-51` — confirm `tone` defaults to `'inherit'` and is applied whenever `variant` is unset.
- `src/components/Link/Link.module.css:10-68,72-74` — confirm `@layer component-defaults` closes at line 68 and `.inherit` (line 72) sits outside it.
- `pnpm test` (800/800 passing), `pnpm lint` (0 errors), `pnpm exec tsc --noEmit` (clean) all pass.
- No visual change — literally no selector changed, comment-only diff.

## Decisions made
- Per this issue's own acceptance criteria ("if NOT safe... document why and leave it as-is — report the finding to the user rather than silently forcing a fix"), left the selector untouched rather than force a de-scoping that would introduce a real regression risk.
- Skipped the full 4-agent `/simplify` ceremony (single-file comment-only change, per the process the user and I agreed on after #333) — did keep the review pass, which is what caught the `.inherit` collision in the first place.

## Out of scope
None — this closes out the full de-scoping investigation chain from #326 through #336. Remaining open work in this thread is #331 (the greppable CI gate, already corrected to be JSX-aware based on findings from this chain).