### PR TITLE
Move S3_BUCKET_NAME, SSR_LAMBDA_FUNCTION_NAME, and CLOUDFRONT_DISTRIBUTION_ID from Secrets to repo Variables

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,13 +42,13 @@ jobs:
           aws-region: eu-west-2
 
       - name: Deploy client bundle to S3
-        run: aws s3 sync ./dist/client s3://${{ secrets.S3_BUCKET_NAME }} --delete --exclude "apps/sand-box/*" --exclude "apps/pokedex/*"
+        run: aws s3 sync ./dist/client s3://${{ vars.AWS_S3_BUCKET_NAME }} --delete --exclude "apps/sand-box/*" --exclude "apps/pokedex/*"
 
       - name: Zip server bundle
         run: cd dist/server && zip -r ../server.zip .
 
       - name: Deploy server bundle to Lambda
-        run: aws lambda update-function-code --function-name ${{ secrets.SSR_LAMBDA_FUNCTION_NAME }} --zip-file fileb://dist/server.zip
+        run: aws lambda update-function-code --function-name ${{ vars.AWS_SSR_LAMBDA_FUNCTION_NAME }} --zip-file fileb://dist/server.zip
 
       - name: Invalidate CloudFront
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+        run: aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
Closes #371

## What changed
`.github/workflows/deploy.yml` now reads three resource identifiers from repo Variables instead of Secrets, with an `AWS_` prefix for naming consistency across the whole ecosystem:
- `secrets.S3_BUCKET_NAME` → `vars.AWS_S3_BUCKET_NAME`
- `secrets.SSR_LAMBDA_FUNCTION_NAME` → `vars.AWS_SSR_LAMBDA_FUNCTION_NAME`
- `secrets.CLOUDFRONT_DISTRIBUTION_ID` → `vars.AWS_CLOUDFRONT_DISTRIBUTION_ID`

## Why
None of these three values are sensitive — a bucket name, a Lambda function name, and a CloudFront distribution ID are just resource identifiers; only the deploying credential's actual IAM permissions matter. Secrets are the wrong primitive for non-sensitive config. Matches the identical decision already shipped in the sibling `pokedex` and `sand-box` repos.

## How to verify
- All three repo Variables already created and confirmed with the correct live values before this PR was opened.
- `pnpm lint`/`pnpm test` (869/869)/`pnpm exec tsc --noEmit` all clean.
- Diff is exactly 3 insertions / 3 deletions — nothing else touched (the `--exclude` flags, zip step, and OIDC credentials step are byte-for-byte unchanged).

## Decisions made
None beyond what the issue specifies — mechanical rename matching an already-established pattern.

## Out of scope
Removing the three old Secrets — bundled with the live-verification step (a separate follow-up, same as #369's pattern), only after a real deploy run on this workflow succeeds.