### PR TITLE
Extract shared reorder-controls component from IngredientList/StepList

### DIFF
--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -1,7 +1,8 @@
 import Button from '@components/Button'
-import { iconChevronDown, iconChevronUp, iconPlus, iconRemove } from '@components/icons'
+import { iconPlus } from '@components/icons'
 import Input from '@components/Input'
 import List, { ListItem } from '@components/List'
+import ReorderControls from '@components/ReorderControls'
 import { useReorderableList } from '@hooks/useReorderableList'
 import type { Ingredient } from '@models/recipe'
 import type { FC } from 'react'
@@ -75,33 +76,16 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
               />
             </div>
             <div className={styles.actions}>
-              <Button
-                onClick={() => handleMoveUp(index)}
-                ariaLabel={`Move up ingredient ${index + 1}`}
-                variant="outline"
-                disabled={index === 0}
-                className={moveActionClassName}
-              >
-                {iconChevronUp}
-              </Button>
-              <Button
-                onClick={() => handleMoveDown(index)}
-                ariaLabel={`Move down ingredient ${index + 1}`}
-                variant="outline"
-                disabled={index === ingredients.length - 1}
-                className={moveActionClassName}
-              >
-                {iconChevronDown}
-              </Button>
-              <Button
-                onClick={() => handleRemove(index)}
-                ariaLabel={`Remove ingredient ${index + 1}`}
-                variant="outline"
-                disabled={ingredients.length <= 1}
-                className={removeActionClassName}
-              >
-                {iconRemove}
-              </Button>
+              <ReorderControls
+                index={index}
+                count={ingredients.length}
+                itemLabel="ingredient"
+                onMoveUp={handleMoveUp}
+                onMoveDown={handleMoveDown}
+                onRemove={handleRemove}
+                moveActionClassName={moveActionClassName}
+                removeActionClassName={removeActionClassName}
+              />
             </div>
           </ListItem>
         ))}

