### PR TITLE
Add a radius token between --radius-sm and --radius-md

### DIFF
--- a/docs/design/paper/token-migration.md
+++ b/docs/design/paper/token-migration.md
@@ -144,6 +144,24 @@ for the cases above would have visibly broken the component (dialog/card nearly 
 width). That's why they were kept as flagged literals rather than forced onto `--max-w-article`
 at the time — #233 is the "later" this note referred to.
 
+### 3d. `--radius` gap fill
+
+The radius scale (`--radius-sm` 6px / `--radius-md` 10px / `--radius-lg` 12px / `--radius-xl`
+16px / `--radius-2xl` 18px / `--radius-full` 999px) had no step between `--radius-sm` and
+`--radius-md`, so consumers whose design literal fell in that gap were kept as hardcoded `8px`
+or `9px` with a "design literal, nearest token is Npx off" comment — flagged during #230's
+`/simplify` review.
+
+| Consumer | Old | Role | Resolution |
+|---|---|---|---|
+| `TagInput.module.css` `.chip`, `IngredientList.module.css`/`StepList.module.css`/`RecipeList.module.css` `.actionButton`, `UserManagement.module.css` `.removeAction` | `8px` literal | Small action buttons / chips | **Resolved (issue #344):** exact match onto the new token, no visual change. |
+| `UserManagement.module.css` `.roleSeg`, `RecipePreview.module.css` `.editLink`/`.viewLink`/`.publishButton`/`.notFoundBackLink` | `9px` literal | Segmented control / pill buttons | **Resolved (issue #344):** converged onto the same token; a real but accepted 1px visual change (9px → 8px). |
+
+**Resolved (issue #344):** the design system gained `--radius` (bare, unsuffixed — same
+base-tier naming convention as `--border-width`), 8px, the exact arithmetic midpoint of
+`--radius-sm` and `--radius-md`. All of the above call sites now reference `var(--radius)`;
+their "nearest token is Npx off" comments no longer apply and were removed.
+
 ## 4. Meaning flips (name unchanged, semantics changed)
 
 These keep their old name but now mean something different — a consumer that didn't change

--- a/src/components/IngredientList/IngredientList.module.css
+++ b/src/components/IngredientList/IngredientList.module.css
@@ -70,9 +70,7 @@
   min-height: 0;
   flex-shrink: 0;
   padding: 0;
-  /* 8px: design literal (Admin Recipe Editor.dc.html `.iconbtn`) —
-     --radius-sm (6px) is the nearest token but is 2px off. */
-  border-radius: 8px;
+  border-radius: var(--radius);
   border-color: var(--color-border);
   background: var(--color-field);
   color: var(--color-text-muted);

--- a/src/components/StepList/StepList.module.css
+++ b/src/components/StepList/StepList.module.css
@@ -67,9 +67,7 @@
   min-height: 0;
   flex-shrink: 0;
   padding: 0;
-  /* 8px: design literal — --radius-sm (6px) is the nearest token but is
-     2px off. */
-  border-radius: 8px;
+  border-radius: var(--radius);
   border-color: var(--color-border);
   background: var(--color-field);
   color: var(--color-text-muted);

--- a/src/components/TagInput/TagInput.module.css
+++ b/src/components/TagInput/TagInput.module.css
@@ -21,15 +21,14 @@
   gap: var(--space-2);
 }
 
-/* Tag's own padding (--space-1/--space-3, symmetric) and radius
-   (--radius-sm, 6px) are close but not an exact match for this design's
-   literal chip shape (5px 7px 5px 11px asymmetric padding, 8px radius) —
-   scoped under `.chips` so it reliably outranks Tag's own bare `.tag`
-   class regardless of CSS import order, same specificity-tie fix used
-   throughout this epic. */
+/* Tag's own padding (--space-1/--space-3, symmetric) is close but not an
+   exact match for this design's literal chip shape (5px 7px 5px 11px
+   asymmetric padding) — scoped under `.chips` so it reliably outranks
+   Tag's own bare `.tag` class regardless of CSS import order, same
+   specificity-tie fix used throughout this epic. */
 .chips .chip {
   padding: 5px 7px 5px 11px;
-  border-radius: 8px;
+  border-radius: var(--radius);
 }
 
 /* Tag exposes its remove button via the `removeClassName` prop (issue #265),

--- a/src/pages/admin/RecipeList/RecipeList.module.css
+++ b/src/pages/admin/RecipeList/RecipeList.module.css
@@ -197,9 +197,7 @@
   color: var(--color-text-muted);
   background: transparent;
   border: var(--border-width) solid transparent;
-  /* 8px: design literal — --radius-sm (6px) is the nearest token but is
-     2px off. */
-  border-radius: 8px;
+  border-radius: var(--radius);
   padding: 6px 10px;
   /* 6px: design literal, between --space-1 (4px) and --space-2 (8px). */
   gap: 6px;

--- a/src/pages/admin/RecipePreview/RecipePreview.module.css
+++ b/src/pages/admin/RecipePreview/RecipePreview.module.css
@@ -149,9 +149,7 @@
 .viewLink {
   font-size: 13px;
   padding: 8px 15px;
-  /* 9px: design literal — --radius-md (10px) is the nearest token but is
-     1px off. */
-  border-radius: 9px;
+  border-radius: var(--radius);
   gap: 7px;
 }
 
@@ -163,9 +161,7 @@
 .bannerActions .publishButton {
   padding: 8px 15px;
   font-size: 13px;
-  /* 9px: design literal — --radius-md (10px) is the nearest token but is
-     1px off. */
-  border-radius: 9px;
+  border-radius: var(--radius);
   gap: 7px;
 }
 
@@ -252,8 +248,6 @@
 .notFoundBackLink {
   font-size: 14px;
   padding: 10px 18px;
-  /* 9px: design literal — --radius-md (10px) is the nearest token but is
-     1px off, same value as `.editLink`/`.viewLink`/`.publishButton` above. */
-  border-radius: 9px;
+  border-radius: var(--radius);
   gap: 7px;
 }

--- a/src/pages/admin/UserManagement/UserManagement.module.css
+++ b/src/pages/admin/UserManagement/UserManagement.module.css
@@ -140,8 +140,7 @@
   display: inline-flex;
   background: var(--color-field);
   border: var(--border-width) solid var(--color-border);
-  /* 9px: design literal, between --radius-sm (6px) and --radius-md (10px). */
-  border-radius: 9px;
+  border-radius: var(--radius);
   padding: 3px;
   gap: 2px;
 }
