### PR TITLE
Give Button a danger/outline tone instead of out-specificity-ing it from RecipeEditor

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -80,6 +80,16 @@
   background-color: var(--color-hover);
 }
 
+/* tone="danger" only makes sense combined with variant="outline" (see the
+   prop doc comment in Button.tsx) — tints the outline variant's hover state
+   red for destructive-but-secondary actions (e.g. RecipeEditor's "Discard
+   draft"), instead of the outline variant's default accent-blue hover. */
+.outline.toneDanger:hover:not(:disabled) {
+  border-color: var(--color-error);
+  color: var(--color-error);
+  background-color: var(--color-error-bg);
+}
+
 /* ── Shape ───────────────────────────────────────────────────── */
 
 .pill {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -11,6 +11,8 @@ export interface ButtonProps {
   shape?: 'rounded' | 'pill'
   /** @default 'md' */
   size?: 'sm' | 'md'
+  /** Tints the `outline` variant's hover state red for destructive-but-secondary actions. Only meaningful combined with `variant="outline"`. @default undefined */
+  tone?: 'danger'
   disabled?: boolean
   /** Shows a spinner and blocks interaction. @default false */
   loading?: boolean
@@ -30,6 +32,7 @@ const Button = ({
   variant = 'solid',
   shape = 'rounded',
   size = 'md',
+  tone,
   disabled = false,
   loading = false,
   iconLeft,
@@ -45,6 +48,7 @@ const Button = ({
     styles[variant],
     styles[shape],
     styles[size],
+    tone === 'danger' && styles.toneDanger,
     fullWidth && styles.fullWidth,
     loading && styles.loading,
     extraClassName,

--- a/src/pages/admin/RecipeEditor/RecipeEditor.module.css
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.module.css
@@ -370,16 +370,6 @@
   gap: var(--space-3);
 }
 
-/* .actionsCol .discardButton (not bare): raises specificity above
-   Button's own `.outline` hover — the design's "Discard draft" ghost
-   button tints red on hover (`.ghost-btn.danger:hover`), Button's shared
-   outline variant tints accent-blue instead. */
-.actionsCol .discardButton:hover:not(:disabled) {
-  border-color: var(--color-error);
-  color: var(--color-error);
-  background: var(--color-error-bg);
-}
-
 .checklistWrap {
   border-top: var(--border-width) solid var(--color-border);
   padding-top: 14px;

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -847,9 +847,9 @@ const RecipeEditor: FC = () => {
                     onClick={() => setDiscardDialogOpen(true)}
                     type="button"
                     variant="outline"
+                    tone="danger"
                     disabled={submitting}
                     fullWidth
-                    className={styles.discardButton}
                   >
                     Discard draft
                   </Button>


### PR DESCRIPTION
Closes #350

## What changed
- `Button` gains an optional `tone?: 'danger'` prop that tints the `outline` variant's hover state red (`src/components/Button/Button.tsx`), styled via a new `.outline.toneDanger:hover:not(:disabled)` rule in `Button.module.css`.
- `RecipeEditor`'s "Discard draft" button now uses `variant="outline" tone="danger"` instead of a `className={styles.discardButton}` hook.
- Deleted the dead `.actionsCol .discardButton:hover:not(:disabled)` descendant-selector specificity hack from `RecipeEditor.module.css`.

## Why
The old rule existed purely to out-specificity `Button`'s own `.outline:hover` — exactly the pattern `scripts/check-descendant-selectors.ts` exists to catch, but it was invisible to that gate (no `@layer component-defaults` on Button yet, and the gate only matches the `variant`-prop collision pattern, not `:hover` pseudo-state overrides). A real `tone` API — mirroring `Link`'s existing `tone` prop convention — lets callers select a supported look instead of reaching outside the component.

## How to verify
- `pnpm check:descendant-selectors` reports clean.
- `pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit` all pass with no new errors.
- Visually: open the recipe editor for a draft recipe, hover the "Discard draft" button — it should tint red (border/text/background), same as before.

## Decisions made
- `.toneDanger` is a compound selector (`.outline.toneDanger`) rather than a bare class, since the prop is only meaningful combined with `variant="outline"` — it can't leak onto `.solid`/`.danger` variants since Button's variant classes are mutually exclusive.
- Kept `tone="danger"` distinct from the pre-existing `variant="danger"` (solid red variant) — two different "danger" concepts (a full variant vs. a hover tint), matching the naming a reviewer flagged as worth a note but not worth blocking on.
- No new Button unit test asserts the `toneDanger` class directly — consistent with `Button.test.tsx`'s existing convention of not testing CSS Module class application for other variant/shape/size props.