### PR TITLE
Consolidate remaining duplicated/near-duplicate inline icons into icons.tsx

### DIFF
--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -1,6 +1,7 @@
 
 import { getUploadUrl } from '@api/recipes'
 import Button from '@components/Button'
+import { iconAddImage, iconReplace, iconUploadCloud } from '@components/icons'
 import Image from '@components/Image'
 import ProcessingPlaceholder from '@components/ProcessingPlaceholder'
 import { parseImageType, recipeImageUrl, type ImageType } from '@models/recipe'
@@ -21,70 +22,6 @@ export interface ImageUploadProps {
 }
 
 const MAX_SIZE = 10 * 1024 * 1024
-
-// Hoisted elements, not components — these never take props, so there's no
-// need to re-invoke a function (and rebuild the tree) on every render; see
-// `iconRetry` in src/pages/admin/RecipeList/RecipeList.tsx for the same
-// established pattern.
-//
-// Design: docs/design/paper/pages/Admin Recipe Editor.dc.html's `.upload`
-// dropzone icon (upload-cloud, stroke-width 1.6).
-const iconUploadCloud = (
-  <svg
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.6}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-    <polyline points="17 8 12 3 7 8" />
-    <line x1="12" y1="3" x2="12" y2="15" />
-  </svg>
-)
-
-// Design: same doc's STEPS section "+ Add step image" ghost-button icon.
-const iconAddImage = (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.8}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <rect x="3" y="3" width="18" height="18" rx="2" />
-    <circle cx="9" cy="9" r="2" />
-    <path d="m21 15-3.1-3.1a2 2 0 0 0-2.8 0L6 21" />
-  </svg>
-)
-
-// Design's overlaid icon-button is a trash glyph (it deletes the image
-// outright in the design's simulated backend). This component only has a
-// replace-via-re-upload callback surface (see the "Ready state" note in
-// the PR description), so a pencil/replace glyph is used instead of the
-// literal trash icon to avoid implying a destructive delete that doesn't
-// exist here.
-const iconReplace = (
-  <svg
-    width="15"
-    height="15"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M12 20h9" />
-    <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
-  </svg>
-)
 
 const ImageUpload: FC<ImageUploadProps> = ({
   slug,

--- a/src/components/IngredientList/IngredientList.tsx
+++ b/src/components/IngredientList/IngredientList.tsx
@@ -1,5 +1,5 @@
 import Button from '@components/Button'
-import { iconPlus } from '@components/icons'
+import { IconPlus } from '@components/icons'
 import Input from '@components/Input'
 import List, { ListItem } from '@components/List'
 import ReorderControls from '@components/ReorderControls'
@@ -90,7 +90,7 @@ const IngredientList: FC<IngredientListProps> = ({ ingredients, onChange, onAnno
           </ListItem>
         ))}
       </List>
-      <Button onClick={handleAdd} variant="outline" iconLeft={iconPlus} className={styles.addButton}>
+      <Button onClick={handleAdd} variant="outline" iconLeft={<IconPlus size={14} />} className={styles.addButton}>
         Add ingredient
       </Button>
     </>

--- a/src/components/StepList/StepList.tsx
+++ b/src/components/StepList/StepList.tsx
@@ -1,5 +1,5 @@
 import Button from '@components/Button'
-import { iconPlus } from '@components/icons'
+import { IconPlus } from '@components/icons'
 import ImageUpload from '@components/ImageUpload'
 import Input from '@components/Input'
 import List, { ListItem } from '@components/List'
@@ -138,7 +138,7 @@ const StepList: FC<StepListProps> = ({
           </ListItem>
         ))}
       </List>
-      <Button onClick={handleAdd} variant="outline" iconLeft={iconPlus} className={styles.addButton}>
+      <Button onClick={handleAdd} variant="outline" iconLeft={<IconPlus size={14} />} className={styles.addButton}>
         Add step
       </Button>
     </>

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -321,7 +321,7 @@ export const iconAddImage = (
 )
 
 // Design's overlaid icon-button is a trash glyph (it deletes the image
-// outright in the design's simulated backend). This component only has a
+// outright in the design's simulated backend). ImageUpload only has a
 // replace-via-re-upload callback surface (see the "Ready state" note in
 // the PR description), so a pencil/replace glyph is used instead of the
 // literal trash icon to avoid implying a destructive delete that doesn't

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -43,10 +43,14 @@ export const iconRemove = (
   </svg>
 )
 
