### PR TITLE
Migrate deploy workflow to OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -34,8 +38,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::713881813802:role/personal-website-deploy
           aws-region: eu-west-2
 
       - name: Deploy client bundle to S3


### PR DESCRIPTION
Closes #368

## What changed
Migrates `.github/workflows/deploy.yml`'s `Configure AWS credentials` step from static AWS keys to OIDC role-assumption.

- **Credentials**: `role-to-assume: arn:aws:iam::713881813802:role/personal-website-deploy` (the per-app IAM role from `akli-infrastructure` #191), replacing `aws-access-key-id`/`aws-secret-access-key`.
- **Permissions**: added `id-token: write` (required to receive the OIDC token) and `contents: read` (declaring any `permissions:` key zeroes out unlisted scopes by default).

Nothing else about the deploy changes — same `SiteBucket`, same S3 sync exclusions (`--exclude "apps/sand-box/*" --exclude "apps/pokedex/*"`), same Lambda update step, same CloudFront invalidation. This workflow triggers only on `push` to `main` (no `pull_request` trigger, unlike `pokedex`/`sand-box`), so there's no branch-guard bug to fix here.

## Why
Part of the **OIDC Deploy Credentials** milestone (PRD: `docs/prds/oidc-deploy-credentials.md`), mirroring the same migration already completed in `pokedex` and `sand-box` — this is the fourth and final repo in the per-app-buckets/OIDC suite.

## How to verify
- Diff is confined to `.github/workflows/deploy.yml` (5 insertions, 2 deletions) — no application code touched.
- `pnpm lint` — clean. `pnpm test` — 869/869 passing (78 test files). `pnpm exec tsc --noEmit` — clean. `pnpm check:descendant-selectors` CI gate — clean.
- **Cannot be fully verified without a real GitHub Actions run** — OIDC auth success, actual S3 sync, Lambda update, and CloudFront invalidation all depend on the live trust policy and role permissions. That's issue #369.

## Decisions made
- **Role ARN stays hardcoded**, not a repo variable — matches the PRD's own explicit framing ("not sensitive... can be committed directly or kept as a repo variable, either is fine") and the identical choice already made in `pokedex`/`sand-box`.
- **`S3_BUCKET_NAME`/`SSR_LAMBDA_FUNCTION_NAME`/`CLOUDFRONT_DISTRIBUTION_ID` left untouched** as Secrets — converting them to repo Variables (with an `AWS_` prefix for consistency with the sibling repos) is a separate, already-filed follow-up (#371), deliberately out of scope here to keep this PR to the credentials-step swap only.

## Out of scope
No new follow-ups filed by this PR — #371 (Variable conversion) and #369 (live verification + secret removal) were already filed/exist as separate issues before this PR.