### PR TITLE
OIDC deploy migration for personal-website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -34,8 +38,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::713881813802:role/personal-website-deploy
           aws-region: eu-west-2
 
       - name: Deploy client bundle to S3

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "personal-website",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "packageManager": "pnpm@11.9.0",
   "engines": {


### PR DESCRIPTION
## What changed

Merges the **OIDC Deploy Credentials** milestone into `main` (PRD: `docs/prds/oidc-deploy-credentials.md`). Merging this PR triggers a real `push`-to-`main` deploy run via `.github/workflows/deploy.yml` — this is the live verification issue #369 needs.

- **#368** — migrated `deploy.yml` from static AWS keys to OIDC (`role-to-assume` against `arn:aws:iam::713881813802:role/personal-website-deploy`). Nothing else changed — same `SiteBucket`, same exclusions, same Lambda update, same CloudFront invalidation.

Also bumps `package.json` to `1.11.1` (patch — the only merged issue is `type:refactor`).

## Heads up — this is the highest-stakes of the three OIDC migrations
Unlike `pokedex`/`sand-box` (which deploy to sub-paths under `apps/*`), this workflow deploys the **actual main site** at `akli.dev` — client bundle to `SiteBucket`, SSR bundle to the live Lambda function, and invalidates the whole distribution (`/*`). If the new role's trust policy or IAM permissions have any gap, this deploy could fail or (worse) partially succeed in a way that breaks the live site. Worth watching the Actions run closely after merging, not just checking for a green checkmark.

## After merge — issue #369 verification steps
- Confirm the real `push`-to-`main` deploy run succeeds via actual step-by-step CI logs (not just overall conclusion) — S3 sync, Lambda update, and CloudFront invalidation all completing.
- Spot-check `https://akli.dev` still serves correctly afterward (this repo's bucket doesn't change, so the site should be immediately live and correct, unlike `pokedex`/`sand-box` which still wait on `akli-infrastructure` #193).
- Once confirmed, remove the now-unused `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets.