### PR TITLE
Add real SSR to the Vite dev server (fix hydration-mismatch console errors in dev)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -84,7 +84,7 @@ export default [
     },
   },
   {
-    files: ['scripts/**/*.ts'],
+    files: ['scripts/**/*.ts', 'vite.config.ts'],
     languageOptions: {
       globals: {
         ...globals.node,

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -88,7 +88,11 @@ const buildHeadHtml = (routePath: string, data?: RecipeData): string => {
 
 const handler = createStaticHandler(routes)
 
-export const render = async (url: string, data?: RecipeData): Promise<string> => {
+export const render = async (
+  url: string,
+  data?: RecipeData,
+  htmlTemplate?: string
+): Promise<string> => {
   const request = new Request(`http://localhost${url}`)
   const context = await handler.query(request)
 
@@ -98,7 +102,10 @@ export const render = async (url: string, data?: RecipeData): Promise<string> =>
 
   const router = createStaticRouter(handler.dataRoutes, context)
   const head = buildHeadHtml(url, data)
-  const beforeHtml = templateBeforeOutlet.replace('<!--ssr-head-->', head)
+  const [beforeOutlet, afterOutlet] = htmlTemplate
+    ? htmlTemplate.split('<!--ssr-outlet-->')
+    : [templateBeforeOutlet, templateAfterOutlet]
+  const beforeHtml = beforeOutlet.replace('<!--ssr-head-->', head)
 
   return new Promise<string>((resolve, reject) => {
     const { pipe } = renderToPipeableStream(
@@ -119,7 +126,7 @@ export const render = async (url: string, data?: RecipeData): Promise<string> =>
           })
 
           reactStream.on('end', () => {
-            const fullHtml = beforeHtml + reactHtml + templateAfterOutlet
+            const fullHtml = beforeHtml + reactHtml + afterOutlet
             resolve(fullHtml)
           })
 

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -35,7 +35,12 @@ try {
 </html>`
 }
 
-const [templateBeforeOutlet, templateAfterOutlet] = template.split('<!--ssr-outlet-->')
+const splitTemplate = (html: string): [string, string] => {
+  const [before, after] = html.split('<!--ssr-outlet-->')
+  return [before, after]
+}
+
+const [templateBeforeOutlet, templateAfterOutlet] = splitTemplate(template)
 
 const buildHeadHtml = (routePath: string, data?: RecipeData): string => {
   const meta = getMetaTags(routePath, data)
@@ -103,7 +108,7 @@ export const render = async (
   const router = createStaticRouter(handler.dataRoutes, context)
   const head = buildHeadHtml(url, data)
   const [beforeOutlet, afterOutlet] = htmlTemplate
-    ? htmlTemplate.split('<!--ssr-outlet-->')
+    ? splitTemplate(htmlTemplate)
     : [templateBeforeOutlet, templateAfterOutlet]
   const beforeHtml = beforeOutlet.replace('<!--ssr-head-->', head)
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,9 +76,18 @@ const collectInlineStyles = async (
     const entryMod = await server.moduleGraph.getModuleByUrl(entryUrl)
     const cssModules = collectCssModules(entryMod)
 
+    // index.css is entry-client.tsx's global stylesheet (tokens, fonts,
+    // resets, @layer ordering) — entry-server.tsx never imports it, since
+    // production SSR relies on the built <link> stylesheet for it instead.
+    // The dev module graph walk above starts from entry-server.tsx, so it
+    // never reaches index.css, and every component CSS Module's var(--...)
+    // references resolve to nothing without it — the exact "unstyled" look
+    // reported, despite component-level CSS already being inlined correctly.
+    const cssUrls = new Set([...cssModules.keys(), '/src/index.css'])
+
     const cssTexts = await Promise.all(
-      [...cssModules.values()].map(async (mod) => {
-        const directUrl = mod.url.includes('?') ? `${mod.url}&direct` : `${mod.url}?direct`
+      [...cssUrls].map(async (url) => {
+        const directUrl = url.includes('?') ? `${url}&direct` : `${url}?direct`
         // No { ssr: true } here despite this module being found via the SSR
         // module graph — passing it makes Vite route ?direct CSS requests
         // through ssrTransformScript (a JS parser) instead of the CSS

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,13 +24,13 @@ const rootDir = dirname(fileURLToPath(import.meta.url))
 const collectCssModules = (
   mod: ModuleNode | undefined,
   visited: Set<string> = new Set(),
-  cssModules: Map<string, ModuleNode> = new Map()
-): Map<string, ModuleNode> => {
+  cssModules: Set<string> = new Set()
+): Set<string> => {
   if (!mod || visited.has(mod.url)) return cssModules
   visited.add(mod.url)
 
   if (isCSSRequest(mod.url)) {
-    cssModules.set(mod.url, mod)
+    cssModules.add(mod.url)
   }
 
   for (const imported of mod.importedModules) {
@@ -83,7 +83,13 @@ const collectInlineStyles = async (
     // never reaches index.css, and every component CSS Module's var(--...)
     // references resolve to nothing without it — the exact "unstyled" look
     // reported, despite component-level CSS already being inlined correctly.
-    const cssUrls = new Set([...cssModules.keys(), '/src/index.css'])
+    //
+    // Deliberately hardcoded rather than also walking entry-client.tsx's
+    // graph: that module only gets registered once the browser actually
+    // requests it, which happens after this response is sent — on a cold
+    // dev-server start that walk would find nothing, reintroducing this
+    // exact bug intermittently instead of fixing it deterministically.
+    const cssUrls = new Set([...cssModules, '/src/index.css'])
 
     const cssTexts = await Promise.all(
       [...cssUrls].map(async (url) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,13 +8,79 @@ import react from '@vitejs/plugin-react'
 import rehypeMermaid from 'rehype-mermaid'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
-import { loadEnv, type Plugin } from 'vite'
+import { isCSSRequest, loadEnv, type ModuleNode, type Plugin, type ViteDevServer } from 'vite'
 import { imagetools } from 'vite-imagetools'
 import { defineConfig } from 'vitest/config'
 import remarkReadingTime from './plugins/remark-reading-time'
 import { sitemapPlugin } from './sitemap-plugin'
 
 const rootDir = dirname(fileURLToPath(import.meta.url))
+
+// Recursively walks the dev module graph from `mod`, collecting every
+// CSS(-Modules) module transitively imported (statically or dynamically).
+// Dedupes by URL rather than object identity, since Vite's ModuleNode is a
+// "backward compatible" view that may hand back distinct wrapper objects
+// for the same underlying module across separate lookups.
+const collectCssModules = (
+  mod: ModuleNode | undefined,
+  visited: Set<string> = new Set(),
+  cssModules: Map<string, ModuleNode> = new Map()
+): Map<string, ModuleNode> => {
+  if (!mod || visited.has(mod.url)) return cssModules
+  visited.add(mod.url)
+
+  if (isCSSRequest(mod.url)) {
+    cssModules.set(mod.url, mod)
+  }
+
+  for (const imported of mod.importedModules) {
+    collectCssModules(imported, visited, cssModules)
+  }
+
+  return cssModules
+}
+
+// Vite dev mode never emits a blocking <link rel="stylesheet"> for CSS
+// Modules — it transforms them into JS that injects a <style> tag as a side
+// effect of the importing module executing on the client. Before this file's
+// SSR middleware existed that was invisible: pnpm dev never painted real
+// content before client JS ran, so there was nothing to flash. Now that we
+// SSR real markup, the browser paints real class names immediately while the
+// rules for them are still absent until the client bundle executes each
+// CSS-module import — a visible flash of unstyled content.
+//
+// The fix (Vite's documented dev-SSR CSS-collection pattern): after
+// rendering, walk the module graph for every CSS module transitively
+// imported by the SSR entry, fetch each one's real transformed CSS text, and
+// inline it as a <style> block in <head> so first paint is already styled.
+// The dev-mode JS-injected <style> tags still land later — harmless
+// redundant styling, since by then nothing is left to visually flash.
+//
+// SSR-transformed CSS modules only export the class-name map (dev mode's
+// css-post plugin returns `modulesCode || 'export {}'` for SSR consumers —
+// no CSS text), so `ssrModule` can't supply the text. Instead we re-request
+// each module's URL with Vite's own `?direct` marker, which is exactly what
+// the dev server itself appends for CSS requested via <link> instead of a
+// JS import — it makes the css-post plugin skip the JS-injection wrapper and
+// return the real processed CSS text.
+const collectInlineStyles = async (
+  server: ViteDevServer,
+  entryUrl: string
+): Promise<string> => {
+  const entryMod = await server.moduleGraph.getModuleByUrl(entryUrl)
+  const cssModules = collectCssModules(entryMod)
+
+  const cssTexts = await Promise.all(
+    [...cssModules.values()].map(async (mod) => {
+      const directUrl = mod.url.includes('?') ? `${mod.url}&direct` : `${mod.url}?direct`
+      const result = await server.transformRequest(directUrl)
+      return result?.code ?? ''
+    })
+  )
+
+  const css = cssTexts.filter(Boolean).join('\n')
+  return css ? `<style data-vite-dev-ssr-inline>${css}</style>` : ''
+}
 
 // Vite's dev server never runs SSR on its own — it serves the static index.html
 // with <!--ssr-outlet--> unrendered, which produces a hydration mismatch on the
@@ -47,11 +113,19 @@ const ssrDevServerPlugin = (): Plugin => ({
             server.transformIndexHtml(url, rawHtml),
             server.ssrLoadModule('/src/entry-server.tsx'),
           ])
+          // Sequenced, not parallelized: admin routes are React.lazy(), so
+          // their module (and its CSS) only lands in the module graph once
+          // render() actually reaches and awaits that Suspense boundary.
+          // Collecting styles concurrently with render() would race that.
           const html = await render(url, undefined, transformedHtml)
+          const inlineStyles = await collectInlineStyles(server, '/src/entry-server.tsx')
+          const htmlWithStyles = inlineStyles
+            ? html.replace('</head>', `${inlineStyles}</head>`)
+            : html
 
           res.statusCode = 200
           res.setHeader('Content-Type', 'text/html')
-          res.end(html)
+          res.end(htmlWithStyles)
         } catch (error) {
           server.ssrFixStacktrace(error as Error)
           next(error)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,19 +67,34 @@ const collectInlineStyles = async (
   server: ViteDevServer,
   entryUrl: string
 ): Promise<string> => {
-  const entryMod = await server.moduleGraph.getModuleByUrl(entryUrl)
-  const cssModules = collectCssModules(entryMod)
+  // Purely cosmetic anti-FOUC enhancement — render() has already produced
+  // valid markup by the time this runs, so any failure here (e.g. a single
+  // CSS module failing to transform) must degrade to the unstyled HTML
+  // rather than propagate to the middleware's outer catch, which would send
+  // an otherwise-successful render to Vite's error overlay.
+  try {
+    const entryMod = await server.moduleGraph.getModuleByUrl(entryUrl)
+    const cssModules = collectCssModules(entryMod)
 
-  const cssTexts = await Promise.all(
-    [...cssModules.values()].map(async (mod) => {
-      const directUrl = mod.url.includes('?') ? `${mod.url}&direct` : `${mod.url}?direct`
-      const result = await server.transformRequest(directUrl)
-      return result?.code ?? ''
-    })
-  )
+    const cssTexts = await Promise.all(
+      [...cssModules.values()].map(async (mod) => {
+        const directUrl = mod.url.includes('?') ? `${mod.url}&direct` : `${mod.url}?direct`
+        // No { ssr: true } here despite this module being found via the SSR
+        // module graph — passing it makes Vite route ?direct CSS requests
+        // through ssrTransformScript (a JS parser) instead of the CSS
+        // pipeline, throwing on every module. Confirmed by isolation test;
+        // the default client-environment transform is what actually works.
+        const result = await server.transformRequest(directUrl)
+        return result?.code ?? ''
+      })
+    )
 
-  const css = cssTexts.filter(Boolean).join('\n')
-  return css ? `<style data-vite-dev-ssr-inline>${css}</style>` : ''
+    const css = cssTexts.filter(Boolean).join('\n')
+    return css ? `<style data-vite-dev-ssr-inline>${css}</style>` : ''
+  } catch (error) {
+    console.warn('[ssr-dev-server] Failed to collect inline styles, falling back to unstyled HTML:', error)
+    return ''
+  }
 }
 
 // Vite's dev server never runs SSR on its own — it serves the static index.html

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -166,12 +166,17 @@ export default defineConfig(({ command, isSsrBuild, mode }) => {
     },
   },
   ssr: {
-    // Only bundle deps into the SSR build for production (a single CJS file
-    // for Lambda, with no node_modules). Vite's dev-mode ssrLoadModule reads
-    // this same option, and forcing packages like React's dev runtime through
-    // Vite's SSR transform pipeline (instead of externalizing/require-ing them
-    // from node_modules) breaks on their `typeof module` CJS-interop checks.
-    noExternal: command === 'build' ? true : undefined,
+    // Bundle deps for production builds (a single CJS file for Lambda, with
+    // no node_modules) and for Vitest, which also resolves through this
+    // config with command === 'serve' (it calls Vite's createServer()
+    // internally) but defaults `mode` to 'test' — forcing noExternal there
+    // matches production's bundled path and preserves prior test coverage.
+    // Only the real interactive dev server (mode === 'development') gets
+    // noExternal: undefined, since Vite's dev-mode ssrLoadModule, run live
+    // over HTTP, breaks when packages like React's dev runtime are forced
+    // through Vite's SSR transform pipeline instead of externalized/required
+    // from node_modules, on their `typeof module` CJS-interop checks.
+    noExternal: command === 'build' || mode === 'test' ? true : undefined,
     external: ['node:fs', 'node:path'],
   },
   build: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from 'fs'
+import { readFileSync, readdirSync } from 'fs'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
 import mdx from '@mdx-js/rollup'
@@ -8,15 +8,58 @@ import react from '@vitejs/plugin-react'
 import rehypeMermaid from 'rehype-mermaid'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
-import { loadEnv } from 'vite'
+import { loadEnv, type Plugin } from 'vite'
 import { imagetools } from 'vite-imagetools'
 import { defineConfig } from 'vitest/config'
 import remarkReadingTime from './plugins/remark-reading-time'
 import { sitemapPlugin } from './sitemap-plugin'
 
+const rootDir = dirname(fileURLToPath(import.meta.url))
+
+// Vite's dev server never runs SSR on its own — it serves the static index.html
+// with <!--ssr-outlet--> unrendered, which produces a hydration mismatch on the
+// first real DOM node. This renders the app for real, the same way the Lambda
+// handler does in production, using Vite's own transformed HTML template so
+// HMR/client scripts keep working.
+const ssrDevServerPlugin = (): Plugin => ({
+  name: 'ssr-dev-server',
+  configureServer(server) {
+    return () => {
+      server.middlewares.use(async (req, res, next) => {
+        const url = req.originalUrl
+
+        if (
+          !url ||
+          req.method !== 'GET' ||
+          url.startsWith('/@') ||
+          url.startsWith('/src/') ||
+          url.startsWith('/node_modules/') ||
+          /\.[^/?]+$/.test(url.split('?')[0])
+        ) {
+          next()
+          return
+        }
+
+        try {
+          const rawHtml = readFileSync(join(rootDir, 'index.html'), 'utf-8')
+          const transformedHtml = await server.transformIndexHtml(url, rawHtml)
+          const { render } = await server.ssrLoadModule('/src/entry-server.tsx')
+          const html = await render(url, undefined, transformedHtml)
+
+          res.statusCode = 200
+          res.setHeader('Content-Type', 'text/html')
+          res.end(html)
+        } catch (error) {
+          server.ssrFixStacktrace(error as Error)
+          next(error)
+        }
+      })
+    }
+  },
+})
+
 const getBlogRoutes = (): Array<{ route: string; priority: number; changefreq: 'monthly' }> => {
-  const currentDir = dirname(fileURLToPath(import.meta.url))
-  const postsDir = join(currentDir, 'src/pages/Blog/posts')
+  const postsDir = join(rootDir, 'src/pages/Blog/posts')
   try {
     const files = readdirSync(postsDir)
     return files
@@ -31,11 +74,12 @@ const getBlogRoutes = (): Array<{ route: string; priority: number; changefreq: '
   }
 }
 
-export default defineConfig(({ isSsrBuild, mode }) => {
-  const env = loadEnv(mode, dirname(fileURLToPath(import.meta.url)), '')
+export default defineConfig(({ command, isSsrBuild, mode }) => {
+  const env = loadEnv(mode, rootDir, '')
   return {
   plugins: [
     react(),
+    ssrDevServerPlugin(),
     mdx({
       remarkPlugins: [
         remarkFrontmatter,
@@ -122,7 +166,12 @@ export default defineConfig(({ isSsrBuild, mode }) => {
     },
   },
   ssr: {
-    noExternal: true,
+    // Only bundle deps into the SSR build for production (a single CJS file
+    // for Lambda, with no node_modules). Vite's dev-mode ssrLoadModule reads
+    // this same option, and forcing packages like React's dev runtime through
+    // Vite's SSR transform pipeline (instead of externalizing/require-ing them
+    // from node_modules) breaks on their `typeof module` CJS-interop checks.
+    noExternal: command === 'build' ? true : undefined,
     external: ['node:fs', 'node:path'],
   },
   build: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,14 +27,15 @@ const ssrDevServerPlugin = (): Plugin => ({
     return () => {
       server.middlewares.use(async (req, res, next) => {
         const url = req.originalUrl
+        const acceptsHtml = req.headers.accept?.includes('text/html')
 
         if (
           !url ||
           req.method !== 'GET' ||
+          !acceptsHtml ||
           url.startsWith('/@') ||
           url.startsWith('/src/') ||
-          url.startsWith('/node_modules/') ||
-          /\.[^/?]+$/.test(url.split('?')[0])
+          url.startsWith('/node_modules/')
         ) {
           next()
           return
@@ -42,8 +43,10 @@ const ssrDevServerPlugin = (): Plugin => ({
 
         try {
           const rawHtml = readFileSync(join(rootDir, 'index.html'), 'utf-8')
-          const transformedHtml = await server.transformIndexHtml(url, rawHtml)
-          const { render } = await server.ssrLoadModule('/src/entry-server.tsx')
+          const [transformedHtml, { render }] = await Promise.all([
+            server.transformIndexHtml(url, rawHtml),
+            server.ssrLoadModule('/src/entry-server.tsx'),
+          ])
           const html = await render(url, undefined, transformedHtml)
 
           res.statusCode = 200
@@ -169,14 +172,18 @@ export default defineConfig(({ command, isSsrBuild, mode }) => {
     // Bundle deps for production builds (a single CJS file for Lambda, with
     // no node_modules) and for Vitest, which also resolves through this
     // config with command === 'serve' (it calls Vite's createServer()
-    // internally) but defaults `mode` to 'test' — forcing noExternal there
-    // matches production's bundled path and preserves prior test coverage.
-    // Only the real interactive dev server (mode === 'development') gets
-    // noExternal: undefined, since Vite's dev-mode ssrLoadModule, run live
-    // over HTTP, breaks when packages like React's dev runtime are forced
-    // through Vite's SSR transform pipeline instead of externalized/required
-    // from node_modules, on their `typeof module` CJS-interop checks.
-    noExternal: command === 'build' || mode === 'test' ? true : undefined,
+    // internally) — forcing noExternal there matches production's bundled
+    // path and preserves prior test coverage. `process.env.VITEST` is the
+    // reliable Vitest-detection signal here (Vitest always sets it), unlike
+    // `mode`, which is a general Vite concept a real dev server run could
+    // also set to 'test' (e.g. `vite dev --mode test` for a `.env.test`
+    // file) without being Vitest at all. The real interactive dev server
+    // gets noExternal: undefined, since Vite's dev-mode ssrLoadModule, run
+    // live over HTTP, breaks when packages like React's dev runtime are
+    // forced through Vite's SSR transform pipeline instead of
+    // externalized/required from node_modules, on their `typeof module`
+    // CJS-interop checks.
+    noExternal: command === 'build' || process.env.VITEST ? true : undefined,
     external: ['node:fs', 'node:path'],
   },
   build: {


### PR DESCRIPTION
Closes #354

## What changed
`pnpm dev` never ran SSR at all — it served the static `index.html` with `<!--ssr-outlet-->` left unrendered, so `hydrateRoot` had nothing real to reconcile against and flagged a mismatch on the first DOM node on every route. This adds a Vite `configureServer` middleware (`vite.config.ts`) that renders each navigation through the same `src/entry-server.tsx` `render()` path production uses, via `transformIndexHtml` (keeps HMR working) + `ssrLoadModule` (live-reloaded render function). `render()` now takes an optional injectable `htmlTemplate` for this; the production call site in `src/lambda-handler.ts` is unchanged and gets the original built-file behavior.

Also required: `ssr.noExternal` is now scoped to production builds and Vitest only (`command === 'build' || process.env.VITEST`) — forcing the real dev server's `ssrLoadModule` to bundle deps like React's dev runtime through Vite's SSR transform pipeline broke their `typeof module` CJS-interop checks.

**Follow-up fix (same PR):** enabling real SSR in dev exposed a flash-of-unstyled-content bug — Vite dev mode injects CSS Modules as JS-executed `<style>` tags rather than blocking `<link>` stylesheets, so real SSR markup now painted immediately with no styles applied until the client bundle ran. Fixed by walking the dev module graph after each render to collect every CSS module transitively imported, re-requesting each with Vite's `?direct` marker to get real CSS text, and inlining it into `<head>` before the response is sent — so first paint is already styled.

## Why
Dev parity with production — `pnpm dev` now exercises the same SSR/hydration path a real page load does, instead of always hydrating against an empty shell. Reported by the user seeing the hydration error on the homepage; the root cause (no dev-SSR at all) was already identified during #352's investigation into the same warning on `/recipes`.

## How to verify
- `pnpm test` — 835/835 pass, `pnpm lint` — 0 errors, `pnpm exec tsc --noEmit` — clean.
- `curl -H "Accept: text/html" http://localhost:5173/` (with `pnpm dev` running) returns real rendered SSR HTML, no literal `<!--ssr-outlet-->`, and a `<style data-vite-dev-ssr-inline>` block with real CSS rules in `<head>`. Same for `/recipes`, `/recipes/:slug`, `/blog`, `/admin/login` (including the lazy-loaded `Login.module.css` rules).
- Loaded all five routes in a browser via Playwright with console/pageerror listeners: zero hydration-mismatch messages.
- Edited a component while `pnpm dev` was running: HMR fast-refresh still updates without a full reload.
- `pnpm build:client && pnpm build:server` still succeeds; `src/entry-server.test.tsx` and `src/lambda-handler.test.ts` pass against the real built output, confirming the production SSR path is unaffected.

## Decisions made
A review pass on the initial SSR-middleware commit flagged two real gaps that were fixed before opening this PR:
- The original `noExternal` condition used `mode === 'test'` to detect Vitest, but `mode` is a general Vite concept — a plain `vite dev --mode test` run would've silently hit the same CJS-interop bug this PR fixes. Switched to `process.env.VITEST`, which Vitest always sets.
- The original asset-vs-page-navigation check used a URL-extension regex, which would misclassify any future route with a dot in its last path segment (a slug, a versioned path) as a static asset — skipping SSR and silently reproducing the hydration bug, with no test coverage to catch it. Switched to checking the request's `Accept` header, matching how Vite's own internal `htmlFallbackMiddleware` classifies HTML navigations.

A `/simplify` pass also deduped the `<!--ssr-outlet-->` template-split logic into a shared helper and parallelized two independent `await`s in the middleware.

A second review pass on the CSS-inlining commit flagged that a single failing CSS-module transform would crash the entire page render instead of degrading gracefully — fixed with a try/catch that falls back to unstyled HTML (the pre-existing flash, not a broken page) on failure. That same round also tried passing `{ ssr: true }` to `server.transformRequest` on the reasoning that the module was discovered via the SSR module graph — an isolation test showed this actually breaks CSS collection entirely on the installed Vite version (routes `?direct` CSS requests through a JS transform instead of the CSS pipeline), so it was reverted with a comment explaining why, rather than silently reintroducing the bug this PR fixes.

## Out of scope
None — self-contained to the dev-server SSR path. No follow-ups filed.
