### PR TITLE
Finalize docs, tests, and greppable gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,8 @@ To write a new PRD, copy `docs/prds/template.md` and fill it in.
 - Each component/page has a co-located test file `<Name>.test.tsx`
 - Use path aliases: `@api/`, `@components/`, `@contexts/`, `@hooks/`, `@pages/`, `@models/` (→ `src/types/`)
 - Dark mode via `data-theme` attribute on the document root
-- Warm "paper" design (soft radii, hairline borders, Geist/JetBrains Mono) per `docs/prds/paper-redesign.md` (source of truth `docs/design/paper/`) — `--radius-none` no longer exists; pick from the soft radius scale (`--radius-sm/md/lg/xl/2xl/full`) per `docs/design/paper/token-migration.md`. The token layer (#218) has landed; component rebuilds are still landing across the rest of the epic (`epic/paper-redesign`).
+- Warm "paper" design (soft radii, hairline borders, Geist/JetBrains Mono) per `docs/prds/paper-redesign.md` (source of truth `docs/design/paper/`) — `--radius-none` no longer exists; pick from the soft radius scale (`--radius-sm/md/lg/xl/2xl/full`) per `docs/design/paper/token-migration.md`. The paper redesign epic (`epic/paper-redesign`) is complete — the token layer (#218) and all component rebuilds have landed.
+- Accessibility test bar: `vitest-axe` + `eslint-plugin-jsx-a11y` are the project's standard for a11y coverage. New components/pages that render meaningful content should follow the pattern already used across `Home`, `RecipeDetailView`, `RecipeList`, `Recipes`, `Blog`/`BlogPost`, `Apps`, and `Login`: `import { axe } from 'vitest-axe'` and `expect(await axe(container)).toHaveNoViolations()` on the key rendered states.
 - Use const arrow functions, not function declarations — enforced by ESLint (`func-style: expression`)
 - After modifying TSX files, run `pnpm exec eslint --fix` on changed files to auto-fix import order
 - Before creating new UI elements, check `src/components/` for existing reusable components (Image, Typography, Button, Card, Link, Loading, etc.). Always prefer existing components over raw HTML tags.

--- a/docs/design/paper/token-migration.md
+++ b/docs/design/paper/token-migration.md
@@ -187,16 +187,38 @@ wouldn't catch them:
   - Mermaid's own dark theme (via rehype/MDX plugin config) would be the more "correct"
     long-term fix, but that's outside `src/**` CSS and outside this issue's scope.
 
+- **Mermaid dark-mode label-text fix** (added later, unrelated to this migration): mermaid's
+  own inline `<style>` tags set node/edge/cluster label text to `#333`, which reads as a
+  muddy mid-gray rather than near-white after the `invert(0.88)` filter above (measured: 51,51,51
+  only inverts to mid-gray, not the ~224,224,224 pure black gets). Fixed by forcing
+  `color`/`fill: #000 !important` on the label-bearing tag names (`span`/`p`/`text`/`tspan`)
+  inside `[data-theme="dark"] svg[id^="mermaid-"]`, so the pre-invert input is pure black and
+  the post-invert output is near-white. The `#000` here is a **required literal, not a token**
+  — the invert-filter math needs an exact pure-black input, and no `--color-*` token is pure
+  black — so it's a permanent, intentional exception to the §6 "no hardcoded brutalist literal"
+  grep, not a regression (it postdates this migration entirely).
+
 ## 6. Verification
 
 ```
 # No src/** file references a removed token:
-grep -rn -- "radius-none\|color-bg-subtle\|color-border-subtle\|color-primary-hover\|color-link-hover\|font-weight-extrabold\|max-w-xs\|max-w-sm\|max-w-md\|max-w-lg\|max-w-2xl" src
-# → no output
-
-# No hardcoded brutalist literals remain:
-grep -rniE "#000000|#000\b|invert\(1\)|[0-9]px [0-9]px 0" src
+grep -rn -- "radius-none\|color-bg-subtle\|color-border-subtle\|color-primary-hover\|color-link-hover\|font-weight-extrabold\|max-w-xs\|max-w-md\|max-w-lg\|max-w-2xl" src
 # → no output
 ```
 
-Both return clean as of this migration.
+`--max-w-sm` was dropped from this pattern (it was present at the original time of writing):
+issue #233 reinstated `--max-w-sm` as a legitimate current token (§3c) — it's no longer a
+removed token, so keeping it in this pattern would false-positive on its own real consumers
+(`ConfirmDialog`, `SocialCard`, `ToastProvider`).
+
+```
+# No hardcoded brutalist literals remain:
+grep -rniE "#000000|#000\b|invert\(1\)|[0-9]px [0-9]px 0" src
+# → src/index.css: one `invert(1)` match inside a comment (prose explaining what is
+#   *not* used, not code) and two `#000 !important` declarations (the mermaid
+#   dark-mode label-text fix documented above). Both are known, justified exceptions
+#   that postdate this migration — not brutalist regressions. No other output expected.
+```
+
+Both patterns are clean of genuine neo-brutalist-era CSS as of this migration; the
+`src/index.css` exceptions above are later, unrelated, and independently justified.

--- a/src/components/AppCard/AppCard.module.css
+++ b/src/components/AppCard/AppCard.module.css
@@ -36,6 +36,12 @@
 }
 
 .imageWrapper > figure > div {
+  /* Image's own container div has a 12px radius on all four corners by
+     default (for standalone use) — here it sits flush at the top of a
+     card whose own overflow:hidden already rounds the top edge, so the
+     container's radius only ever shows as an unwanted rounded seam where
+     the image meets the body below. Flattened to a plain rect; the card's
+     outer radius handles the top corners — same fix as RecipeCard.module.css. */
   border: none;
   border-radius: 0;
 }

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -72,6 +72,18 @@ describe('Header', () => {
       expect(screen.getByRole('link', { name: 'Users' })).toHaveAttribute('aria-current', 'page')
       expect(screen.getByRole('link', { name: 'Recipes' })).not.toHaveAttribute('aria-current')
     })
+
+    it('moves aria-current to the newly active link when navigating via click', () => {
+      renderWithRouter(<Header variant="admin" links={LINKS} />, { route: '/admin/recipes' })
+
+      expect(screen.getByRole('link', { name: 'Recipes' })).toHaveAttribute('aria-current', 'page')
+      expect(screen.getByRole('link', { name: 'Users' })).not.toHaveAttribute('aria-current')
+
+      fireEvent.click(screen.getByRole('link', { name: 'Users' }))
+
+      expect(screen.getByRole('link', { name: 'Users' })).toHaveAttribute('aria-current', 'page')
+      expect(screen.getByRole('link', { name: 'Recipes' })).not.toHaveAttribute('aria-current')
+    })
   })
 
   describe('logged-out variant', () => {

--- a/src/components/RecipeIngredients/RecipeIngredients.module.css
+++ b/src/components/RecipeIngredients/RecipeIngredients.module.css
@@ -25,6 +25,8 @@
   height: 17px;
   margin: 0;
   border: 1.5px solid var(--color-border-strong);
+  /* 5px: design literal — --radius-sm (6px) is the nearest token but is
+     1px off. */
   border-radius: 5px;
   cursor: pointer;
   position: relative;

--- a/src/components/RecipeIngredients/RecipeIngredients.test.tsx
+++ b/src/components/RecipeIngredients/RecipeIngredients.test.tsx
@@ -70,6 +70,16 @@ describe('RecipeIngredients checkboxes', () => {
     expect(flourCheckbox).not.toBeChecked()
   })
 
+  it('toggling one ingredient does not affect the checked state of the others', () => {
+    render(<RecipeIngredients ingredients={mockIngredients} slug="spaghetti-bolognese" />)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'flour 200 g' }))
+
+    expect(screen.getByRole('checkbox', { name: 'flour 200 g' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'sugar 100 g' })).not.toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'butter 50 g' })).not.toBeChecked()
+  })
+
   it('persists checked state to localStorage keyed by the recipe slug', () => {
     render(<RecipeIngredients ingredients={mockIngredients} slug="spaghetti-bolognese" />)
 

--- a/src/index.css
+++ b/src/index.css
@@ -96,7 +96,14 @@ svg[id^="mermaid-"] {
    way to beat a selector this stylesheet structurally cannot match.
    Targeting the tag names directly (not mermaid's class names)
    catches every text-bearing wrapper mermaid uses across node/edge/
-   cluster labels without needing to track each one's exact class. */
+   cluster labels without needing to track each one's exact class.
+   Literal #000 (not a --color-* token) is required for both properties:
+   this rule only exists to force mermaid's own inline `color:#333` back
+   down to pure black as the pre-invert input, so the filter above lands
+   on near-white text — any warm-toned token would invert to an off
+   color, not white. Known, permanent exception to the "no hardcoded
+   brutalist literal" grep in token-migration.md §6 — unrelated to the
+   old neo-brutalist system, added after that migration (see §5). */
 [data-theme="dark"] svg[id^="mermaid-"] span,
 [data-theme="dark"] svg[id^="mermaid-"] p,
 [data-theme="dark"] svg[id^="mermaid-"] text,

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -1,10 +1,15 @@
 import { fetchRecipes, fetchTags } from '@api/recipes'
 import type { RecipeIndex, Tag } from '@models/recipe'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { axe } from 'vitest-axe'
 import Recipes from './Recipes'
+
+const LocationDisplay = () => {
+  const location = useLocation()
+  return <div data-testid="location">{location.pathname}{location.search}</div>
+}
 
 vi.mock('@api/recipes', () => ({
   fetchRecipes: vi.fn(),
@@ -95,6 +100,45 @@ describe('Recipes page', () => {
     })
     expect(screen.getByText('Italian Pasta Carbonara')).toBeInTheDocument()
     expect(screen.queryByText('Thai Green Curry')).not.toBeInTheDocument()
+  })
+
+  it('clicking a tag chip writes ?tag=<tag> to the URL', async () => {
+    render(
+      <MemoryRouter initialEntries={['/recipes']}>
+        <Recipes />
+        <LocationDisplay />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /italian/i }))
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/recipes?tag=Italian')
+    expect(screen.getByRole('button', { name: /italian/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('clicking the active tag chip again clears ?tag from the URL', async () => {
+    render(
+      <MemoryRouter initialEntries={['/recipes?tag=Italian']}>
+        <Recipes />
+        <LocationDisplay />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /italian/i }))
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/recipes')
+    expect(screen.getByTestId('location').textContent).not.toMatch(/tag=/)
   })
 
   it('searches by keyword (title match)', async () => {

--- a/src/pages/Recipes/Recipes.test.tsx
+++ b/src/pages/Recipes/Recipes.test.tsx
@@ -59,10 +59,11 @@ const mockTags: Tag[] = [
   { tag: 'Spicy', count: 1 },
 ]
 
-const renderRecipes = (initialRoute = '/recipes') =>
+const renderRecipes = (initialRoute = '/recipes', { withLocation = false } = {}) =>
   render(
     <MemoryRouter initialEntries={[initialRoute]}>
       <Recipes />
+      {withLocation && <LocationDisplay />}
     </MemoryRouter>
   )
 
@@ -103,12 +104,7 @@ describe('Recipes page', () => {
   })
 
   it('clicking a tag chip writes ?tag=<tag> to the URL', async () => {
-    render(
-      <MemoryRouter initialEntries={['/recipes']}>
-        <Recipes />
-        <LocationDisplay />
-      </MemoryRouter>
-    )
+    renderRecipes('/recipes', { withLocation: true })
 
     await waitFor(() => {
       expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()
@@ -124,12 +120,7 @@ describe('Recipes page', () => {
   })
 
   it('clicking the active tag chip again clears ?tag from the URL', async () => {
-    render(
-      <MemoryRouter initialEntries={['/recipes?tag=Italian']}>
-        <Recipes />
-        <LocationDisplay />
-      </MemoryRouter>
-    )
+    renderRecipes('/recipes?tag=Italian', { withLocation: true })
 
     await waitFor(() => {
       expect(screen.getByText('Classic Margherita Pizza')).toBeInTheDocument()

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -252,6 +252,8 @@
 .notFoundBackLink {
   font-size: 14px;
   padding: 10px 18px;
+  /* 9px: design literal — --radius-md (10px) is the nearest token but is
+     1px off, same value as `.editLink`/`.viewLink`/`.publishButton` above. */
   border-radius: 9px;
   gap: 7px;
 }

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -155,7 +155,9 @@
   background: transparent;
   border: none;
   padding: 8px 16px;
-  border-radius: 6px;
+  /* Small toggle chip inside the segmented control → --radius-sm role
+     (docs/design/paper/token-migration.md §3a), and 6px is an exact match. */
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: background var(--duration-fast) var(--easing-default),
     color var(--duration-fast) var(--easing-default);
@@ -311,6 +313,8 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
   padding: 2px 7px;
+  /* 5px: design literal — --radius-sm (6px) is the nearest token but is
+     1px off. */
   border-radius: 5px;
   display: inline-block;
 }
@@ -371,6 +375,8 @@
   color: var(--color-text-muted);
   background: transparent;
   border: var(--border-width) solid transparent;
+  /* 8px: design literal — --radius-sm (6px) is the nearest token but is
+     2px off — same value as RecipeList.module.css's `.actionButton`. */
   border-radius: 8px;
   padding: 6px 11px;
   gap: 6px;


### PR DESCRIPTION
Closes #230

## What changed
- Fixed a stale grep pattern in `docs/design/paper/token-migration.md` §6: `--max-w-sm` was listed as a "removed token" even though issue #233 reinstated it as a legitimate current token (`ConfirmDialog`, `SocialCard`, `ToastProvider`) — false-positiving the greppable gate.
- Fixed a second stale-gate discrepancy: the "no hardcoded brutalist literal" grep wasn't actually clean — `src/index.css`'s mermaid dark-mode label-text fix (added after the original migration, for an unrelated reason) legitimately needs a literal `#000`. Documented this as a known, permanent exception in the doc rather than leaving the gate silently non-passing.
- Fixed one genuine token-migration oversight: `UserManagement.module.css`'s `border-radius: 6px` → `var(--radius-sm)` (exact match, was never migrated).
- Added "design literal" justification comments (matching the existing codebase convention) to a handful of pre-existing hardcoded radii that don't cleanly map to a token, in `AppCard`, `RecipeIngredients`, `RecipePreview`, `UserManagement`.
- Closed genuine test coverage gaps: tag-chip click → URL round-trip (`Recipes.test.tsx`), ingredient-checkbox isolation (`RecipeIngredients.test.tsx`), `aria-current` on click-navigation (`Header.test.tsx`). Audited the rest of the AC's named interactions (autosave transitions, publish gating, toast auto-dismiss, `aria-pressed`, dialog focus-trap entry/exit) and confirmed they already have solid coverage from the earlier #225–229 rebuild issues — no padding added.
- Updated `CLAUDE.md`: replaced the stale "rebuilds still landing" note with an epic-complete status, and documented the `vitest-axe` + `eslint-plugin-jsx-a11y` a11y test bar already in use across 8 test files.
- Confirmed `docs/prds/redesign.md` is already correctly deprecated (done in an earlier epic issue) — no action needed.

## Why
Closing-verification issue for the akli.dev Warm Editorial "Paper" Redesign epic (#232) — brings docs, tests, and the greppable token gates in line with what actually landed across #225–229 before the epic merges to main.

## How to verify
- `pnpm test` (833/833), `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm check:descendant-selectors` all pass
- Both grep commands in `docs/design/paper/token-migration.md` §6 return only the documented exceptions
- `git diff main...epic/paper-redesign` for the full epic state (this PR is the last piece before that merge)

## Decisions made
- Left the pre-existing `LocationDisplay` test helper duplicated across `ProtectedRoute.test.tsx`/`RecipeSearch.test.tsx`/`Login.test.tsx` untouched — this PR's new copy in `Recipes.test.tsx` was refactored to reuse the file's own `renderRecipes` helper instead of adding a 4th standalone copy, but consolidating all 4 into a shared test-utils import would touch files outside this issue's scope for a very small win; not worth a tracked issue on its own.
- Left the mermaid dark-mode `#000 !important` fix as-is — the more "correct" long-term fix (configuring mermaid's own theme via the rehype/MDX plugin) is explicitly out of scope for `src/**` CSS, already noted in `token-migration.md`, and not worth a separate tracked issue for a purely cosmetic edge case with no current user-facing bug.
- The dialog "Tab doesn't escape" half of the focus-trap AC isn't tested — jsdom 26 doesn't implement native `<dialog>` focus-trapping, and `ConfirmDialog` has no custom JS trap to test (relies entirely on the native element). Entry-focus and focus-restore are both tested.

## Out of scope (filed as follow-up issues)

- **#344** — Add a radius token between `--radius-sm` and `--radius-md`. Surfaced by `/simplify`: ~10 call sites across 8 files hardcode an 8px/9px literal with a "nearest token is off" comment because the scale has a gap there. Deferred because it requires a design decision on the token's value and touches files outside this issue's scope.