### PR TITLE
Simplify Login.tsx's field-config abstraction back to literal blocks

### DIFF
--- a/src/pages/admin/Login/Login.tsx
+++ b/src/pages/admin/Login/Login.tsx
@@ -5,7 +5,7 @@ import Input from '@components/Input'
 import Typography from '@components/Typography'
 import { useAuth } from '@contexts/AuthContext'
 import type { AuthChallenge } from '@models/auth'
-import { type ChangeEvent, type FormEvent, useEffect, useRef, useState } from 'react'
+import { type FormEvent, useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import styles from './Login.module.css'
@@ -15,17 +15,6 @@ const isChallenge = (result: unknown): result is AuthChallenge =>
   result !== null &&
   'challengeName' in result &&
   (result as AuthChallenge).challengeName === 'NEW_PASSWORD_REQUIRED'
-
-interface FieldConfig {
-  id: string
-  name: string
-  label: string
-  type: string
-  autoComplete: string
-  placeholder: string
-  value: string
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void
-}
 
 const Login = () => {
   const { login } = useAuth()
@@ -123,52 +112,6 @@ const Login = () => {
       }
   const submitLabel = loading ? copy.loadingLabel : copy.idleLabel
 
-  const fields: FieldConfig[] = isSetPassword
-    ? [
-        {
-          id: 'new-password',
-          name: 'newPassword',
-          label: 'New password',
-          type: 'password',
-          autoComplete: 'new-password',
-          placeholder: 'At least 8 characters',
-          value: newPassword,
-          onChange: (e) => setNewPassword(e.target.value),
-        },
-        {
-          id: 'confirm-password',
-          name: 'confirmPassword',
-          label: 'Confirm password',
-          type: 'password',
-          autoComplete: 'new-password',
-          placeholder: 'Re-enter your new password',
-          value: confirmPassword,
-          onChange: (e) => setConfirmPassword(e.target.value),
-        },
-      ]
-    : [
-        {
-          id: 'email',
-          name: 'email',
-          label: 'Email',
-          type: 'email',
-          autoComplete: 'username',
-          placeholder: 'you@akli.dev',
-          value: email,
-          onChange: (e) => setEmail(e.target.value),
-        },
-        {
-          id: 'password',
-          name: 'password',
-          label: 'Password',
-          type: 'password',
-          autoComplete: 'current-password',
-          placeholder: '••••••••••',
-          value: password,
-          onChange: (e) => setPassword(e.target.value),
-        },
-      ]
-
   return (
     <div className={styles.page}>
       <div className={styles.column}>
@@ -196,24 +139,75 @@ const Login = () => {
             onSubmit={isSetPassword ? handleNewPassword : handleLogin}
             noValidate
           >
-            {fields.map((field, index) => (
-              <label key={field.id} className={styles.field} htmlFor={field.id}>
-                <Typography variant="label" as="span">
-                  {field.label}
-                </Typography>
-                <Input
-                  ref={index === 0 ? firstFieldRef : undefined}
-                  id={field.id}
-                  name={field.name}
-                  type={field.type}
-                  autoComplete={field.autoComplete}
-                  placeholder={field.placeholder}
-                  value={field.value}
-                  onChange={field.onChange}
-                  ariaDescribedBy={error ? 'form-error' : undefined}
-                />
-              </label>
-            ))}
+            {isSetPassword ? (
+              <>
+                <label className={styles.field} htmlFor="new-password">
+                  <Typography variant="label" as="span">
+                    New password
+                  </Typography>
+                  <Input
+                    ref={firstFieldRef}
+                    id="new-password"
+                    name="newPassword"
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder="At least 8 characters"
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    ariaDescribedBy={error ? 'form-error' : undefined}
+                  />
+                </label>
+                <label className={styles.field} htmlFor="confirm-password">
+                  <Typography variant="label" as="span">
+                    Confirm password
+                  </Typography>
+                  <Input
+                    id="confirm-password"
+                    name="confirmPassword"
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder="Re-enter your new password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    ariaDescribedBy={error ? 'form-error' : undefined}
+                  />
+                </label>
+              </>
+            ) : (
+              <>
+                <label className={styles.field} htmlFor="email">
+                  <Typography variant="label" as="span">
+                    Email
+                  </Typography>
+                  <Input
+                    ref={firstFieldRef}
+                    id="email"
+                    name="email"
+                    type="email"
+                    autoComplete="username"
+                    placeholder="you@akli.dev"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    ariaDescribedBy={error ? 'form-error' : undefined}
+                  />
+                </label>
+                <label className={styles.field} htmlFor="password">
+                  <Typography variant="label" as="span">
+                    Password
+                  </Typography>
+                  <Input
+                    id="password"
+                    name="password"
+                    type="password"
+                    autoComplete="current-password"
+                    placeholder="••••••••••"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    ariaDescribedBy={error ? 'form-error' : undefined}
+                  />
+                </label>
+              </>
+            )}
 
             <Button type="submit" loading={loading} fullWidth>
               {submitLabel}


### PR DESCRIPTION
Closes #349

## What changed
Replaced Login.tsx's `FieldConfig` interface and `fields.map(...)` render loop — generic-list machinery built for exactly two fixed, never-reordered two-item lists — with literal per-mode `<label><Input/></label>` blocks. The index-based `firstFieldRef` lookup (`index === 0 ? firstFieldRef : undefined`) is replaced with a plain ref assigned directly to the first input in whichever mode is rendered.

## Why
Surfaced by an epic-wide `/simplify` pass during #231's manual QA. Two literal blocks per mode have roughly the same line count as the array + map (actual diff: 70 insertions / 76 deletions, net smaller) without the config interface or index-based ref plumbing, and are easier to scan since you don't need to mentally "run" the map to see what renders.

## How to verify
- `pnpm test` — 835/835 tests pass, including `Login.test.tsx` unmodified.
- `pnpm lint` — 0 errors.
- `pnpm exec tsc --noEmit` — 0 errors.
- Manually: visit `/admin/login`, confirm email/password fields render and autofocus on email; the set-password flow (triggered by Cognito's `NEW_PASSWORD_REQUIRED` challenge) renders new-password/confirm-password fields with autofocus on new-password.

## Decisions made
Ran `/simplify` on the diff (4 parallel review angles). Two independent reviews (simplification, altitude) flagged that the 4 literal `<label><Input/></label>` blocks duplicate wrapper markup and suggested either reverting to the config/map or extracting a shared `FormField` wrapper component. Skipped both: a cross-file check (reuse review) found the codebase's other admin forms (`RecipeEditor.tsx` has 7+ literal field blocks, `UserManagement.tsx` similarly) already use this exact hand-rolled literal-block style with no shared wrapper, despite more duplication than here — reverting or extracting a new wrapper would either undo this issue's explicit rationale or introduce a pattern inconsistent with the rest of the codebase. Efficiency review found no issues (diff is efficiency-neutral to slightly better — no intermediate array/object allocation per render).

## Out of scope
None — this is a self-contained, single-file refactor with no new follow-ups filed.