@@ -375,9 +374,7 @@
   color: var(--color-text-muted);
   background: transparent;
   border: var(--border-width) solid transparent;
-  /* 8px: design literal — --radius-sm (6px) is the nearest token but is
-     2px off — same value as RecipeList.module.css's `.actionButton`. */
-  border-radius: 8px;
+  border-radius: var(--radius);
   padding: 6px 11px;
   gap: 6px;
   cursor: pointer;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -144,6 +144,7 @@
 
   /* ── Border radius — soft, rounded ────────────────────────── */
   --radius-sm:   6px;   /* chips, small controls */
+  --radius:      8px;   /* small buttons/action chips — between sm and md */
   --radius-md:   10px;  /* inputs, buttons */
   --radius-lg:   12px;  /* code panels, callouts */
   --radius-xl:   16px;  /* cards, panels, dialogs */


### PR DESCRIPTION
Closes #344

## What changed
- Added `--radius: 8px` to `src/styles/tokens.css`, filling the gap between `--radius-sm` (6px) and `--radius-md` (10px).
- Migrated 9 call sites (one more than the issue's own approximate count — a fresh grep also caught `RecipeList.module.css:202`, which the issue's list missed) from hardcoded `8px`/`9px` literals to `var(--radius)`, removing their now-obsolete "design literal, nearest token is Npx off" comments.
- Updated `docs/design/paper/token-migration.md` with a new §3d documenting the new token, following the same pattern §233/`--max-w-sm` used for tokens added after the original migration.

## Why
Surfaced by `/simplify` during #230's review: 10 (actually 9) recurring instances of the same "design literal" comment across 8 files was a sign the radius scale itself was missing a step, not that each site needed its own one-off justification.

## How to verify
- `pnpm test` (833/833, zero test files touched — this really is behavior-neutral from the suite's perspective), `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm check:descendant-selectors` all pass
- `grep -rn "border-radius: 8px\|border-radius: 9px" src/ --include="*.module.css"` returns zero matches

## Decisions made
- **Token name/value**: `--radius` (bare, unsuffixed — matches `--border-width`'s base-tier naming convention in the same file) at `8px` (exact arithmetic midpoint of `--radius-sm`/`--radius-md`). The 8px/9px call sites split evenly 4-4 with no natural majority, so this was a real design call — confirmed with the repo owner before implementation rather than picked unilaterally.
- **Accepted 1px visual change**: 4 of the 9 sites (`UserManagement.module.css` `.roleSeg`, and `RecipePreview.module.css`'s `.editLink`/`.viewLink`, `.publishButton`, `.notFoundBackLink`) were previously `9px` and are now `8px` — a real, signed-off consequence of resolving the 8px/9px disagreement onto one token, not a regression.

## Out of scope
None — this is a fully self-contained token-reference cleanup with no further follow-ups.