-export const iconPlus = (
+export interface IconPlusProps {
+  size: number
+}
+
+export const IconPlus: FC<IconPlusProps> = ({ size }) => (
   <svg
-    width="14"
-    height="14"
+    width={size}
+    height={size}
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
@@ -59,9 +63,9 @@ export const iconPlus = (
   </svg>
 )
 
-// iconEdit/iconPreview/iconPublish carry explicit width/height even though
-// some consumers (RecipeList.tsx's .rowActions .actionButton) have a CSS
-// rule that overrides SVG-level sizing anyway — the other consumer (Link's
+// iconEdit/iconPublish carry explicit width/height even though some
+// consumers (RecipeList.tsx's .rowActions .actionButton) have a CSS rule
+// that overrides SVG-level sizing anyway — the other consumer (Link's
 // `icon` prop) has no such rule, so the SVG's own attributes are what size
 // it there. The explicit size is correct in both places, so it's kept.
 export const iconEdit = (
@@ -81,10 +85,14 @@ export const iconEdit = (
   </svg>
 )
 
-export const iconPreview = (
+export interface IconPreviewProps {
+  size: number
+}
+
+export const IconPreview: FC<IconPreviewProps> = ({ size }) => (
   <svg
-    width="14"
-    height="14"
+    width={size}
+    height={size}
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
@@ -166,6 +174,171 @@ export const iconRetry = (
   >
     <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
     <path d="M3 3v5h5" />
+  </svg>
+)
+
+export const iconLock = (
+  <svg
+    width="13"
+    height="13"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="3" y="11" width="18" height="11" rx="2" />
+    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+  </svg>
+)
+
+export const iconInvite = (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <line x1="19" y1="8" x2="19" y2="14" />
+    <line x1="22" y1="11" x2="16" y2="11" />
+  </svg>
+)
+
+export const iconUnpublish = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M3 3v18h18" />
+    <path d="m19 9-5 5-4-4-3 3" />
+  </svg>
+)
+
+export const iconDocument = (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.7"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+    <path d="M14 2v5h5" />
+  </svg>
+)
+
+export const iconViewPublic = (
+  <svg
+    width="13"
+    height="13"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M7 17 17 7" />
+    <path d="M7 7h10v10" />
+  </svg>
+)
+
+// Search-with-exclamation glyph — matches Admin Recipe Preview.dc.html's
+// not-found icon (lines 123) exactly.
+export const iconNotFound = (
+  <svg
+    width="25"
+    height="25"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.7"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-3.5-3.5" />
+    <path d="M11 8v3" />
+    <path d="M11 14h.01" />
+  </svg>
+)
+
+// Design: docs/design/paper/pages/Admin Recipe Editor.dc.html's `.upload`
+// dropzone icon (upload-cloud, stroke-width 1.6).
+export const iconUploadCloud = (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.6}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="17 8 12 3 7 8" />
+    <line x1="12" y1="3" x2="12" y2="15" />
+  </svg>
+)
+
+// Design: same doc's STEPS section "+ Add step image" ghost-button icon.
+export const iconAddImage = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <circle cx="9" cy="9" r="2" />
+    <path d="m21 15-3.1-3.1a2 2 0 0 0-2.8 0L6 21" />
+  </svg>
+)
+
+// Design's overlaid icon-button is a trash glyph (it deletes the image
+// outright in the design's simulated backend). This component only has a
+// replace-via-re-upload callback surface (see the "Ready state" note in
+// the PR description), so a pencil/replace glyph is used instead of the
+// literal trash icon to avoid implying a destructive delete that doesn't
+// exist here.
+export const iconReplace = (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 20h9" />
+    <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
   </svg>
 )
 

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -43,11 +43,11 @@ export const iconRemove = (
   </svg>
 )
 
-export interface IconPlusProps {
+export interface SizedIconProps {
   size: number
 }
 
-export const IconPlus: FC<IconPlusProps> = ({ size }) => (
+export const IconPlus: FC<SizedIconProps> = ({ size }) => (
   <svg
     width={size}
     height={size}
@@ -85,11 +85,7 @@ export const iconEdit = (
   </svg>
 )
 
-export interface IconPreviewProps {
-  size: number
-}
-
-export const IconPreview: FC<IconPreviewProps> = ({ size }) => (
+export const IconPreview: FC<SizedIconProps> = ({ size }) => (
   <svg
     width={size}
     height={size}

--- a/src/pages/admin/RecipeEditor/RecipeEditor.tsx
+++ b/src/pages/admin/RecipeEditor/RecipeEditor.tsx
@@ -11,7 +11,7 @@ import {
 import AutosaveStatus from '@components/AutosaveStatus'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
-import { IconAlertCircle, iconPreview } from '@components/icons'
+import { IconAlertCircle, IconPreview, iconLock } from '@components/icons'
 import ImageUpload from '@components/ImageUpload'
 import IngredientList from '@components/IngredientList'
 import Link from '@components/Link'
@@ -251,23 +251,6 @@ const draftFromCreated = (id: string, slug: string): Recipe => ({
 })
 
 const NEW_PATH = '/admin/recipes/new'
-
-const iconLock = (
-  <svg
-    width="13"
-    height="13"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <rect x="3" y="11" width="18" height="11" rx="2" />
-    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-  </svg>
-)
 
 const RecipeEditor: FC = () => {
   const { id: routeId } = useParams<{ id: string }>()
@@ -901,7 +884,7 @@ const RecipeEditor: FC = () => {
                 <div className={styles.previewWrap}>
                   <Link
                     to={`/recipes/${form.slug}`}
-                    icon={iconPreview}
+                    icon={<IconPreview size={14} />}
                     iconSide="right"
                     nudge="none"
                     className={styles.previewLink}

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -34,6 +34,10 @@ import { pluralize } from '../../../utils/pluralize'
 import { relativeUpdatedLabel } from '../../../utils/relativeTime'
 import styles from './RecipeList.module.css'
 
+// Hoisted so every row in the list below reuses the same element by
+// reference instead of mounting a fresh IconPreview per row per render.
+const iconPreviewAction = <IconPreview size={14} />
+
 const RecipeList = () => {
   const { getAccessToken, logout } = useAuth()
   const { showToast } = useToast()
@@ -185,7 +189,7 @@ const RecipeList = () => {
                   className={`${interactions.focusRing} ${styles.actionButton}`}
                   nudge="none"
                 >
-                  <IconPreview size={14} />
+                  {iconPreviewAction}
                   Preview
                 </Link>
                 <button

--- a/src/pages/admin/RecipeList/RecipeList.tsx
+++ b/src/pages/admin/RecipeList/RecipeList.tsx
@@ -6,7 +6,17 @@ import {
   unpublishRecipe,
 } from '@api/recipes'
 import ConfirmDialog from '@components/ConfirmDialog'
-import { iconDelete, iconEdit, iconPreview, iconPublish, iconRetry, iconWarning } from '@components/icons'
+import {
+  IconPlus,
+  IconPreview,
+  iconDelete,
+  iconDocument,
+  iconEdit,
+  iconPublish,
+  iconRetry,
+  iconUnpublish,
+  iconWarning,
+} from '@components/icons'
 import Link from '@components/Link'
 import StateBox from '@components/StateBox'
 import StatusBadge from '@components/StatusBadge'
@@ -23,54 +33,6 @@ import text from '../../../styles/text.module.css'
 import { pluralize } from '../../../utils/pluralize'
 import { relativeUpdatedLabel } from '../../../utils/relativeTime'
 import styles from './RecipeList.module.css'
-
-const iconPlus = (
-  <svg
-    width="15"
-    height="15"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2.2"
-    strokeLinecap="round"
-    aria-hidden="true"
-  >
-    <line x1="12" y1="5" x2="12" y2="19" />
-    <line x1="5" y1="12" x2="19" y2="12" />
-  </svg>
-)
-
-const iconUnpublish = (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M3 3v18h18" />
-    <path d="m19 9-5 5-4-4-3 3" />
-  </svg>
-)
-
-const iconDocument = (
-  <svg
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.7"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
-    <path d="M14 2v5h5" />
-  </svg>
-)
 
 const RecipeList = () => {
   const { getAccessToken, logout } = useAuth()
@@ -174,7 +136,7 @@ const RecipeList = () => {
             Your kitchen is empty. Create your first recipe to start building the collection.
           </Typography>
           <Link to="/admin/recipes/new" variant="solid" className={styles.newButton}>
-            {iconPlus}
+            <IconPlus size={15} />
             Create your first recipe
           </Link>
         </div>
@@ -223,7 +185,7 @@ const RecipeList = () => {
                   className={`${interactions.focusRing} ${styles.actionButton}`}
                   nudge="none"
                 >
-                  {iconPreview}
+                  <IconPreview size={14} />
                   Preview
                 </Link>
                 <button
@@ -262,7 +224,7 @@ const RecipeList = () => {
           </Typography>
         </div>
         <Link to="/admin/recipes/new" variant="solid" className={styles.newButton}>
-          {iconPlus}
+          <IconPlus size={15} />
           New recipe
         </Link>
       </div>

--- a/src/pages/admin/RecipePreview/RecipePreview.tsx
+++ b/src/pages/admin/RecipePreview/RecipePreview.tsx
@@ -1,7 +1,7 @@
 import { isSessionError } from '@api/auth'
 import { fetchRecipeByIdAdmin, publishRecipe } from '@api/recipes'
 import Button from '@components/Button'
-import { iconEdit, iconPublish } from '@components/icons'
+import { IconPreview, iconEdit, iconNotFound, iconPublish, iconViewPublic } from '@components/icons'
 import Link from '@components/Link'
 import Loading from '@components/Loading'
 import RecipeDetailView from '@components/RecipeDetailView'
@@ -21,11 +21,9 @@ import { MAIN_LANDMARK_ID } from '../../../constants/mainLandmark'
 import stateBox from '../../../styles/stateBox.module.css'
 import styles from './RecipePreview.module.css'
 
-// Hoisted elements, not components — these never take props, so there's no
-// need to re-invoke a function (and rebuild the tree) on every render. Same
-// established pattern as `iconRetry` in icons.tsx / `iconLock` in
-// RecipeEditor.tsx. Paths match Admin Recipe Preview.dc.html's inline SVGs
-// (lines 76, 81-82, 88, 93, 100) exactly.
+// Hoisted element, not a component — it never takes props, so there's no
+// need to re-invoke a function (and rebuild the tree) on every render. Path
+// matches Admin Recipe Preview.dc.html's inline SVG (line 76) exactly.
 const iconStatusPublished = (
   <svg
     width="17"
@@ -39,61 +37,6 @@ const iconStatusPublished = (
     aria-hidden="true"
   >
     <path d="M20 6 9 17l-5-5" />
-  </svg>
-)
-
-const iconStatusDraft = (
-  <svg
-    width="17"
-    height="17"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
-    <circle cx="12" cy="12" r="3" />
-  </svg>
-)
-
-const iconViewPublic = (
-  <svg
-    width="13"
-    height="13"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M7 17 17 7" />
-    <path d="M7 7h10v10" />
-  </svg>
-)
-
-// Search-with-exclamation glyph — matches Admin Recipe Preview.dc.html's
-// not-found icon (lines 123) exactly.
-const iconNotFound = (
-  <svg
-    width="25"
-    height="25"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.7"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <circle cx="11" cy="11" r="8" />
-    <path d="m21 21-3.5-3.5" />
-    <path d="M11 8v3" />
-    <path d="M11 14h.01" />
   </svg>
 )
 
@@ -250,7 +193,7 @@ const RecipePreview: FC = () => {
             </Link>
             <span aria-hidden="true" className={styles.bannerDivider} />
             <span aria-hidden="true" className={styles.statusIcon}>
-              {isDraft ? iconStatusDraft : iconStatusPublished}
+              {isDraft ? <IconPreview size={17} /> : iconStatusPublished}
             </span>
             <Typography variant="body" className={styles.bannerMessage}>
               {isDraft

--- a/src/pages/admin/UserManagement/UserManagement.tsx
+++ b/src/pages/admin/UserManagement/UserManagement.tsx
@@ -2,7 +2,7 @@ import { handleSessionError } from '@api/auth'
 import { fetchUsers, inviteUser, removeUser, UserExistsError } from '@api/users'
 import Button from '@components/Button'
 import ConfirmDialog from '@components/ConfirmDialog'
-import { IconAlertCircle, iconDelete, iconRetry, iconWarning } from '@components/icons'
+import { IconAlertCircle, iconDelete, iconInvite, iconRetry, iconWarning } from '@components/icons'
 import Input from '@components/Input'
 import StateBox from '@components/StateBox'
 import StatusBadge from '@components/StatusBadge'
@@ -20,25 +20,6 @@ import styles from './UserManagement.module.css'
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const isValidEmail = (value: string): boolean => EMAIL_PATTERN.test(value.trim())
-
-const iconInvite = (
-  <svg
-    width="15"
-    height="15"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-    <circle cx="9" cy="7" r="4" />
-    <line x1="19" y1="8" x2="19" y2="14" />
-    <line x1="22" y1="11" x2="16" y2="11" />
-  </svg>
-)
 
 const ROLE_OPTIONS: AdminRole[] = ['contributor', 'admin']
 


### PR DESCRIPTION
Closes #347

## What changed

- `iconPlus`/`iconPreview` in `icons.tsx` are now size-configurable `IconPlus`/`IconPreview` components (`FC<SizedIconProps>`), matching the existing `IconAlertCircle` size-prop pattern.
- Nine one-off icons (`iconLock`, `iconInvite`, `iconUnpublish`, `iconDocument`, `iconViewPublic`, `iconNotFound`, `iconUploadCloud`, `iconAddImage`, `iconReplace`) moved from per-file local consts into `icons.tsx` as plain exports.
- `RecipePreview.tsx`'s local `iconStatusDraft` (byte-identical to `iconPreview`, just 17px) is deleted in favor of `<IconPreview size={17} />`.
- All call sites across `RecipeList.tsx`, `RecipePreview.tsx`, `RecipeEditor.tsx`, `UserManagement.tsx`, `ImageUpload.tsx`, `IngredientList.tsx`, and `StepList.tsx` updated to import from `@components/icons` instead of declaring/duplicating their own SVGs.
- Every relocated/parameterized icon's `viewBox`, width/height, `strokeWidth`, path data, and `aria-hidden` presence is byte-for-byte unchanged from its pre-refactor version — this was verified individually for each icon during review.

## Why

`icons.tsx` already existed to share icons, but several admin pages kept one-off local SVG consts instead of using/extending it — including two near-duplicates (`iconPlus` at 14px vs. 15px, `iconPreview`/`iconStatusDraft` at 14px vs. 17px) that had already drifted apart by a few pixels with no tracked reason. This consolidates every glyph to one source of truth, following the precedent `IconAlertCircle` already established in the same file.

## How to verify

- `pnpm test`, `pnpm lint`, `pnpm exec tsc --noEmit` all pass with no new errors.
- Diff each moved/parameterized icon in `icons.tsx` against its git history to confirm the SVG markup is unchanged.
- Visually spot-check the Recipes list (new-recipe buttons, row Preview icon), Recipe Preview banner (draft/published icon), Recipe Editor (lock icon, preview link), User Management (invite button), and the recipe image upload dropzone/replace button in a running instance — no icon should look different than before this PR.

## Decisions made

- `IconPlus`/`IconPreview` share one `SizedIconProps` interface (`{ size: number }`) rather than two independently-declared identical interfaces — caught by `/simplify`'s reuse pass.
- `RecipeList.tsx`'s per-row Preview icon is hoisted to a module-level `iconPreviewAction` element so every row reuses the same reference instead of mounting a fresh `IconPreview` per row per render — caught by `/simplify`'s efficiency pass; this was the only call site of the six actually sitting inside a render loop, the other five (empty-state/header buttons, Editor's preview link) are single-invocation and not worth hoisting.

## Out of scope (skipped `/simplify` findings, with reasons)

- **Revert `IconPlus`/`IconPreview` to per-size hoisted consts instead of a size-prop component** — this would contradict the issue's explicit AC to match the existing `IconAlertCircle` size-prop pattern; the one call site that was actually hot (RecipeList's per-row icon) is already hoisted above.
- **Normalize `strokeWidth` numeric-vs-string formatting and add `aria-hidden` to `iconUploadCloud`/`iconAddImage`/`iconReplace`** — these three intentionally lack `aria-hidden` on the svg itself because their parent elements already provide `aria-hidden`/`aria-label` context (see the existing code comments); adding it would be a behavior change outside this refactor's "no visual/behavior change" scope.
- **`IconPreview` now represents two domain concepts ("preview" action vs. "draft" status) since the shapes are byte-identical** — this exact consolidation was explicitly directed by the issue body itself, not an implementation choice made in this PR.

## Note on visual verification

The issue's AC calls for verifying "with a real render, not just tests, since CSS Modules aren't parsed in vitest." I don't have credentials for the authenticated admin backend in this environment, so I wasn't able to load these admin pages in a browser. In lieu of that, every relocated/parameterized icon's SVG markup was diffed byte-for-byte against its pre-refactor version (viewBox, width/height, strokeWidth, path data, aria-hidden) — this rules out any change to the icon markup itself, though a manual spot-check in a running instance (see "How to verify" above) is still worth doing before merge.