--- a/src/components/ReorderControls/ReorderControls.test.tsx
+++ b/src/components/ReorderControls/ReorderControls.test.tsx
@@ -1,0 +1,190 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import ReorderControls from './ReorderControls'
+
+describe('ReorderControls', () => {
+  it('renders three buttons with accessible names derived from itemLabel/index', () => {
+    render(
+      <ReorderControls
+        index={0}
+        count={3}
+        itemLabel="ingredient"
+        onMoveUp={vi.fn()}
+        onMoveDown={vi.fn()}
+        onRemove={vi.fn()}
+        moveActionClassName="move"
+        removeActionClassName="remove"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Move up ingredient 1' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Move down ingredient 1' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove ingredient 1' })).toBeInTheDocument()
+  })
+
+  it('disables the move-up button when index is 0', () => {
+    render(
+      <ReorderControls
+        index={0}
+        count={3}
+        itemLabel="ingredient"
+        onMoveUp={vi.fn()}
+        onMoveDown={vi.fn()}
+        onRemove={vi.fn()}
+        moveActionClassName="move"
+        removeActionClassName="remove"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Move up ingredient 1' })).toBeDisabled()
+  })
+
+  it('enables the move-up button when index is not 0', () => {
+    render(
+      <ReorderControls
+        index={1}
+        count={3}
+        itemLabel="ingredient"
+        onMoveUp={vi.fn()}
+        onMoveDown={vi.fn()}
+        onRemove={vi.fn()}
+        moveActionClassName="move"
+        removeActionClassName="remove"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Move up ingredient 2' })).toBeEnabled()
+  })
+
+  it('disables the move-down button when index is the last item', () => {
+    render(
+      <ReorderControls
+        index={2}
+        count={3}
+        itemLabel="ingredient"
+        onMoveUp={vi.fn()}
+        onMoveDown={vi.fn()}
+        onRemove={vi.fn()}
+        moveActionClassName="move"
+        removeActionClassName="remove"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Move down ingredient 3' })).toBeDisabled()
+  })
+
+  it('enables the move-down button when index is not the last item', () => {
+    render(
+      <ReorderControls
+        index={0}
+        count={3}
+        itemLabel="ingredient"
+        onMoveUp={vi.fn()}
+        onMoveDown={vi.fn()}
+        onRemove={vi.fn()}
+        moveActionClassName="move"
+        removeActionClassName="remove"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Move down ingredient 1' })).toBeEnabled()
+  })
+
+  it('disables the remove button when count is 1', () => {
+    render(
+      <ReorderControls
+        index={0}
+        count={1}
+        itemLabel="ingredient"
+        onMoveUp={vi.fn()}
+        onMoveDown={vi.fn()}
+        onRemove={vi.fn()}
+        moveActionClassName="move"
+        removeActionClassName="remove"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Remove ingredient 1' })).toBeDisabled()
+  })
+
+  it('enables the remove button when count is greater than 1', () => {
+    render(
+      <ReorderControls
+        index={0}
+        count={2}
+        itemLabel="ingredient"
+        onMoveUp={vi.fn()}
+        onMoveDown={vi.fn()}
+        onRemove={vi.fn()}
+        moveActionClassName="move"
+        removeActionClassName="remove"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Remove ingredient 1' })).toBeEnabled()
+  })
+
+  it('calls onMoveUp with the current index when the move-up button is clicked', () => {
+    const onMoveUp = vi.fn()
+    render(
+      <ReorderControls
+        index={1}
+        count={3}
+        itemLabel="step"
+        onMoveUp={onMoveUp}
+        onMoveDown={vi.fn()}
+        onRemove={vi.fn()}
+        moveActionClassName="move"
+        removeActionClassName="remove"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move up step 2' }))
+
+    expect(onMoveUp).toHaveBeenCalledTimes(1)
+    expect(onMoveUp).toHaveBeenCalledWith(1)
+  })
+
+  it('calls onMoveDown with the current index when the move-down button is clicked', () => {
+    const onMoveDown = vi.fn()
+    render(
+      <ReorderControls
+        index={0}
+        count={3}
+        itemLabel="step"
+        onMoveUp={vi.fn()}
+        onMoveDown={onMoveDown}
+        onRemove={vi.fn()}
+        moveActionClassName="move"
+        removeActionClassName="remove"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move down step 1' }))
+
+    expect(onMoveDown).toHaveBeenCalledTimes(1)
+    expect(onMoveDown).toHaveBeenCalledWith(0)
+  })
+
+  it('calls onRemove with the current index when the remove button is clicked', () => {
+    const onRemove = vi.fn()
+    render(
+      <ReorderControls
+        index={2}
+        count={3}
+        itemLabel="step"
+        onMoveUp={vi.fn()}
+        onMoveDown={vi.fn()}
+        onRemove={onRemove}
+        moveActionClassName="move"
+        removeActionClassName="remove"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove step 3' }))
+
+    expect(onRemove).toHaveBeenCalledTimes(1)
+    expect(onRemove).toHaveBeenCalledWith(2)
+  })
+})

--- a/src/components/ReorderControls/ReorderControls.tsx
+++ b/src/components/ReorderControls/ReorderControls.tsx
@@ -1,0 +1,57 @@
+import Button from '@components/Button'
+import { iconChevronDown, iconChevronUp, iconRemove } from '@components/icons'
+import type { FC } from 'react'
+
+export interface ReorderControlsProps {
+  index: number
+  count: number
+  itemLabel: string
+  onMoveUp: (index: number) => void
+  onMoveDown: (index: number) => void
+  onRemove: (index: number) => void
+  moveActionClassName: string
+  removeActionClassName: string
+}
+
+const ReorderControls: FC<ReorderControlsProps> = ({
+  index,
+  count,
+  itemLabel,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+  moveActionClassName,
+  removeActionClassName,
+}) => (
+  <>
+    <Button
+      onClick={() => onMoveUp(index)}
+      ariaLabel={`Move up ${itemLabel} ${index + 1}`}
+      variant="outline"
+      disabled={index === 0}
+      className={moveActionClassName}
+    >
+      {iconChevronUp}
+    </Button>
+    <Button
+      onClick={() => onMoveDown(index)}
+      ariaLabel={`Move down ${itemLabel} ${index + 1}`}
+      variant="outline"
+      disabled={index === count - 1}
+      className={moveActionClassName}
+    >
+      {iconChevronDown}
+    </Button>
+    <Button
+      onClick={() => onRemove(index)}
+      ariaLabel={`Remove ${itemLabel} ${index + 1}`}
+      variant="outline"
+      disabled={count <= 1}
+      className={removeActionClassName}
+    >
+      {iconRemove}
+    </Button>
+  </>
+)
+
+export default ReorderControls

--- a/src/components/ReorderControls/index.ts
+++ b/src/components/ReorderControls/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ReorderControls'
+export type { ReorderControlsProps } from './ReorderControls'

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -1,8 +1,9 @@
 import Button from '@components/Button'
-import { iconChevronDown, iconChevronUp, iconPlus, iconRemove } from '@components/icons'
+import { iconPlus } from '@components/icons'
 import ImageUpload from '@components/ImageUpload'
 import Input from '@components/Input'
 import List, { ListItem } from '@components/List'
+import ReorderControls from '@components/ReorderControls'
 import Textarea from '@components/Textarea'
 import { useReorderableList } from '@hooks/useReorderableList'
 import { stepImageType, type RecipeImage, type Step } from '@models/recipe'
@@ -93,33 +94,16 @@ const StepList: FC<StepListProps> = ({
             <div className={styles.header}>
               <span className={styles.stepNumber}>{index + 1}</span>
               <div className={styles.actions}>
-                <Button
-                  onClick={() => handleMoveUp(index)}
-                  ariaLabel={`Move up step ${index + 1}`}
-                  variant="outline"
-                  disabled={index === 0}
-                  className={moveActionClassName}
-                >
-                  {iconChevronUp}
-                </Button>
-                <Button
-                  onClick={() => handleMoveDown(index)}
-                  ariaLabel={`Move down step ${index + 1}`}
-                  variant="outline"
-                  disabled={index === steps.length - 1}
-                  className={moveActionClassName}
-                >
-                  {iconChevronDown}
-                </Button>
-                <Button
-                  onClick={() => handleRemove(index)}
-                  ariaLabel={`Remove step ${index + 1}`}
-                  variant="outline"
-                  disabled={steps.length <= 1}
-                  className={removeActionClassName}
-                >
-                  {iconRemove}
-                </Button>
+                <ReorderControls
+                  index={index}
+                  count={steps.length}
+                  itemLabel="step"
+                  onMoveUp={handleMoveUp}
+                  onMoveDown={handleMoveDown}
+                  onRemove={handleRemove}
+                  moveActionClassName={moveActionClassName}
+                  removeActionClassName={removeActionClassName}
+                />
               </div>
             </div>
             <Textarea


### PR DESCRIPTION
Closes #348

## What changed
- Added `src/components/ReorderControls/` — a shared component rendering the move-up/move-down/remove three-button block, taking `index`, `count`, `itemLabel`, the three callbacks, and the two action classNames as props.
- `IngredientList` and `StepList` now render `<ReorderControls>` instead of an inline, hand-duplicated three-button block.

## Why
Both components rendered an identical trio of buttons (same aria-label phrasing, same first/last boundary-disable logic) around the same `useReorderableList` hook, kept in sync by hand. Extracting it removes the duplication and its drift risk.

## How to verify
- `pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit` all pass.
- Open the recipe editor, add a few ingredients/steps, confirm move-up/move-down/remove still work identically (first item can't move up, last can't move down, can't remove the last remaining item).

## Decisions made
- Kept the `.actionButton` CSS geometry duplicated per-component rather than sharing it — `StepList.module.css`'s existing header comment documents a prior, deliberate decision on this ("only two consumers exist today, each with its own `.actions` layout root"); this PR only shares the JSX/behavior via className props passed through, not the CSS itself.
- `ReorderControls` owns no CSS module of its own for the same reason — `moveActionClassName`/`removeActionClassName` are still computed by each caller from their own `.module.css` and passed in as plain strings.
- Added `ReorderControls.test.tsx` for the new shared component (accessible names, boundary-disable logic, click-callback wiring); did not add a `vitest-axe` check since that bar applies to page/content-level components per CLAUDE.md, not small leaf controls like this one — matching `Button.test.tsx`'s existing convention.