### PR TITLE
Manual QA and refinements

### DIFF
--- a/src/components/ImageUpload/ImageUpload.module.css
+++ b/src/components/ImageUpload/ImageUpload.module.css
@@ -118,7 +118,17 @@
 .replaceButton:hover {
   color: var(--color-text);
   border-color: var(--color-border-strong);
-  background-color: var(--color-hover);
+  /* Not --color-hover: that's a near-transparent wash (rgba alpha ~0.02–0.04)
+     meant to tint an already-transparent/opaque-page-colored surface (e.g.
+     Button's own .outline, which is `background-color: transparent` at
+     rest). This button is opaque at rest specifically because it overlays
+     an arbitrary photo — swapping to a near-transparent background on
+     hover let the cover image show through almost unobstructed, reading as
+     "the background disappeared" rather than a hover highlight.
+     --color-field is reliably lighter than --color-bg in both themes
+     (#FFFFFF vs #FBFAF7 light; #1B1914 vs #141310 dark) and, unlike
+     --color-hover, stays fully opaque. */
+  background-color: var(--color-field);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -103,6 +103,42 @@
   composes: linkIcon from '../../styles/interactions.module.css';
 }
 
+/* Reuses the "↗" glyph's own shape/weight (rather than the thinner "→"
+   glyph in most fonts) but rotated to visually point right, for CTAs
+   that want the up-right arrow's look with a rightward (not diagonal)
+   hover nudge. Self-contained rather than composing the shared
+   `linkIcon`/`nudgeRight` pair from interactions.module.css: that pair's
+   hover rule sets a bare `translateX`, which would silently clobber (or
+   be clobbered by, depending on bundle order) a rule here combining a
+   static rotation with the same translate. */
+.iconRotateRight {
+  display: inline-flex;
+  transition: transform var(--duration-base) var(--easing-default);
+  transform: rotate(45deg);
+}
+
+/* translateX listed before rotate: CSS composes transform functions
+   right-to-left against the point, so this order applies the rotation
+   first and then the translate in the outer (screen) coordinate space —
+   a clean horizontal nudge. The reverse order would translate first and
+   then rotate that offset too, dragging the hover motion diagonal. */
+.nudgeRight:hover .iconRotateRight {
+  transform: translateX(3px) rotate(45deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .iconRotateRight {
+    transition: none;
+  }
+
+  /* Cancel the hover nudge itself (not just its transition), matching
+     .nudgeRight/.nudgeLeft/.nudgeUpRight's shared reduced-motion reset —
+     but keep the static rotation, since that's orientation, not motion. */
+  .nudgeRight:hover .iconRotateRight {
+    transform: rotate(45deg);
+  }
+}
+
 .nudgeRight {
   composes: nudgeRight from '../../styles/interactions.module.css';
 }

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -21,10 +21,6 @@
     transition: color var(--duration-fast) var(--easing-default);
   }
 
