### PR TITLE
Secrets-to-Variables naming cleanup for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,13 +42,13 @@ jobs:
           aws-region: eu-west-2
 
       - name: Deploy client bundle to S3
-        run: aws s3 sync ./dist/client s3://${{ secrets.S3_BUCKET_NAME }} --delete --exclude "apps/sand-box/*" --exclude "apps/pokedex/*"
+        run: aws s3 sync ./dist/client s3://${{ vars.AWS_S3_BUCKET_NAME }} --delete --exclude "apps/sand-box/*" --exclude "apps/pokedex/*"
 
       - name: Zip server bundle
         run: cd dist/server && zip -r ../server.zip .
 
       - name: Deploy server bundle to Lambda
-        run: aws lambda update-function-code --function-name ${{ secrets.SSR_LAMBDA_FUNCTION_NAME }} --zip-file fileb://dist/server.zip
+        run: aws lambda update-function-code --function-name ${{ vars.AWS_SSR_LAMBDA_FUNCTION_NAME }} --zip-file fileb://dist/server.zip
 
       - name: Invalidate CloudFront
-        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+        run: aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "personal-website",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.11.2",
   "type": "module",
   "packageManager": "pnpm@11.9.0",
   "engines": {


### PR DESCRIPTION
## What changed

Merges #371 into `main` — renames three deploy-workflow resource identifiers from Secrets to Variables (`AWS_S3_BUCKET_NAME`, `AWS_SSR_LAMBDA_FUNCTION_NAME`, `AWS_CLOUDFRONT_DISTRIBUTION_ID`), matching the naming convention already shipped in `pokedex`/`sand-box`. Pure rename, zero behavior change — same bucket, same Lambda function, same distribution, only where the values are read from changes.

Also bumps `package.json` to `1.11.2`.

## Real-world consequence of merging
Same as the earlier OIDC migration PR for this repo — this deploys the actual main site (`akli.dev`), including the SSR Lambda update and a full-distribution CloudFront invalidation. All three repo Variables are already created and confirmed with the correct live values, so this should be a clean no-op behaviorally — but worth watching the deploy run rather than assuming success from a green checkmark, given what's at stake.

## Pre-merge verification already done
- `pnpm lint`, `pnpm test` (869/869), `pnpm exec tsc --noEmit` all clean.
- Diff confirmed to touch only the three variable references — `--exclude` flags, zip step, and OIDC credentials step all byte-for-byte unchanged.

## After merge
- Confirm the CI deploy run succeeds via real step-by-step logs, then spot-check `akli.dev` is still serving correctly.
- Once confirmed, remove the three now-unused Secrets (`S3_BUCKET_NAME`, `SSR_LAMBDA_FUNCTION_NAME`, `CLOUDFRONT_DISTRIBUTION_ID`).