-  .link:hover {
-    color: var(--color-primary);
-  }
-
   /* Button/pill shapes several admin pages independently hand-rolled on top
      of plain Link — border/bg, radius, hover color-swap, transition, all
      re-derived per file (issue #270). Centralized here so consumers only
@@ -78,6 +74,16 @@
 }
 
 .accent {
+  color: var(--color-primary);
+}
+
+/* Unlayered (not in @layer component-defaults) so its specificity
+   (class + :hover) actually beats the tone rules above — an unlayered
+   rule always wins over a layered one regardless of specificity, so this
+   couldn't live in the layer next to the base `.link` rule the way
+   `.ghost:hover`/`.solid:hover` do (those have no unlayered tone class to
+   compete with). */
+.link:hover {
   color: var(--color-primary);
 }
 

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -82,8 +82,13 @@
    rule always wins over a layered one regardless of specificity, so this
    couldn't live in the layer next to the base `.link` rule the way
    `.ghost:hover`/`.solid:hover` do (those have no unlayered tone class to
-   compete with). */
-.link:hover {
+   compete with).
+   Excludes .ghost/.solid: those variants own their hover color entirely
+   (layered `.ghost:hover`/`.solid:hover` above) — .solid's white text is
+   meant to stay white on hover (just a slight opacity dim), and without
+   this exclusion the unlayered rule here would win regardless of layer
+   order and repaint it accent-blue instead. */
+.link:hover:not(.ghost):not(.solid) {
   color: var(--color-primary);
 }
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -15,6 +15,13 @@ export interface LinkProps {
   iconSide?: 'left' | 'right'
   /** Direction the icon nudges on hover. @default 'right' */
   nudge?: 'left' | 'right' | 'up-right' | 'none'
+  /**
+   * Rotates the icon 45deg clockwise so a "↗" glyph reads as pointing
+   * right, while keeping a rightward (not diagonal) hover nudge — for CTAs
+   * that want the up-right arrow's visual weight/style without its
+   * diagonal direction.
+   */
+  rotateIcon?: boolean
   /** Button/pill shape. Omit for a plain link (default, unchanged). */
   variant?: 'ghost' | 'solid'
   ariaLabel?: string
@@ -37,6 +44,7 @@ const Link: FC<LinkProps> = ({
   iconSide = 'right',
   nudge = 'right',
   variant,
+  rotateIcon,
   ariaLabel,
   className: externalClassName,
 }) => {
@@ -61,7 +69,7 @@ const Link: FC<LinkProps> = ({
     .filter(Boolean)
     .join(' ')
 
-  const iconClassName = styles.icon
+  const iconClassName = rotateIcon ? styles.iconRotateRight : styles.icon
 
   const content = icon ? (
     <>

--- a/src/components/RecipeDetailView/RecipeDetailView.module.css
+++ b/src/components/RecipeDetailView/RecipeDetailView.module.css
@@ -91,6 +91,12 @@
   line-height: 1.7;
   color: var(--color-text);
   margin: 0;
+  /* recipe.intro comes from a plain <textarea> in the editor — HTML
+     collapses newlines by default, so line breaks typed there were
+     silently lost on render. pre-line preserves them as line breaks
+     while still collapsing runs of spaces/tabs and wrapping normally
+     (unlike pre-wrap, which would also preserve extra spaces verbatim). */
+  white-space: pre-line;
 }
 
 .divider {

--- a/src/components/RecipeIngredients/RecipeIngredients.module.css
+++ b/src/components/RecipeIngredients/RecipeIngredients.module.css
@@ -62,10 +62,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  /* Fixed white, not --color-on-primary — same rationale as Tag's own
-     .active state (design hardcodes #fff on the accent fill regardless
-     of theme). */
-  color: #fff;
+  color: var(--color-on-accent-fixed);
   font-size: 10px;
   line-height: 1;
 }

--- a/src/components/RecipeIngredients/RecipeIngredients.module.css
+++ b/src/components/RecipeIngredients/RecipeIngredients.module.css
@@ -2,6 +2,22 @@
   list-style: none;
   padding: 0;
   margin: 0;
+  /* Design wants checked-off ingredient text to visibly fade (design source:
+     docs/design/paper/pages/Recipe.dc.html's `--faint` color). Plain
+     --color-text-faint-on-surface can't be reused here: at ~4.75:1 against
+     --color-surface it's nearly indistinguishable from --color-text-muted
+     (~4.81:1), which is already this row's non-checked color — so the
+     "faded" state read as unchanged. This local override is tuned to
+     ~4.55:1, the lightest shade that still clears WCAG AA's 4.5:1 floor
+     against --color-surface, giving the most fade this surface allows.
+     Dark mode's existing faint-on-surface token already has enough gap
+     from muted (~4.71:1 vs ~6.68:1) to read as a visible fade, so it's
+     reused unchanged there. */
+  --checked-ingredient-color: #736D63;
+}
+
+:global([data-theme='dark']) .list {
+  --checked-ingredient-color: var(--color-text-faint-on-surface);
 }
 
 .item:not(:first-child) {
@@ -65,8 +81,8 @@
   text-decoration: line-through;
   /* WCAG AA override: --color-text-faint fails 4.5:1 against this
      panel's --color-surface (4.35:1 light / 4.40:1 dark) — use the
-     shared --color-text-faint-on-surface token instead. */
-  color: var(--color-text-faint-on-surface);
+     locally-tuned --checked-ingredient-color instead (see .list). */
+  color: var(--checked-ingredient-color);
 }
 
 .qty {
@@ -77,7 +93,7 @@
 }
 
 .checkbox:checked ~ .qty {
-  color: var(--color-text-faint-on-surface);
+  color: var(--checked-ingredient-color);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/RecipeSteps/RecipeSteps.module.css
+++ b/src/components/RecipeSteps/RecipeSteps.module.css
@@ -42,6 +42,13 @@
   line-height: 1.7;
   color: var(--color-text);
   margin: 0 0 var(--space-3);
+  /* step.text comes from a multi-line <Textarea> in the editor — HTML
+     collapses newlines by default, so line breaks typed there were
+     silently lost on render. pre-line preserves them as line breaks
+     while still collapsing runs of spaces/tabs and wrapping normally
+     (unlike pre-wrap, which would also preserve extra spaces verbatim);
+     same fix as RecipeDetailView's own .intro. */
+  white-space: pre-line;
 }
 
 .image {

--- a/src/components/RecipeSteps/RecipeSteps.module.css
+++ b/src/components/RecipeSteps/RecipeSteps.module.css
@@ -37,18 +37,17 @@
    `@layer component-defaults` (Typography.module.css, #263), so this plain
    unlayered class deterministically wins without needing the old
    descendant-selector trick. */
+/* One `.text` per line (see RecipeSteps.tsx) rather than one block with
+   `white-space: pre-line` — matches the design's own step.lines[] model
+   (docs/design/paper/pages/Recipe.dc.html) exactly: a fixed --space-3
+   (12px) gap between sentences, distinct from the larger ~28px this
+   font-size/line-height would produce between wrapped *and* newline-
+   separated lines alike if they all lived in one pre-line block. */
 .text {
   font-size: 16.5px;
   line-height: 1.7;
   color: var(--color-text);
   margin: 0 0 var(--space-3);
-  /* step.text comes from a multi-line <Textarea> in the editor — HTML
-     collapses newlines by default, so line breaks typed there were
-     silently lost on render. pre-line preserves them as line breaks
-     while still collapsing runs of spaces/tabs and wrapping normally
-     (unlike pre-wrap, which would also preserve extra spaces verbatim);
-     same fix as RecipeDetailView's own .intro. */
-  white-space: pre-line;
 }
 
 .image {

--- a/src/components/RecipeSteps/RecipeSteps.test.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.test.tsx
@@ -48,6 +48,30 @@ describe('RecipeSteps', () => {
     expect(screen.getByText('Let it cool')).toBeInTheDocument()
   })
 
+  it('renders each newline-separated sentence in step.text as its own paragraph', () => {
+    const multiLineSteps: Step[] = [
+      {
+        stepId: stepId1,
+        order: 1,
+        text: 'Preheat the oven.\nHeat a pan with oil.\nAdd the lardons and cook.',
+      },
+    ]
+
+    render(<RecipeSteps steps={multiLineSteps} slug={slug} />)
+
+    const preheat = screen.getByText('Preheat the oven.')
+    const heat = screen.getByText('Heat a pan with oil.')
+    const add = screen.getByText('Add the lardons and cook.')
+
+    expect(preheat.tagName).toBe('P')
+    expect(heat.tagName).toBe('P')
+    expect(add.tagName).toBe('P')
+    // Each sentence is its own element (not one blob with embedded
+    // newlines), so the tighter --space-3 margin applies per line.
+    expect(preheat).not.toBe(heat)
+    expect(heat).not.toBe(add)
+  })
+
   it('shows step image with alt text when image is present', () => {
     render(<RecipeSteps steps={mockSteps} slug={slug} />)
 

--- a/src/components/RecipeSteps/RecipeSteps.tsx
+++ b/src/components/RecipeSteps/RecipeSteps.tsx
@@ -19,7 +19,14 @@ const RecipeSteps: FC<RecipeStepsProps> = ({ steps, slug }) => (
           {idx + 1}
         </span>
         <div className={styles.content}>
-          <Typography variant="body" className={styles.text}>{step.text}</Typography>
+          {step.text
+            .split('\n')
+            .filter((line) => line.trim())
+            .map((line, lineIdx) => (
+              <Typography key={lineIdx} variant="body" className={styles.text}>
+                {line}
+              </Typography>
+            ))}
           {step.image && (step.image.processedAt ? (
             <Image
               src={recipeImageUrl(slug, stepImageType(step.stepId), 'medium')}

--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -48,11 +48,10 @@ a.tag:hover:not(.active) {
 
 .active {
   background-color: var(--color-primary);
-  /* Fixed white, not --color-on-primary (which flips to dark text in
-     dark mode) — the design's `.tag-chip[data-active]`/`.cat-chip
-     [data-active]` both hardcode color:#fff regardless of theme, same
-     pattern as the "Browse all recipes" CTA. */
-  color: #fff;
+  /* --color-on-accent-fixed, not --color-on-primary (which flips to dark
+     text in dark mode) — the design's `.tag-chip[data-active]`/`.cat-chip
+     [data-active]` both hardcode color:#fff regardless of theme. */
+  color: var(--color-on-accent-fixed);
   border-color: var(--color-primary);
 }
 

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -133,6 +133,25 @@ export const iconWarning = (
   </svg>
 )
 
+// No explicit width/height — both current consumers (RecipeList's
+// .rowActions .actionButton, UserManagement's .rowActionSlot .removeAction)
+// already force 15x15 via their own CSS regardless of the SVG's own size.
+export const iconDelete = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M3 6h18" />
+    <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+  </svg>
+)
+
 export const iconRetry = (
   <svg
     width="15"

--- a/src/pages/Apps/Apps.tsx
+++ b/src/pages/Apps/Apps.tsx
@@ -77,8 +77,9 @@ const Apps: FC = () => {
           </Typography>
           <Link
             to="/blog"
-            icon="→"
+            icon="↗"
             nudge="right"
+            rotateIcon
             tone="accent"
             className={styles.readBlogLink}
           >

--- a/src/pages/Blog/Blog.test.tsx
+++ b/src/pages/Blog/Blog.test.tsx
@@ -101,7 +101,7 @@ describe('Blog', () => {
   it('renders the page heading', () => {
     renderBlog()
     expect(
-      screen.getByRole('heading', { level: 1, name: 'Blog' })
+      screen.getByRole('heading', { level: 1, name: 'Notes' })
     ).toBeInTheDocument()
   })
 

--- a/src/pages/Blog/Blog.test.tsx
+++ b/src/pages/Blog/Blog.test.tsx
@@ -101,7 +101,7 @@ describe('Blog', () => {
   it('renders the page heading', () => {
     renderBlog()
     expect(
-      screen.getByRole('heading', { level: 1, name: 'Notes' })
+      screen.getByRole('heading', { level: 1, name: 'Archive' })
     ).toBeInTheDocument()
   })
 

--- a/src/pages/Blog/Blog.tsx
+++ b/src/pages/Blog/Blog.tsx
@@ -49,7 +49,7 @@ const Blog = () => {
         <Typography variant="caption" as="p" className={styles.eyebrow}>
           The blog
         </Typography>
-        <Typography variant="heading1">Blog</Typography>
+        <Typography variant="heading1">Notes</Typography>
         <Typography variant="bodyLarge">Posts coming soon.</Typography>
       </section>
     )
@@ -62,7 +62,7 @@ const Blog = () => {
           The blog
         </Typography>
         <Typography variant="heading1" className={styles.heading}>
-          Blog
+          Notes
         </Typography>
         <Typography variant="bodyLarge" className={styles.intro}>
           Thoughts on building things, technical deep-dives, and the lessons

--- a/src/pages/Blog/Blog.tsx
+++ b/src/pages/Blog/Blog.tsx
@@ -49,7 +49,7 @@ const Blog = () => {
         <Typography variant="caption" as="p" className={styles.eyebrow}>
           The blog
         </Typography>
-        <Typography variant="heading1">Notes</Typography>
+        <Typography variant="heading1">Archive</Typography>
         <Typography variant="bodyLarge">Posts coming soon.</Typography>
       </section>
     )
@@ -62,7 +62,7 @@ const Blog = () => {
           The blog
         </Typography>
         <Typography variant="heading1" className={styles.heading}>
-          Notes
+          Archive
         </Typography>
         <Typography variant="bodyLarge" className={styles.intro}>
           Thoughts on building things, technical deep-dives, and the lessons

--- a/src/pages/Home/Home.module.css
+++ b/src/pages/Home/Home.module.css
@@ -105,26 +105,17 @@
   padding: var(--space-3) var(--space-6);
   border-radius: var(--radius-full);
   text-decoration: none;
+  /* `opacity` is only meaningful on the solid variant (RecipeList's own
+     `.newButton` has the identical comment/fix for the same reason): this
+     unlayered class overrides `.solid`'s own transition wholesale rather
+     than merging with it (a bare CSS `transition` shorthand always
+     replaces the whole property, layered or not), so `.solid:hover`'s
+     opacity dim would otherwise snap instantly instead of fading. */
   transition:
     background var(--duration-fast) var(--easing-default),
     color var(--duration-fast) var(--easing-default),
-    border-color var(--duration-fast) var(--easing-default);
-}
-
-.ctaSolid {
-  background: var(--color-btn-bg);
-  color: var(--color-btn-fg);
-  border: var(--border-width) solid var(--color-btn-bg);
-}
-
-.ctaSolid:hover {
-  background: var(--color-primary);
-  border-color: var(--color-primary);
-  /* Without this, Link's own generic `.link:hover` rule (accent-blue
-     text) bleeds through onto the now-blue background, making the
-     label unreadable in both themes. #fff matches the design exactly
-     (hardcoded there too, not theme-dependent). */
-  color: #fff;
+    border-color var(--duration-fast) var(--easing-default),
+    opacity var(--duration-fast) var(--easing-default);
 }
 
 .ctaOutline {

--- a/src/pages/Home/Home.test.tsx
+++ b/src/pages/Home/Home.test.tsx
@@ -49,13 +49,11 @@ describe('Home', () => {
     expect(screen.getByText('Full-stack engineer')).toBeInTheDocument()
   })
 
-  it('displays plain, non-hyperbolic bio copy', () => {
+  it('displays the bio copy matching the design', () => {
     renderHome()
     expect(
-      screen.getByText(/I build web applications with React, TypeScript, and AWS/i)
+      screen.getByText(/I build beautiful, responsive web applications with React, TypeScript/i)
     ).toBeInTheDocument()
-    expect(screen.queryByText(/beautiful/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/passionate/i)).not.toBeInTheDocument()
   })
 
   it('renders the profile image with real alt text', () => {

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -59,7 +59,7 @@ const LinkSection: FC<LinkSectionProps> = ({ headingId, eyebrow, allHref, rows }
       >
         {eyebrow}
       </Typography>
-      <Link to={allHref} icon="→" nudge="right" className={styles.sectionAll}>
+      <Link to={allHref} icon="↗" nudge="right" rotateIcon className={styles.sectionAll}>
         All
       </Link>
     </div>
@@ -177,8 +177,9 @@ const Home: FC = () => {
             <div className={styles.browseAll}>
               <Link
                 to="/recipes"
-                icon="→"
+                icon="↗"
                 nudge="right"
+                rotateIcon
                 className={`${styles.cta} ${styles.ctaSolid}`}
               >
                 Browse all recipes

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -123,9 +123,9 @@ const Home: FC = () => {
           Full-stack engineer
         </Typography>
         <Typography variant="body" as="p" className={styles.bio}>
-          I build web applications with React, TypeScript, and AWS — from the
-          frontend down to the infrastructure that runs it. This site collects
-          some of what I&apos;ve built and written along the way.
+          I build beautiful, responsive web applications with React,
+          TypeScript, and modern web technologies — with a focus on
+          accessible, user-friendly experiences.
         </Typography>
         <div className={styles.ctaRow}>
           <a

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -180,7 +180,8 @@ const Home: FC = () => {
                 icon="↗"
                 nudge="right"
                 rotateIcon
-                className={`${styles.cta} ${styles.ctaSolid}`}
+                variant="solid"
+                className={styles.cta}
               >
                 Browse all recipes
               </Link>

--- a/src/pages/Recipes/Recipes.tsx
+++ b/src/pages/Recipes/Recipes.tsx
@@ -19,7 +19,7 @@ const RecipesHero: FC<{ intro?: ReactNode }> = ({ intro }) => (
       From the Kitchen
     </Typography>
     <Typography variant="heading1" className={styles.heading}>
-      Things I keep coming back to.
+      The meals I cook on repeat.
     </Typography>
     {intro && (
       <Typography variant="bodyLarge" className={styles.intro}>

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -435,9 +435,7 @@
   border: var(--border-width-thick) solid var(--color-border);
   font-size: 10px;
   line-height: 1;
-  /* Fixed white, not --color-on-primary — same rationale as
-     RecipeIngredients' own checked checkbox tick. */
-  color: #fff;
+  color: var(--color-on-accent-fixed);
 }
 
 .checklistItem[data-done="true"] .checklistIcon {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -412,13 +412,37 @@
   color: var(--color-text);
 }
 
+/* Done items fade out rather than disappearing — the whole set of publish
+   requirements stays visible as a persistent progress checklist (see the
+   comment on computePublishChecklist in RecipeEditor.tsx). Same "already
+   handled" fade idiom as the public recipe page's checked-off ingredients
+   (RecipeIngredients.module.css); --color-text-faint-on-surface for the
+   same reason — .railCard sits on --color-surface, and plain
+   --color-text-faint fails WCAG AA there. */
+.checklistItem[data-done="true"] {
+  color: var(--color-text-faint-on-surface);
+}
+
 .checklistIcon {
   flex-shrink: 0;
   margin-top: 1px;
   width: 16px;
   height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: var(--radius-full);
   border: var(--border-width-thick) solid var(--color-border);
+  font-size: 10px;
+  line-height: 1;
+  /* Fixed white, not --color-on-primary — same rationale as
+     RecipeIngredients' own checked checkbox tick. */
+  color: #fff;
+}
+
+.checklistItem[data-done="true"] .checklistIcon {
+  border-color: var(--color-success);
+  background: var(--color-success);
 }
 
 .previewWrap {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.test.tsx
@@ -575,6 +575,36 @@ describe('RecipeEditor page', () => {
         expect(screen.getByRole('button', { name: /publish/i })).not.toBeDisabled()
       })
     })
+
+    it('keeps Title/Intro visible (checked off) in the checklist once filled in, instead of dropping them', async () => {
+      const user = userEvent.setup()
+      renderEditor('/admin/recipes/new')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /publish/i })).toBeInTheDocument()
+      })
+
+      await user.type(screen.getByRole('textbox', { name: /title/i }), 'My Recipe')
+      await user.type(screen.getByRole('textbox', { name: /intro/i }), 'A great recipe')
+
+      const publishButton = screen.getByRole('button', { name: /publish/i })
+      const describedBy = publishButton.getAttribute('aria-describedby')
+      const checklist = document.getElementById(describedBy as string)
+
+      await waitFor(() => {
+        const titleItem = within(checklist as HTMLElement).getByText('Title').closest('li')
+        const introItem = within(checklist as HTMLElement).getByText('Intro').closest('li')
+        expect(titleItem).toHaveAttribute('data-done', 'true')
+        expect(introItem).toHaveAttribute('data-done', 'true')
+        expect(titleItem?.textContent).toContain('✓')
+        expect(introItem?.textContent).toContain('✓')
+      })
+
+      // Still-missing items remain present and unchecked.
+      const coverItem = within(checklist as HTMLElement).getByText('Cover image').closest('li')
+      expect(coverItem).toHaveAttribute('data-done', 'false')
+      expect(coverItem?.textContent).not.toContain('✓')
+    })
   })
 
   describe('published-mode submit (Update)', () => {

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -211,20 +211,15 @@ interface PublishChecklistItem {
 // item rather than disappearing from the box). Per-step image warnings
 // below stay conditional (pushed only when there's an actual problem)
 // since they only apply to steps that have an image at all.
-const BASE_PUBLISH_CHECKLIST: { label: string; isDone: (form: FormState) => boolean }[] = [
-  { label: 'Title', isDone: (form) => !!form.title.trim() },
-  { label: 'Intro', isDone: (form) => !!form.intro.trim() },
-  { label: 'Cover image', isDone: (form) => form.coverImageProcessedAt !== undefined },
-  { label: 'Alt text', isDone: (form) => !!form.coverImageAlt.trim() },
-  { label: 'At least one ingredient', isDone: (form) => form.ingredients.some((ing) => ing.item.trim()) },
-  { label: 'At least one step', isDone: (form) => form.steps.some((s) => s.text.trim()) },
-]
-
 const computePublishChecklist = (form: FormState): PublishChecklistItem[] => {
-  const items: PublishChecklistItem[] = BASE_PUBLISH_CHECKLIST.map(({ label, isDone }) => ({
-    label,
-    done: isDone(form),
-  }))
+  const items: PublishChecklistItem[] = [
+    { label: 'Title', done: !!form.title.trim() },
+    { label: 'Intro', done: !!form.intro.trim() },
+    { label: 'Cover image', done: form.coverImageProcessedAt !== undefined },
+    { label: 'Alt text', done: !!form.coverImageAlt.trim() },
+    { label: 'At least one ingredient', done: form.ingredients.some((ing) => ing.item.trim()) },
+    { label: 'At least one step', done: form.steps.some((s) => s.text.trim()) },
+  ]
   form.steps.forEach((step, index) => {
     if (step.image && step.image.processedAt === undefined) {
       items.push({ label: `Step ${index + 1} image still processing`, done: false })

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -198,23 +198,42 @@ const buildPatchPayload = (form: FormState): Partial<Recipe> => ({
   ...(isValidSlug(form.slug) ? { slug: form.slug } : {}),
 })
 
-const computeMissingFields = (form: FormState): string[] => {
-  const missing: string[] = []
-  if (!form.title.trim()) missing.push('Title')
-  if (!form.intro.trim()) missing.push('Intro')
-  if (form.coverImageProcessedAt === undefined) missing.push('Cover image')
-  if (!form.coverImageAlt.trim()) missing.push('Alt text')
-  if (!form.ingredients.some((ing) => ing.item.trim())) missing.push('At least one ingredient')
-  if (!form.steps.some((s) => s.text.trim())) missing.push('At least one step')
+interface PublishChecklistItem {
+  label: string
+  done: boolean
+}
+
+// The base requirements are always applicable to every recipe, so they're
+// listed unconditionally with a done/not-done state (design source: Admin
+// Recipe Editor.dc.html's `missing()`/`cl` mapping — every item is always
+// rendered and ticked off in place, never filtered down to only what's
+// outstanding, so a filled-in Title/Intro stays visible as a completed
+// item rather than disappearing from the box). Per-step image warnings
+// below stay conditional (pushed only when there's an actual problem)
+// since they only apply to steps that have an image at all.
+const BASE_PUBLISH_CHECKLIST: { label: string; isDone: (form: FormState) => boolean }[] = [
+  { label: 'Title', isDone: (form) => !!form.title.trim() },
+  { label: 'Intro', isDone: (form) => !!form.intro.trim() },
+  { label: 'Cover image', isDone: (form) => form.coverImageProcessedAt !== undefined },
+  { label: 'Alt text', isDone: (form) => !!form.coverImageAlt.trim() },
+  { label: 'At least one ingredient', isDone: (form) => form.ingredients.some((ing) => ing.item.trim()) },
+  { label: 'At least one step', isDone: (form) => form.steps.some((s) => s.text.trim()) },
+]
+
+const computePublishChecklist = (form: FormState): PublishChecklistItem[] => {
+  const items: PublishChecklistItem[] = BASE_PUBLISH_CHECKLIST.map(({ label, isDone }) => ({
+    label,
+    done: isDone(form),
+  }))
   form.steps.forEach((step, index) => {
     if (step.image && step.image.processedAt === undefined) {
-      missing.push(`Step ${index + 1} image still processing`)
+      items.push({ label: `Step ${index + 1} image still processing`, done: false })
     }
     if (step.image?.processedAt !== undefined && !step.image.alt?.trim()) {
-      missing.push(`Step ${index + 1} image alt text`)
+      items.push({ label: `Step ${index + 1} image alt text`, done: false })
     }
   })
-  return missing
+  return items
 }
 
 const draftFromCreated = (id: string, slug: string): Recipe => ({
@@ -448,8 +467,8 @@ const RecipeEditor: FC = () => {
 
   const slugValid = isValidSlug(form.slug)
 
-  const missingFields = computeMissingFields(form)
-  const canPublish = missingFields.length === 0 && slugValid
+  const publishChecklist = computePublishChecklist(form)
+  const canPublish = publishChecklist.every((item) => item.done) && slugValid
 
   const handlePublish = async () => {
     if (!form.id) return
@@ -851,10 +870,16 @@ const RecipeEditor: FC = () => {
                       aria-labelledby={`${MISSING_FIELDS_ID}-label`}
                       className={styles.checklist}
                     >
-                      {missingFields.map((field) => (
-                        <li key={field} className={styles.checklistItem}>
-                          <span className={styles.checklistIcon} aria-hidden="true" />
-                          <span>{field}</span>
+                      {publishChecklist.map((item) => (
+                        <li
+                          key={item.label}
+                          className={styles.checklistItem}
+                          data-done={item.done}
+                        >
+                          <span className={styles.checklistIcon} aria-hidden="true">
+                            {item.done ? '✓' : ''}
+                          </span>
+                          <span>{item.label}</span>
                         </li>
                       ))}
                     </ul>

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -908,7 +908,7 @@ const RecipeEditor: FC = () => {
                     to={`/recipes/${form.slug}`}
                     icon={iconPreview}
                     iconSide="right"
-                    nudge="right"
+                    nudge="none"
                     className={styles.previewLink}
                   >
                     View live recipe

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -6,7 +6,7 @@ import {
   unpublishRecipe,
 } from '@api/recipes'
 import ConfirmDialog from '@components/ConfirmDialog'
-import { iconEdit, iconPreview, iconPublish, iconRetry, iconWarning } from '@components/icons'
+import { iconDelete, iconEdit, iconPreview, iconPublish, iconRetry, iconWarning } from '@components/icons'
 import Link from '@components/Link'
 import StateBox from '@components/StateBox'
 import StatusBadge from '@components/StatusBadge'
@@ -52,22 +52,6 @@ const iconUnpublish = (
   >
     <path d="M3 3v18h18" />
     <path d="m19 9-5 5-4-4-3 3" />
-  </svg>
-)
-
-const iconDelete = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M3 6h18" />
-    <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
-    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
   </svg>
 )
 

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -2,7 +2,7 @@ import { handleSessionError } from '@api/auth'
 import { fetchUsers, inviteUser, removeUser, UserExistsError } from '@api/users'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
-import { IconAlertCircle, iconRetry, iconWarning } from '@components/icons'
+import { IconAlertCircle, iconDelete, iconRetry, iconWarning } from '@components/icons'
 import Input from '@components/Input'
 import StateBox from '@components/StateBox'
 import StatusBadge from '@components/StatusBadge'
@@ -37,22 +37,6 @@ const iconInvite = (
     <circle cx="9" cy="7" r="4" />
     <line x1="19" y1="8" x2="19" y2="14" />
     <line x1="22" y1="11" x2="16" y2="11" />
-  </svg>
-)
-
-const iconTrash = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M3 6h18" />
-    <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
-    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
   </svg>
 )
 
@@ -315,7 +299,7 @@ const UserManagement = () => {
                         onClick={() => setRemoveTarget(userRow)}
                         title="Remove user"
                       >
-                        {iconTrash}
+                        {iconDelete}
                         Remove
                       </button>
                     )}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -85,6 +85,14 @@
   --color-primary:       #1F66E0;   /* links, focus, active filter, accents */
   --color-on-primary:    #FFFFFF;
   --color-link:          #1F66E0;
+  /* Fixed white, not --color-on-primary (which flips to dark text in dark
+     mode) — the design hardcodes #fff on small accent-filled glyphs (a
+     checkmark tick, an active tag chip) regardless of theme. Consolidates
+     what were 3 identical component-local #fff literals (Tag's .active,
+     RecipeIngredients' checked checkbox tick, RecipeEditor's checklist
+     tick), each previously cross-referencing the other two in comments,
+     into one shared token — same pattern as --color-success-on-tint above. */
+  --color-on-accent-fixed: #fff;
 
   /* Inverted button (primary CTA) */
   --color-btn-bg:        #1C1A16;
@@ -229,6 +237,7 @@
   --color-primary:       #6BA0FF;
   --color-on-primary:    #11151F;
   --color-link:          #6BA0FF;
+  --color-on-accent-fixed: #fff;
 
   --color-btn-bg:        #F3F0E8;
   --color-btn-fg:        #141310;


### PR DESCRIPTION
Closes #231

## What changed

Manual QA pass across the paper-redesign epic, with fixes applied live as issues were found:

**Interaction/hover fixes:**
- Footer and other plain-tone links weren't changing color on hover (an `@layer` ordering bug let the tone class's unlayered color always win over the layered hover rule)
- Solid/ghost buttons (e.g. "New recipe") briefly regressed to repainting their text accent-blue on hover after the footer-hover fix — corrected with a `:not(.ghost):not(.solid)` exclusion
- Home's "Browse all recipes" CTA had the same blue-hover bug via its own hand-rolled `.ctaSolid` class — switched to Link's shared `variant="solid"` (matching RecipeList's "New recipe" button) instead of maintaining a parallel implementation
- The cover-image "replace" button's hover faded toward transparent instead of lightening, since it reused a wash meant for already-transparent buttons — switched to an opaque, genuinely lighter token
- RecipeEditor's "View live recipe" eye icon no longer nudges on hover (nudge is for arrows only, matching the existing convention on RecipePreview's edit icon)

**Visual/design-fidelity fixes:**
- Checked-off recipe ingredients now visibly fade (previous AA-safe color was nearly identical to unchecked text)
- Home/Apps/Recipes CTA arrows now consistently use the up-right glyph rotated to point right, matching the App card's arrow style
- RecipeEditor's "Before publishing" checklist now stays visible with a checkmark once each requirement is met, instead of items silently disappearing (matches the design's persistent-checklist model)
- Recipe intro and step text now respect line breaks typed in the editor instead of collapsing into one paragraph; step-to-step sentence spacing tightened to match the design's 12px gap instead of a full line-height gap

**Copy:**
- Home hero bio copy restored to match the design
- Recipes page title → "The meals I cook on repeat."
- Blog page title → "Archive"

**Cleanup (epic-wide `/simplify` pass, run as this issue's verification step):**
- Consolidated 3 duplicated hardcoded `#fff` colors into one `--color-on-accent-fixed` token
- Consolidated two byte-identical trash-icon SVGs into one shared `icons.tsx` export
- Flattened an unnecessary closure-table indirection in RecipeEditor's publish-checklist construction

## Why

This is the epic's final manual QA/verification issue (blocked by #225–#229, all merged) — reviewing the live redesign end-to-end and fixing what didn't match the design or behaved inconsistently before the epic merges to `main`.

## How to verify

- Hover over links/buttons across Home, Apps, Recipes, Blog, and the admin recipe editor in both themes — colors and nudge behavior should match the descriptions above.
- Check off an ingredient on any recipe page — text should visibly lighten.
- Edit a recipe's intro or a step's text with multiple sentences on separate lines — both should render with line breaks preserved on the public page.
- Load `/recipes` and `/blog` — titles read "The meals I cook on repeat." and "Archive".
- `pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm check:descendant-selectors` all pass.

## Decisions made

- Home's hero bio copy was deliberately reverted to the design's original hyperbolic wording per explicit user direction mid-session (a prior commit in this same epic had intentionally replaced it with plainer copy, guarded by a test) — the guard test was updated to match.
- The `#fff` → `--color-on-accent-fixed` token consolidation and RecipeList/UserManagement icon merge were applied inline as part of the epic-wide `/simplify` pass; several other findings from that pass were judged too broad/risky for this PR and filed as follow-ups instead (see below).
- Did not investigate a hydration warning observed in local dev mode (`pnpm dev`) on the `/recipes` route — none of this PR's commits touch SSR/hydration logic (`entry-server.tsx`, theme detection), so it's very likely pre-existing and out of scope here. Flagging it in case it's worth its own issue.

## Out of scope (filed as follow-up issues)

- **#347** — Consolidate remaining duplicated/near-duplicate inline icons into `icons.tsx`. Needs a size-prop icon pattern across several admin pages, more than a same-PR drive-by.
- **#348** — Extract a shared reorder-controls component from `IngredientList`/`StepList`. Cross-component extraction touching both components' tests.
- **#349** — Simplify `Login.tsx`'s field-config abstraction back to literal blocks. Has existing test coverage worth its own careful pass.
- **#350** — Give `Button` a danger/outline tone instead of out-specificity-ing it from `RecipeEditor`. New `Button` API surface, deserves its own review.